### PR TITLE
feat: handle SmartStart inclusion requests from included nodes

### DIFF
--- a/packages/zwave-js/src/lib/controller/ApplicationUpdateRequest.ts
+++ b/packages/zwave-js/src/lib/controller/ApplicationUpdateRequest.ts
@@ -50,6 +50,9 @@ export class ApplicationUpdateRequest extends Message {
 				CommandConstructor =
 					ApplicationUpdateRequestSmartStartHomeIDReceived;
 				break;
+			case ApplicationUpdateTypes.SmartStart_NodeInfo_Received:
+				CommandConstructor =
+					ApplicationUpdateRequestSmartStartNodeInfoReceived;
 		}
 
 		if (CommandConstructor && (new.target as any) !== CommandConstructor) {
@@ -130,6 +133,31 @@ export class ApplicationUpdateRequestSmartStartHomeIDReceived extends Applicatio
 			"supported CCs": this.supportedCCs
 				.map((cc) => `\n· ${getCCName(cc)}`)
 				.join(""),
+		};
+		return {
+			...super.toLogEntry(),
+			message,
+		};
+	}
+}
+
+export class ApplicationUpdateRequestSmartStartNodeInfoReceived extends ApplicationUpdateRequest {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this.remoteNodeId = this.payload[0];
+		// payload[1] is rxStatus
+		// payload[2] is reserved
+		this.nwiHomeId = this.payload.slice(3, 7);
+	}
+
+	public readonly remoteNodeId: number;
+	public readonly nwiHomeId: Buffer;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const message: MessageRecord = {
+			type: getEnumMemberName(ApplicationUpdateTypes, this.updateType),
+			"remote node ID": this.remoteNodeId,
+			"NWI home ID": buffer2hex(this.nwiHomeId),
 		};
 		return {
 			...super.toLogEntry(),

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -104,6 +104,7 @@ import {
 	ApplicationUpdateRequest,
 	ApplicationUpdateRequestNodeInfoReceived,
 	ApplicationUpdateRequestSmartStartHomeIDReceived,
+	ApplicationUpdateRequestSmartStartNodeInfoReceived,
 } from "../controller/ApplicationUpdateRequest";
 import { BridgeApplicationCommandRequest } from "../controller/BridgeApplicationCommandRequest";
 import { ZWaveController } from "../controller/Controller";
@@ -3039,7 +3040,10 @@ ${handlers.length} left`,
 					return;
 				}
 			} else if (
-				msg instanceof ApplicationUpdateRequestSmartStartHomeIDReceived
+				msg instanceof
+					ApplicationUpdateRequestSmartStartHomeIDReceived ||
+				msg instanceof
+					ApplicationUpdateRequestSmartStartNodeInfoReceived
 			) {
 				// the controller is in Smart Start learn mode and a node requests inclusion via Smart Start
 				this.controllerLog.print(


### PR DESCRIPTION
This is not the correct way to handle it. According to the specs:

> On receipt of this command, a controller node trying to perform a SmartStart inclusion of a node whose S2 DSK matches the NWI HomeID field of this command should indicate to the application layer that the node to be included is currently included in another network and needs to be removed from the foreign network before it can be included.

![grafik](https://github.com/user-attachments/assets/5b317ec1-6a4f-4c1a-9773-069ded58da08)
