### PR TITLE
fix(cc): discard duplicate partial CCs in ConfigurationCC reports

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
@@ -608,6 +608,25 @@ export class AssociationCCReport extends AssociationCC {
 		return this._reportsToFollow > 0;
 	}
 
+	public addToPartialCCSession(session: AssociationCCReport[]): boolean {
+		if (
+			session.length === 0 ||
+			this.reportsToFollow ===
+				session[session.length - 1].reportsToFollow - 1
+		) {
+			session.push(this);
+			return true;
+		}
+		if (
+			this.reportsToFollow === session[session.length - 1].reportsToFollow
+		) {
+			// Assume this report is a duplicate. Keep the session and discard this cc.
+			return true;
+		}
+		// This cc doesn't fit into the session. A new session must be created.
+		return false;
+	}
+
 	public mergePartialCCs(partials: AssociationCCReport[]): void {
 		// Concat the list of nodes
 		this._nodeIds = [...partials, this]

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -856,6 +856,17 @@ export class CommandClass {
 		return false; // By default, all CCs are monolithic
 	}
 
+	/**
+	 * Attempt to add this CC to the partial CC session
+	 * @param session The previously received set of messages received in this partial CC session
+	 * @returns `true` if Partial CC is successfully added to the session
+	 */
+	public addToPartialCCSession(session: CommandClass[]): boolean {
+		// Default to the old behavior of pushing the CC onto the session without any sanity checks
+		session.push(this);
+		return true;
+	}
+
 	/** Include previously received partial responses into a final CC */
 	/* istanbul ignore next */
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -859,7 +859,7 @@ export class CommandClass {
 	/**
 	 * Attempt to add this CC to the partial CC session
 	 * @param session The previously received set of messages received in this partial CC session
-	 * @returns `true` if Partial CC is successfully added to the session
+	 * @returns `true` if session is valid for this CC, false if it needs to be reset
 	 */
 	public addToPartialCCSession(session: CommandClass[]): boolean {
 		// Default to the old behavior of pushing the CC onto the session without any sanity checks

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.test.ts
@@ -1,0 +1,185 @@
+import { CommandClasses } from "@zwave-js/core";
+import type { Driver } from "../driver/Driver";
+import { ZWaveNode } from "../node/Node";
+import { createEmptyMockDriver } from "../test/mocks";
+import {
+	ConfigurationCC,
+	ConfigurationCCGet,
+	ConfigurationCCNameReport,
+	ConfigurationCCReport,
+	ConfigurationCCSet,
+	ConfigurationCommand,
+} from "./ConfigurationCC";
+
+function buildCCBuffer(payload: Buffer): Buffer {
+	return Buffer.concat([
+		Buffer.from([
+			CommandClasses.Configuration, // CC
+		]),
+		payload,
+	]);
+}
+
+function buildNameReportCCBuffer(
+	parameter: number,
+	reportsToFollow: number,
+	name: string,
+): Buffer {
+	const headerSize = 4;
+	const header = Buffer.alloc(headerSize);
+	header[0] = ConfigurationCommand.NameReport;
+	header.writeUInt16BE(parameter, 1);
+	header[3] = reportsToFollow;
+	const payload = Buffer.concat([header, Buffer.from(name)]);
+	return buildCCBuffer(payload);
+}
+
+describe("lib/commandclass/ConfigurationCC => ", () => {
+	let fakeDriver: Driver;
+	let nodeV1: ZWaveNode;
+	let nodeV2: ZWaveNode;
+	let nodeV3: ZWaveNode;
+	let nodeV4: ZWaveNode;
+
+	beforeAll(() => {
+		fakeDriver = createEmptyMockDriver() as unknown as Driver;
+		nodeV1 = new ZWaveNode(10, fakeDriver as any);
+		nodeV2 = new ZWaveNode(20, fakeDriver as any);
+		nodeV3 = new ZWaveNode(30, fakeDriver as any);
+		nodeV4 = new ZWaveNode(40, fakeDriver as any);
+		(fakeDriver.controller.nodes as any).set(10, nodeV1);
+		(fakeDriver.controller.nodes as any).set(20, nodeV2);
+		(fakeDriver.controller.nodes as any).set(30, nodeV3);
+		(fakeDriver.controller.nodes as any).set(40, nodeV3);
+		nodeV1.addCC(CommandClasses.Configuration, {
+			isSupported: true,
+			version: 1,
+		});
+		nodeV2.addCC(CommandClasses.Configuration, {
+			isSupported: true,
+			version: 2,
+		});
+		nodeV3.addCC(CommandClasses.Configuration, {
+			isSupported: true,
+			version: 3,
+		});
+	});
+
+	afterAll(() => {
+		fakeDriver.destroy();
+		nodeV1.destroy();
+		nodeV2.destroy();
+		nodeV3.destroy();
+		nodeV4.destroy();
+	});
+
+	it("the Get command should serialize correctly", () => {
+		const cc = new ConfigurationCCGet(fakeDriver, {
+			nodeId: 10,
+			parameter: 1,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				ConfigurationCommand.Get, // CC Command
+				0x01, // parameter
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Set command should serialize correctly", () => {
+		const cc = new ConfigurationCCSet(fakeDriver, {
+			nodeId: 10,
+			parameter: 5,
+			valueSize: 1,
+			value: 2,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				ConfigurationCommand.Set, // CC Command
+				5, // parameter
+				1, // valueSize
+				2, // value
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Report command (v1/v2) should be deserialized correctly (2 bytes)", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				ConfigurationCommand.Report, // CC Command
+				1, // parameter
+				2, // valueSize
+				0x01, // current value MSB
+				0x02, // current value LSB
+			]),
+		);
+		const cc = new ConfigurationCCReport(fakeDriver, {
+			data: ccData,
+			nodeId: 10,
+		});
+
+		expect(cc.parameter).toBe(1);
+		expect(cc.valueSize).toBe(2);
+		expect(cc.value).toBe(0x0102);
+	});
+
+	it("deserializing an unsupported command should return an unspecified version of ConfigurationCC", () => {
+		const serializedCC = buildCCBuffer(
+			Buffer.from([255]), // not a valid command
+		);
+		const cc: any = new ConfigurationCC(fakeDriver, {
+			nodeId: 10,
+			data: serializedCC,
+		});
+		expect(cc.constructor).toBe(ConfigurationCC);
+	});
+
+	it("the NameReport should properly concatenate partial reports when unique and ordered", () => {
+		const partialCCs = [
+			{ reportsRemaining: 3, name: "abc" },
+			{ reportsRemaining: 2, name: "def" },
+			{ reportsRemaining: 1, name: "ghi" },
+		].map(({ reportsRemaining, name }) => {
+			return new ConfigurationCCNameReport(fakeDriver, {
+				nodeId: 30,
+				data: buildNameReportCCBuffer(1, reportsRemaining, name),
+			});
+		});
+		const finalCC = new ConfigurationCCNameReport(fakeDriver, {
+			nodeId: 30,
+			data: buildNameReportCCBuffer(1, 0, "jkl"),
+		});
+		finalCC.mergePartialCCs(partialCCs);
+
+		expect(finalCC.parameter).toBe(1);
+		expect(finalCC.name).toBe("abcdefghijkl");
+	});
+
+	it("the NameReport should properly concatenate partial reports when repeated", () => {
+		const session = [
+			{ reportsRemaining: 3, name: "abc" },
+			{ reportsRemaining: 2, name: "def" },
+			{ reportsRemaining: 3, name: "abc" },
+			{ reportsRemaining: 2, name: "def" },
+			{ reportsRemaining: 1, name: "ghi" },
+			{ reportsRemaining: 1, name: "ghi" },
+		].reduce((sess, { reportsRemaining, name }) => {
+			const partialCC = new ConfigurationCCNameReport(fakeDriver, {
+				nodeId: 30,
+				data: buildNameReportCCBuffer(1, reportsRemaining, name),
+			});
+			partialCC.addToPartialCCSession(sess);
+			return sess;
+		}, []);
+		const finalCC = new ConfigurationCCNameReport(fakeDriver, {
+			nodeId: 30,
+			data: buildNameReportCCBuffer(1, 0, "jkl"),
+		});
+		finalCC.mergePartialCCs(session);
+
+		expect(finalCC.parameter).toBe(1);
+		expect(finalCC.name).toBe("abcdefghijkl");
+	});
+});

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -2018,6 +2018,17 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
 		return this._reportsToFollow > 0;
 	}
 
+	public addToPartialCCSession(
+		session: ConfigurationCCNameReport[],
+	): boolean {
+		if (session.some((cc) => cc.reportsToFollow === this.reportsToFollow)) {
+			// This is a duplicate partial CC. Discard it.
+			return false;
+		}
+		session.push(this);
+		return true;
+	}
+
 	public mergePartialCCs(partials: ConfigurationCCNameReport[]): void {
 		// Concat the name
 		this._name = [...partials, this]
@@ -2115,6 +2126,17 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
 
 	public expectMoreMessages(): boolean {
 		return this._reportsToFollow > 0;
+	}
+
+	public addToPartialCCSession(
+		session: ConfigurationCCInfoReport[],
+	): boolean {
+		if (session.some((cc) => cc.reportsToFollow === this.reportsToFollow)) {
+			// This is a duplicate partial CC. Discard it.
+			return false;
+		}
+		session.push(this);
+		return true;
 	}
 
 	public mergePartialCCs(partials: ConfigurationCCInfoReport[]): void {

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -2021,12 +2021,22 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
 	public addToPartialCCSession(
 		session: ConfigurationCCNameReport[],
 	): boolean {
-		if (session.some((cc) => cc.reportsToFollow === this.reportsToFollow)) {
-			// This is a duplicate partial CC. Discard it.
-			return false;
+		if (
+			session.length === 0 ||
+			this.reportsToFollow ===
+				session[session.length - 1].reportsToFollow - 1
+		) {
+			session.push(this);
+			return true;
 		}
-		session.push(this);
-		return true;
+		if (
+			this.reportsToFollow === session[session.length - 1].reportsToFollow
+		) {
+			// Assume this report is a duplicate. Keep the session and discard this cc.
+			return true;
+		}
+		// This cc doesn't fit into the session. A new session must be created.
+		return false;
 	}
 
 	public mergePartialCCs(partials: ConfigurationCCNameReport[]): void {
@@ -2131,12 +2141,22 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
 	public addToPartialCCSession(
 		session: ConfigurationCCInfoReport[],
 	): boolean {
-		if (session.some((cc) => cc.reportsToFollow === this.reportsToFollow)) {
-			// This is a duplicate partial CC. Discard it.
-			return false;
+		if (
+			session.length === 0 ||
+			this.reportsToFollow ===
+				session[session.length - 1].reportsToFollow - 1
+		) {
+			session.push(this);
+			return true;
 		}
-		session.push(this);
-		return true;
+		if (
+			this.reportsToFollow === session[session.length - 1].reportsToFollow
+		) {
+			// Assume this report is a duplicate. Keep the session and discard this cc.
+			return true;
+		}
+		// This cc doesn't fit into the session. A new session must be created.
+		return false;
 	}
 
 	public mergePartialCCs(partials: ConfigurationCCInfoReport[]): void {

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
@@ -757,6 +757,27 @@ export class MultiChannelAssociationCCReport extends MultiChannelAssociationCC {
 		return this._reportsToFollow > 0;
 	}
 
+	public addToPartialCCSession(
+		session: MultiChannelAssociationCCReport[],
+	): boolean {
+		if (
+			session.length === 0 ||
+			this.reportsToFollow ===
+				session[session.length - 1].reportsToFollow - 1
+		) {
+			session.push(this);
+			return true;
+		}
+		if (
+			this.reportsToFollow === session[session.length - 1].reportsToFollow
+		) {
+			// Assume this report is a duplicate. Keep the session and discard this cc.
+			return true;
+		}
+		// This cc doesn't fit into the session. A new session must be created.
+		return false;
+	}
+
 	public mergePartialCCs(partials: MultiChannelAssociationCCReport[]): void {
 		// Concat the list of nodes
 		this._nodeIds = [...partials, this]

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
@@ -842,6 +842,27 @@ export class MultiChannelCCEndPointFindReport extends MultiChannelCC {
 		return this._reportsToFollow > 0;
 	}
 
+	public addToPartialCCSession(
+		session: MultiChannelCCEndPointFindReport[],
+	): boolean {
+		if (
+			session.length === 0 ||
+			this.reportsToFollow ===
+				session[session.length - 1].reportsToFollow - 1
+		) {
+			session.push(this);
+			return true;
+		}
+		if (
+			this.reportsToFollow === session[session.length - 1].reportsToFollow
+		) {
+			// Assume this report is a duplicate. Keep the session and discard this cc.
+			return true;
+		}
+		// This cc doesn't fit into the session. A new session must be created.
+		return false;
+	}
+
 	public mergePartialCCs(partials: MultiChannelCCEndPointFindReport[]): void {
 		// Concat the list of end points
 		this._foundEndpoints = [...partials, this]

--- a/packages/zwave-js/src/lib/commandclass/ThermostatFanModeCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatFanModeCC.test.ts
@@ -41,6 +41,7 @@ describe("lib/commandclass/ThermostatFanModeCC => ", () => {
 	});
 
 	afterAll(() => {
+		fakeDriver.destroy();
 		node1.destroy();
 		node5.destroy();
 	});

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2081,7 +2081,14 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 				if (command.expectMoreMessages(session)) {
 					// this is not the final one, store it
 					// and don't handle the command now
-					command.addToPartialCCSession(session);
+					const sessionValid = command.addToPartialCCSession(session);
+					if (!sessionValid) {
+						// This command is not part of the existing session,
+						// Start a new session with this command
+						this.partialCCSessions.set(partialSessionKey!, [
+							command,
+						]);
+					}
 					if (!isTransportServiceEncapsulation(msg.command)) {
 						this.driverLog.logMessage(msg, {
 							secondaryTags: ["partial"],

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2080,9 +2080,9 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 				// This CC belongs to a partial session
 				if (command.expectMoreMessages(session)) {
 					// this is not the final one, store it
-					session.push(command);
+					// and don't handle the command now
+					command.addToPartialCCSession(session);
 					if (!isTransportServiceEncapsulation(msg.command)) {
-						// and don't handle the command now
 						this.driverLog.logMessage(msg, {
 							secondaryTags: ["partial"],
 							direction: "inbound",


### PR DESCRIPTION
This PR adds tests for and fixes the symptoms shown in #3368, but there are more gremlins to kill with regards to `assemblePartialCCs`.

There are a couple big issues with `assemblePartialCCs`

1. It always adds an incoming CC to an existing session if one exists. (This PR addresses that, although it needs to be expanded to other CCs).
2. It never deletes a partial cc session unless it successfully completes.

Number 2 is a big problem. I'm surprised it wasn't noticed earlier, but I guess that very few CCs that are used in normal operation string together partial CCs. `TransportCC` masks the issue, because its implementation of `mergePartialCCs` causes the last received partial CC segments to overwrite the segments of any partial CCs that were left over from an earlier failed session.

Properly fixing number 2 is not trivial, at least for the `Report` CCs that follow the `reportsRemaining` pattern. I think we need to have timeouts for each session and blocks preventing `Get` commands from being sent if they match with an active session, because there's no good way to know if an incoming `Report` is actually from a new session if the node is misbehaving or having communication issues.