### PR TITLE
feat: include enum name in `assertSupportsCommand` error message

### DIFF
--- a/packages/cc/src/cc/AlarmSensorCC.ts
+++ b/packages/cc/src/cc/AlarmSensorCC.ts
@@ -143,6 +143,7 @@ export class AlarmSensorCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			AlarmSensorCommand,
 			AlarmSensorCommand.SupportedGet,
+			nameof(AlarmSensorCommand),
 		);
 
 		const cc = new AlarmSensorCCSupportedGet(this.applHost, {

--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -140,6 +140,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			AssociationCommand,
 			AssociationCommand.SupportedGroupingsGet,
+			nameof(AssociationCommand),
 		);
 
 		const cc = new AssociationCCSupportedGroupingsGet(this.applHost, {
@@ -208,6 +209,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			AssociationCommand,
 			AssociationCommand.Remove,
+			nameof(AssociationCommand),
 		);
 
 		const cc = new AssociationCCRemove(this.applHost, {
@@ -228,6 +230,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			AssociationCommand,
 			AssociationCommand.Remove,
+			nameof(AssociationCommand),
 		);
 
 		if (this.version >= 2) {

--- a/packages/cc/src/cc/AssociationGroupInfoCC.ts
+++ b/packages/cc/src/cc/AssociationGroupInfoCC.ts
@@ -99,6 +99,7 @@ export class AssociationGroupInfoCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			AssociationGroupInfoCommand,
 			AssociationGroupInfoCommand.NameGet,
+			nameof(AssociationGroupInfoCommand),
 		);
 
 		const cc = new AssociationGroupInfoCCNameGet(this.applHost, {
@@ -120,6 +121,7 @@ export class AssociationGroupInfoCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			AssociationGroupInfoCommand,
 			AssociationGroupInfoCommand.InfoGet,
+			nameof(AssociationGroupInfoCommand),
 		);
 
 		const cc = new AssociationGroupInfoCCInfoGet(this.applHost, {
@@ -155,6 +157,7 @@ export class AssociationGroupInfoCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			AssociationGroupInfoCommand,
 			AssociationGroupInfoCommand.CommandListGet,
+			nameof(AssociationGroupInfoCommand),
 		);
 
 		const cc = new AssociationGroupInfoCCCommandListGet(this.applHost, {

--- a/packages/cc/src/cc/BarrierOperatorCC.ts
+++ b/packages/cc/src/cc/BarrierOperatorCC.ts
@@ -119,6 +119,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			BarrierOperatorCommand,
 			BarrierOperatorCommand.Get,
+			nameof(BarrierOperatorCommand),
 		);
 
 		const cc = new BarrierOperatorCCGet(this.applHost, {
@@ -142,6 +143,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			BarrierOperatorCommand,
 			BarrierOperatorCommand.Set,
+			nameof(BarrierOperatorCommand),
 		);
 
 		const cc = new BarrierOperatorCCSet(this.applHost, {
@@ -159,6 +161,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			BarrierOperatorCommand,
 			BarrierOperatorCommand.SignalingCapabilitiesGet,
+			nameof(BarrierOperatorCommand),
 		);
 
 		const cc = new BarrierOperatorCCSignalingCapabilitiesGet(
@@ -183,6 +186,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			BarrierOperatorCommand,
 			BarrierOperatorCommand.EventSignalingGet,
+			nameof(BarrierOperatorCommand),
 		);
 
 		const cc = new BarrierOperatorCCEventSignalingGet(this.applHost, {
@@ -206,6 +210,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			BarrierOperatorCommand,
 			BarrierOperatorCommand.EventSignalingSet,
+			nameof(BarrierOperatorCommand),
 		);
 
 		const cc = new BarrierOperatorCCEventSignalingSet(this.applHost, {

--- a/packages/cc/src/cc/BinarySensorCC.ts
+++ b/packages/cc/src/cc/BinarySensorCC.ts
@@ -101,6 +101,7 @@ export class BinarySensorCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			BinarySensorCommand,
 			BinarySensorCommand.Get,
+			nameof(BinarySensorCommand),
 		);
 
 		const cc = new BinarySensorCCGet(this.applHost, {
@@ -121,6 +122,7 @@ export class BinarySensorCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			BinarySensorCommand,
 			BinarySensorCommand.SupportedGet,
+			nameof(BinarySensorCommand),
 		);
 
 		const cc = new BinarySensorCCSupportedGet(this.applHost, {

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -87,6 +87,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			BinarySwitchCommand,
 			BinarySwitchCommand.Get,
+			nameof(BinarySwitchCommand),
 		);
 
 		const cc = new BinarySwitchCCGet(this.applHost, {
@@ -120,6 +121,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			BinarySwitchCommand,
 			BinarySwitchCommand.Set,
+			nameof(BinarySwitchCommand),
 		);
 
 		const cc = new BinarySwitchCCSet(this.applHost, {

--- a/packages/cc/src/cc/CRC16CC.ts
+++ b/packages/cc/src/cc/CRC16CC.ts
@@ -42,6 +42,7 @@ export class CRC16CCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			CRC16Command,
 			CRC16Command.CommandEncapsulation,
+			nameof(CRC16Command),
 		);
 
 		const cc = new CRC16CCCommandEncapsulation(this.applHost, {

--- a/packages/cc/src/cc/CentralSceneCC.ts
+++ b/packages/cc/src/cc/CentralSceneCC.ts
@@ -105,6 +105,7 @@ export class CentralSceneCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			CentralSceneCommand,
 			CentralSceneCommand.SupportedGet,
+			nameof(CentralSceneCommand),
 		);
 
 		const cc = new CentralSceneCCSupportedGet(this.applHost, {
@@ -130,6 +131,7 @@ export class CentralSceneCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			CentralSceneCommand,
 			CentralSceneCommand.ConfigurationGet,
+			nameof(CentralSceneCommand),
 		);
 
 		const cc = new CentralSceneCCConfigurationGet(this.applHost, {
@@ -153,6 +155,7 @@ export class CentralSceneCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			CentralSceneCommand,
 			CentralSceneCommand.ConfigurationSet,
+			nameof(CentralSceneCommand),
 		);
 
 		const cc = new CentralSceneCCConfigurationSet(this.applHost, {

--- a/packages/cc/src/cc/ClimateControlScheduleCC.ts
+++ b/packages/cc/src/cc/ClimateControlScheduleCC.ts
@@ -101,6 +101,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ClimateControlScheduleCommand,
 			ClimateControlScheduleCommand.Set,
+			nameof(ClimateControlScheduleCommand),
 		);
 
 		const cc = new ClimateControlScheduleCCSet(this.applHost, {
@@ -119,6 +120,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ClimateControlScheduleCommand,
 			ClimateControlScheduleCommand.Get,
+			nameof(ClimateControlScheduleCommand),
 		);
 
 		const cc = new ClimateControlScheduleCCGet(this.applHost, {
@@ -138,6 +140,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ClimateControlScheduleCommand,
 			ClimateControlScheduleCommand.ChangedGet,
+			nameof(ClimateControlScheduleCommand),
 		);
 
 		const cc = new ClimateControlScheduleCCChangedGet(this.applHost, {
@@ -157,6 +160,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ClimateControlScheduleCommand,
 			ClimateControlScheduleCommand.OverrideGet,
+			nameof(ClimateControlScheduleCommand),
 		);
 
 		const cc = new ClimateControlScheduleCCOverrideGet(this.applHost, {
@@ -184,6 +188,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ClimateControlScheduleCommand,
 			ClimateControlScheduleCommand.OverrideSet,
+			nameof(ClimateControlScheduleCommand),
 		);
 
 		const cc = new ClimateControlScheduleCCOverrideSet(this.applHost, {

--- a/packages/cc/src/cc/ColorSwitchCC.ts
+++ b/packages/cc/src/cc/ColorSwitchCC.ts
@@ -179,6 +179,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ColorSwitchCommand,
 			ColorSwitchCommand.SupportedGet,
+			nameof(ColorSwitchCommand),
 		);
 
 		const cc = new ColorSwitchCCSupportedGet(this.applHost, {
@@ -334,6 +335,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ColorSwitchCommand,
 			ColorSwitchCommand.StartLevelChange,
+			nameof(ColorSwitchCommand),
 		);
 
 		const cc = new ColorSwitchCCStartLevelChange(this.applHost, {
@@ -352,6 +354,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ColorSwitchCommand,
 			ColorSwitchCommand.StopLevelChange,
+			nameof(ColorSwitchCommand),
 		);
 
 		const cc = new ColorSwitchCCStopLevelChange(this.applHost, {

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -475,6 +475,7 @@ export class ConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ConfigurationCommand,
 			ConfigurationCommand.Get,
+			nameof(ConfigurationCommand),
 		);
 
 		const { valueBitMask, allowUnexpectedResponse } = options ?? {};
@@ -563,6 +564,7 @@ export class ConfigurationCCAPI extends CCAPI {
 			this.assertSupportsCommand(
 				ConfigurationCommand,
 				ConfigurationCommand.Get,
+				nameof(ConfigurationCommand),
 			);
 
 			const _values = new Map<number, ConfigValue>();
@@ -614,6 +616,7 @@ export class ConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ConfigurationCommand,
 			ConfigurationCommand.Set,
+			nameof(ConfigurationCommand),
 		);
 
 		const normalized = normalizeConfigurationCCAPISetOptions(
@@ -693,6 +696,7 @@ export class ConfigurationCCAPI extends CCAPI {
 			this.assertSupportsCommand(
 				ConfigurationCommand,
 				ConfigurationCommand.Set,
+				nameof(ConfigurationCommand),
 			);
 			for (const {
 				parameter,
@@ -726,6 +730,7 @@ export class ConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ConfigurationCommand,
 			ConfigurationCommand.Set,
+			nameof(ConfigurationCommand),
 		);
 
 		const cc = new ConfigurationCCSet(this.applHost, {
@@ -759,6 +764,7 @@ export class ConfigurationCCAPI extends CCAPI {
 			this.assertSupportsCommand(
 				ConfigurationCommand,
 				ConfigurationCommand.Set,
+				nameof(ConfigurationCommand),
 			);
 			const CCs = distinct(parameters).map(
 				(parameter) =>
@@ -783,6 +789,7 @@ export class ConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ConfigurationCommand,
 			ConfigurationCommand.DefaultReset,
+			nameof(ConfigurationCommand),
 		);
 
 		const cc = new ConfigurationCCDefaultReset(this.applHost, {

--- a/packages/cc/src/cc/DoorLockCC.ts
+++ b/packages/cc/src/cc/DoorLockCC.ts
@@ -317,6 +317,7 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			DoorLockCommand,
 			DoorLockCommand.CapabilitiesGet,
+			nameof(DoorLockCommand),
 		);
 
 		const cc = new DoorLockCCCapabilitiesGet(this.applHost, {
@@ -350,6 +351,7 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			DoorLockCommand,
 			DoorLockCommand.OperationGet,
+			nameof(DoorLockCommand),
 		);
 
 		const cc = new DoorLockCCOperationGet(this.applHost, {
@@ -383,6 +385,7 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			DoorLockCommand,
 			DoorLockCommand.OperationSet,
+			nameof(DoorLockCommand),
 		);
 
 		const cc = new DoorLockCCOperationSet(this.applHost, {
@@ -400,6 +403,7 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			DoorLockCommand,
 			DoorLockCommand.ConfigurationSet,
+			nameof(DoorLockCommand),
 		);
 
 		const cc = new DoorLockCCConfigurationSet(this.applHost, {
@@ -415,6 +419,7 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			DoorLockCommand,
 			DoorLockCommand.ConfigurationGet,
+			nameof(DoorLockCommand),
 		);
 
 		const cc = new DoorLockCCConfigurationGet(this.applHost, {

--- a/packages/cc/src/cc/DoorLockLoggingCC.ts
+++ b/packages/cc/src/cc/DoorLockLoggingCC.ts
@@ -118,6 +118,7 @@ export class DoorLockLoggingCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			DoorLockLoggingCommand,
 			DoorLockLoggingCommand.RecordsSupportedGet,
+			nameof(DoorLockLoggingCommand),
 		);
 
 		const cc = new DoorLockLoggingCCRecordsSupportedGet(this.applHost, {
@@ -140,6 +141,7 @@ export class DoorLockLoggingCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			DoorLockLoggingCommand,
 			DoorLockLoggingCommand.RecordGet,
+			nameof(DoorLockLoggingCommand),
 		);
 
 		const cc = new DoorLockLoggingCCRecordGet(this.applHost, {

--- a/packages/cc/src/cc/EntryControlCC.ts
+++ b/packages/cc/src/cc/EntryControlCC.ts
@@ -99,6 +99,7 @@ export class EntryControlCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			EntryControlCommand,
 			EntryControlCommand.KeySupportedGet,
+			nameof(EntryControlCommand),
 		);
 
 		const cc = new EntryControlCCKeySupportedGet(this.applHost, {
@@ -118,6 +119,7 @@ export class EntryControlCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			EntryControlCommand,
 			EntryControlCommand.EventSupportedGet,
+			nameof(EntryControlCommand),
 		);
 
 		const cc = new EntryControlCCEventSupportedGet(this.applHost, {
@@ -146,6 +148,7 @@ export class EntryControlCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			EntryControlCommand,
 			EntryControlCommand.ConfigurationGet,
+			nameof(EntryControlCommand),
 		);
 
 		const cc = new EntryControlCCConfigurationGet(this.applHost, {
@@ -170,6 +173,7 @@ export class EntryControlCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			EntryControlCommand,
 			EntryControlCommand.ConfigurationGet,
+			nameof(EntryControlCommand),
 		);
 
 		const cc = new EntryControlCCConfigurationSet(this.applHost, {

--- a/packages/cc/src/cc/FirmwareUpdateMetaDataCC.ts
+++ b/packages/cc/src/cc/FirmwareUpdateMetaDataCC.ts
@@ -97,6 +97,7 @@ export class FirmwareUpdateMetaDataCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			FirmwareUpdateMetaDataCommand,
 			FirmwareUpdateMetaDataCommand.MetaDataGet,
+			nameof(FirmwareUpdateMetaDataCommand),
 		);
 
 		const cc = new FirmwareUpdateMetaDataCCMetaDataGet(this.applHost, {
@@ -134,6 +135,7 @@ export class FirmwareUpdateMetaDataCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			FirmwareUpdateMetaDataCommand,
 			FirmwareUpdateMetaDataCommand.RequestGet,
+			nameof(FirmwareUpdateMetaDataCommand),
 		);
 
 		const cc = new FirmwareUpdateMetaDataCCRequestGet(this.applHost, {
@@ -167,6 +169,7 @@ export class FirmwareUpdateMetaDataCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			FirmwareUpdateMetaDataCommand,
 			FirmwareUpdateMetaDataCommand.Report,
+			nameof(FirmwareUpdateMetaDataCommand),
 		);
 
 		const cc = new FirmwareUpdateMetaDataCCReport(this.applHost, {
@@ -187,6 +190,7 @@ export class FirmwareUpdateMetaDataCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			FirmwareUpdateMetaDataCommand,
 			FirmwareUpdateMetaDataCommand.ActivationSet,
+			nameof(FirmwareUpdateMetaDataCommand),
 		);
 
 		const cc = new FirmwareUpdateMetaDataCCActivationSet(this.applHost, {

--- a/packages/cc/src/cc/HumidityControlModeCC.ts
+++ b/packages/cc/src/cc/HumidityControlModeCC.ts
@@ -111,6 +111,7 @@ export class HumidityControlModeCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			HumidityControlModeCommand,
 			HumidityControlModeCommand.Get,
+			nameof(HumidityControlModeCommand),
 		);
 
 		const cc = new HumidityControlModeCCGet(this.applHost, {
@@ -134,6 +135,7 @@ export class HumidityControlModeCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			HumidityControlModeCommand,
 			HumidityControlModeCommand.Set,
+			nameof(HumidityControlModeCommand),
 		);
 
 		const cc = new HumidityControlModeCCSet(this.applHost, {
@@ -150,6 +152,7 @@ export class HumidityControlModeCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			HumidityControlModeCommand,
 			HumidityControlModeCommand.SupportedGet,
+			nameof(HumidityControlModeCommand),
 		);
 
 		const cc = new HumidityControlModeCCSupportedGet(this.applHost, {

--- a/packages/cc/src/cc/HumidityControlOperatingStateCC.ts
+++ b/packages/cc/src/cc/HumidityControlOperatingStateCC.ts
@@ -77,6 +77,7 @@ export class HumidityControlOperatingStateCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			HumidityControlOperatingStateCommand,
 			HumidityControlOperatingStateCommand.Get,
+			nameof(HumidityControlOperatingStateCommand),
 		);
 
 		const cc = new HumidityControlOperatingStateCCGet(this.applHost, {

--- a/packages/cc/src/cc/HumidityControlSetpointCC.ts
+++ b/packages/cc/src/cc/HumidityControlSetpointCC.ts
@@ -185,6 +185,7 @@ export class HumidityControlSetpointCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			HumidityControlSetpointCommand,
 			HumidityControlSetpointCommand.Get,
+			nameof(HumidityControlSetpointCommand),
 		);
 
 		const cc = new HumidityControlSetpointCCGet(this.applHost, {
@@ -217,6 +218,7 @@ export class HumidityControlSetpointCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			HumidityControlSetpointCommand,
 			HumidityControlSetpointCommand.Set,
+			nameof(HumidityControlSetpointCommand),
 		);
 
 		const cc = new HumidityControlSetpointCCSet(this.applHost, {
@@ -236,6 +238,7 @@ export class HumidityControlSetpointCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			HumidityControlSetpointCommand,
 			HumidityControlSetpointCommand.CapabilitiesGet,
+			nameof(HumidityControlSetpointCommand),
 		);
 
 		const cc = new HumidityControlSetpointCCCapabilitiesGet(this.applHost, {
@@ -264,6 +267,7 @@ export class HumidityControlSetpointCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			HumidityControlSetpointCommand,
 			HumidityControlSetpointCommand.SupportedGet,
+			nameof(HumidityControlSetpointCommand),
 		);
 
 		const cc = new HumidityControlSetpointCCSupportedGet(this.applHost, {
@@ -285,6 +289,7 @@ export class HumidityControlSetpointCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			HumidityControlSetpointCommand,
 			HumidityControlSetpointCommand.SupportedGet,
+			nameof(HumidityControlSetpointCommand),
 		);
 
 		const cc = new HumidityControlSetpointCCScaleSupportedGet(

--- a/packages/cc/src/cc/InclusionControllerCC.ts
+++ b/packages/cc/src/cc/InclusionControllerCC.ts
@@ -50,6 +50,7 @@ export class InclusionControllerCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			InclusionControllerCommand,
 			InclusionControllerCommand.Initiate,
+			nameof(InclusionControllerCommand),
 		);
 
 		const cc = new InclusionControllerCCInitiate(this.applHost, {
@@ -69,6 +70,7 @@ export class InclusionControllerCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			InclusionControllerCommand,
 			InclusionControllerCommand.Complete,
+			nameof(InclusionControllerCommand),
 		);
 
 		const cc = new InclusionControllerCCComplete(this.applHost, {

--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -310,6 +310,7 @@ export class IndicatorCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IndicatorCommand,
 			IndicatorCommand.SupportedGet,
+			nameof(IndicatorCommand),
 		);
 
 		const cc = new IndicatorCCSupportedGet(this.applHost, {
@@ -370,6 +371,7 @@ export class IndicatorCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IndicatorCommand,
 			IndicatorCommand.DescriptionGet,
+			nameof(IndicatorCommand),
 		);
 
 		const cc = new IndicatorCCDescriptionGet(this.applHost, {

--- a/packages/cc/src/cc/IrrigationCC.ts
+++ b/packages/cc/src/cc/IrrigationCC.ts
@@ -516,6 +516,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.SystemInfoGet,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCSystemInfoGet(this.applHost, {
@@ -542,6 +543,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.SystemStatusGet,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCSystemStatusGet(this.applHost, {
@@ -579,6 +581,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.SystemConfigGet,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCSystemConfigGet(this.applHost, {
@@ -608,6 +611,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.SystemConfigSet,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCSystemConfigSet(this.applHost, {
@@ -625,6 +629,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.ValveInfoGet,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCValveInfoGet(this.applHost, {
@@ -658,6 +663,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.ValveConfigSet,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCValveConfigSet(this.applHost, {
@@ -675,6 +681,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.ValveConfigGet,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCValveConfigGet(this.applHost, {
@@ -708,6 +715,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.ValveRun,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCValveRun(this.applHost, {
@@ -735,6 +743,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.ValveTableSet,
+			nameof(IrrigationCommand),
 		);
 
 		if (!this.endpoint.virtual) {
@@ -770,6 +779,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.ValveTableGet,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCValveTableGet(this.applHost, {
@@ -794,6 +804,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.ValveTableRun,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCValveTableRun(this.applHost, {
@@ -816,6 +827,7 @@ export class IrrigationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.SystemShutoff,
+			nameof(IrrigationCommand),
 		);
 
 		const cc = new IrrigationCCSystemShutoff(this.applHost, {

--- a/packages/cc/src/cc/ManufacturerSpecificCC.ts
+++ b/packages/cc/src/cc/ManufacturerSpecificCC.ts
@@ -96,6 +96,7 @@ export class ManufacturerSpecificCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			ManufacturerSpecificCommand,
 			ManufacturerSpecificCommand.Get,
+			nameof(ManufacturerSpecificCommand),
 		);
 
 		const cc = new ManufacturerSpecificCCGet(this.applHost, {
@@ -123,6 +124,7 @@ export class ManufacturerSpecificCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			ManufacturerSpecificCommand,
 			ManufacturerSpecificCommand.DeviceSpecificGet,
+			nameof(ManufacturerSpecificCommand),
 		);
 
 		const cc = new ManufacturerSpecificCCDeviceSpecificGet(this.applHost, {

--- a/packages/cc/src/cc/MultiChannelAssociationCC.ts
+++ b/packages/cc/src/cc/MultiChannelAssociationCC.ts
@@ -195,6 +195,7 @@ export class MultiChannelAssociationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			MultiChannelAssociationCommand,
 			MultiChannelAssociationCommand.SupportedGroupingsGet,
+			nameof(MultiChannelAssociationCommand),
 		);
 
 		const cc = new MultiChannelAssociationCCSupportedGroupingsGet(
@@ -221,6 +222,7 @@ export class MultiChannelAssociationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			MultiChannelAssociationCommand,
 			MultiChannelAssociationCommand.Get,
+			nameof(MultiChannelAssociationCommand),
 		);
 
 		const cc = new MultiChannelAssociationCCGet(this.applHost, {
@@ -248,6 +250,7 @@ export class MultiChannelAssociationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			MultiChannelAssociationCommand,
 			MultiChannelAssociationCommand.Set,
+			nameof(MultiChannelAssociationCommand),
 		);
 
 		const cc = new MultiChannelAssociationCCSet(this.applHost, {
@@ -268,6 +271,7 @@ export class MultiChannelAssociationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			MultiChannelAssociationCommand,
 			MultiChannelAssociationCommand.Remove,
+			nameof(MultiChannelAssociationCommand),
 		);
 
 		if (!options.groupId && this.version === 1) {

--- a/packages/cc/src/cc/MultiChannelCC.ts
+++ b/packages/cc/src/cc/MultiChannelCC.ts
@@ -172,6 +172,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultiChannelCommand,
 			MultiChannelCommand.EndPointGet,
+			nameof(MultiChannelCommand),
 		);
 
 		const cc = new MultiChannelCCEndPointGet(this.applHost, {
@@ -200,6 +201,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultiChannelCommand,
 			MultiChannelCommand.CapabilityGet,
+			nameof(MultiChannelCommand),
 		);
 
 		const cc = new MultiChannelCCCapabilityGet(this.applHost, {
@@ -240,6 +242,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultiChannelCommand,
 			MultiChannelCommand.EndPointFind,
+			nameof(MultiChannelCommand),
 		);
 
 		const cc = new MultiChannelCCEndPointFind(this.applHost, {
@@ -263,6 +266,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultiChannelCommand,
 			MultiChannelCommand.AggregatedMembersGet,
+			nameof(MultiChannelCommand),
 		);
 
 		const cc = new MultiChannelCCAggregatedMembersGet(this.applHost, {
@@ -289,6 +293,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultiChannelCommand,
 			MultiChannelCommand.CommandEncapsulation,
+			nameof(MultiChannelCommand),
 		);
 
 		const cc = new MultiChannelCCCommandEncapsulation(this.applHost, {
@@ -305,6 +310,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultiChannelCommand,
 			MultiChannelCommand.GetV1,
+			nameof(MultiChannelCommand),
 		);
 
 		const cc = new MultiChannelCCV1Get(this.applHost, {
@@ -325,6 +331,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultiChannelCommand,
 			MultiChannelCommand.CommandEncapsulationV1,
+			nameof(MultiChannelCommand),
 		);
 
 		const cc = new MultiChannelCCV1CommandEncapsulation(this.applHost, {

--- a/packages/cc/src/cc/MultiCommandCC.ts
+++ b/packages/cc/src/cc/MultiCommandCC.ts
@@ -41,6 +41,7 @@ export class MultiCommandCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultiCommandCommand,
 			MultiCommandCommand.CommandEncapsulation,
+			nameof(MultiCommandCommand),
 		);
 
 		// FIXME: This should not be on the API but rather on the applHost level

--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -213,6 +213,7 @@ export class MultilevelSensorCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			MultilevelSensorCommand,
 			MultilevelSensorCommand.Get,
+			nameof(MultilevelSensorCommand),
 		);
 
 		// Figure out the preferred scale if none was given
@@ -278,6 +279,7 @@ export class MultilevelSensorCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			MultilevelSensorCommand,
 			MultilevelSensorCommand.GetSupportedSensor,
+			nameof(MultilevelSensorCommand),
 		);
 
 		const cc = new MultilevelSensorCCGetSupportedSensor(this.applHost, {
@@ -299,6 +301,7 @@ export class MultilevelSensorCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			MultilevelSensorCommand,
 			MultilevelSensorCommand.GetSupportedScale,
+			nameof(MultilevelSensorCommand),
 		);
 
 		const cc = new MultilevelSensorCCGetSupportedScale(this.applHost, {
@@ -323,6 +326,7 @@ export class MultilevelSensorCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			MultilevelSensorCommand,
 			MultilevelSensorCommand.Report,
+			nameof(MultilevelSensorCommand),
 		);
 
 		const cc = new MultilevelSensorCCReport(this.applHost, {

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -197,6 +197,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultilevelSwitchCommand,
 			MultilevelSwitchCommand.Get,
+			nameof(MultilevelSwitchCommand),
 		);
 
 		const cc = new MultilevelSwitchCCGet(this.applHost, {
@@ -227,6 +228,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultilevelSwitchCommand,
 			MultilevelSwitchCommand.Set,
+			nameof(MultilevelSwitchCommand),
 		);
 
 		const cc = new MultilevelSwitchCCSet(this.applHost, {
@@ -245,6 +247,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultilevelSwitchCommand,
 			MultilevelSwitchCommand.StartLevelChange,
+			nameof(MultilevelSwitchCommand),
 		);
 
 		const cc = new MultilevelSwitchCCStartLevelChange(this.applHost, {
@@ -260,6 +263,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultilevelSwitchCommand,
 			MultilevelSwitchCommand.StopLevelChange,
+			nameof(MultilevelSwitchCommand),
 		);
 
 		const cc = new MultilevelSwitchCCStopLevelChange(this.applHost, {
@@ -274,6 +278,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			MultilevelSwitchCommand,
 			MultilevelSwitchCommand.SupportedGet,
+			nameof(MultilevelSwitchCommand),
 		);
 
 		const cc = new MultilevelSwitchCCSupportedGet(this.applHost, {

--- a/packages/cc/src/cc/NodeNamingCC.ts
+++ b/packages/cc/src/cc/NodeNamingCC.ts
@@ -117,6 +117,7 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			NodeNamingAndLocationCommand,
 			NodeNamingAndLocationCommand.NameGet,
+			nameof(NodeNamingAndLocationCommand),
 		);
 
 		const cc = new NodeNamingAndLocationCCNameGet(this.applHost, {
@@ -136,6 +137,7 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			NodeNamingAndLocationCommand,
 			NodeNamingAndLocationCommand.NameSet,
+			nameof(NodeNamingAndLocationCommand),
 		);
 
 		const cc = new NodeNamingAndLocationCCNameSet(this.applHost, {
@@ -150,6 +152,7 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			NodeNamingAndLocationCommand,
 			NodeNamingAndLocationCommand.LocationGet,
+			nameof(NodeNamingAndLocationCommand),
 		);
 
 		const cc = new NodeNamingAndLocationCCLocationGet(this.applHost, {
@@ -171,6 +174,7 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			NodeNamingAndLocationCommand,
 			NodeNamingAndLocationCommand.LocationSet,
+			nameof(NodeNamingAndLocationCommand),
 		);
 
 		const cc = new NodeNamingAndLocationCCLocationSet(this.applHost, {

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -180,6 +180,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			NotificationCommand,
 			NotificationCommand.Get,
+			nameof(NotificationCommand),
 		);
 
 		const cc = new NotificationCCGet(this.applHost, {
@@ -200,6 +201,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			NotificationCommand,
 			NotificationCommand.Report,
+			nameof(NotificationCommand),
 		);
 
 		const cc = new NotificationCCReport(this.applHost, {
@@ -234,6 +236,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			NotificationCommand,
 			NotificationCommand.Set,
+			nameof(NotificationCommand),
 		);
 
 		const cc = new NotificationCCSet(this.applHost, {
@@ -250,6 +253,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			NotificationCommand,
 			NotificationCommand.SupportedGet,
+			nameof(NotificationCommand),
 		);
 
 		const cc = new NotificationCCSupportedGet(this.applHost, {
@@ -276,6 +280,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			NotificationCommand,
 			NotificationCommand.EventSupportedGet,
+			nameof(NotificationCommand),
 		);
 
 		const cc = new NotificationCCEventSupportedGet(this.applHost, {

--- a/packages/cc/src/cc/PowerlevelCC.ts
+++ b/packages/cc/src/cc/PowerlevelCC.ts
@@ -101,6 +101,7 @@ export class PowerlevelCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			PowerlevelCommand,
 			PowerlevelCommand.TestNodeSet,
+			nameof(PowerlevelCommand),
 		);
 
 		if (testNodeId === this.endpoint.nodeId) {
@@ -143,6 +144,7 @@ export class PowerlevelCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			PowerlevelCommand,
 			PowerlevelCommand.TestNodeGet,
+			nameof(PowerlevelCommand),
 		);
 
 		const cc = new PowerlevelCCTestNodeGet(this.applHost, {

--- a/packages/cc/src/cc/ProtectionCC.ts
+++ b/packages/cc/src/cc/ProtectionCC.ts
@@ -247,6 +247,7 @@ export class ProtectionCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ProtectionCommand,
 			ProtectionCommand.SupportedGet,
+			nameof(ProtectionCommand),
 		);
 
 		const cc = new ProtectionCCSupportedGet(this.applHost, {
@@ -272,6 +273,7 @@ export class ProtectionCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ProtectionCommand,
 			ProtectionCommand.ExclusiveControlGet,
+			nameof(ProtectionCommand),
 		);
 
 		const cc = new ProtectionCCExclusiveControlGet(this.applHost, {
@@ -293,6 +295,7 @@ export class ProtectionCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ProtectionCommand,
 			ProtectionCommand.ExclusiveControlSet,
+			nameof(ProtectionCommand),
 		);
 
 		const cc = new ProtectionCCExclusiveControlSet(this.applHost, {
@@ -307,6 +310,7 @@ export class ProtectionCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ProtectionCommand,
 			ProtectionCommand.TimeoutGet,
+			nameof(ProtectionCommand),
 		);
 
 		const cc = new ProtectionCCTimeoutGet(this.applHost, {
@@ -328,6 +332,7 @@ export class ProtectionCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ProtectionCommand,
 			ProtectionCommand.TimeoutSet,
+			nameof(ProtectionCommand),
 		);
 
 		const cc = new ProtectionCCTimeoutSet(this.applHost, {

--- a/packages/cc/src/cc/SceneActivationCC.ts
+++ b/packages/cc/src/cc/SceneActivationCC.ts
@@ -93,6 +93,7 @@ export class SceneActivationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SceneActivationCommand,
 			SceneActivationCommand.Set,
+			nameof(SceneActivationCommand),
 		);
 
 		const cc = new SceneActivationCCSet(this.applHost, {

--- a/packages/cc/src/cc/SceneActuatorConfigurationCC.ts
+++ b/packages/cc/src/cc/SceneActuatorConfigurationCC.ts
@@ -190,6 +190,7 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SceneActuatorConfigurationCommand,
 			SceneActuatorConfigurationCommand.Set,
+			nameof(SceneActuatorConfigurationCommand),
 		);
 
 		// Undefined `dimmingDuration` defaults to 0 seconds to simplify the call
@@ -217,6 +218,7 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SceneActuatorConfigurationCommand,
 			SceneActuatorConfigurationCommand.Get,
+			nameof(SceneActuatorConfigurationCommand),
 		);
 
 		const cc = new SceneActuatorConfigurationCCGet(this.applHost, {
@@ -245,6 +247,7 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SceneActuatorConfigurationCommand,
 			SceneActuatorConfigurationCommand.Get,
+			nameof(SceneActuatorConfigurationCommand),
 		);
 
 		if (sceneId === 0) {

--- a/packages/cc/src/cc/SceneControllerConfigurationCC.ts
+++ b/packages/cc/src/cc/SceneControllerConfigurationCC.ts
@@ -210,6 +210,7 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SceneControllerConfigurationCommand,
 			SceneControllerConfigurationCommand.Set,
+			nameof(SceneControllerConfigurationCommand),
 		);
 
 		return this.set(groupId, 0, new Duration(0, "seconds"));
@@ -224,6 +225,7 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SceneControllerConfigurationCommand,
 			SceneControllerConfigurationCommand.Set,
+			nameof(SceneControllerConfigurationCommand),
 		);
 
 		if (!this.endpoint.virtual) {
@@ -270,6 +272,7 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SceneControllerConfigurationCommand,
 			SceneControllerConfigurationCommand.Get,
+			nameof(SceneControllerConfigurationCommand),
 		);
 
 		const cc = new SceneControllerConfigurationCCGet(this.applHost, {
@@ -304,6 +307,7 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SceneControllerConfigurationCommand,
 			SceneControllerConfigurationCommand.Get,
+			nameof(SceneControllerConfigurationCommand),
 		);
 
 		if (groupId === 0) {

--- a/packages/cc/src/cc/ScheduleEntryLockCC.ts
+++ b/packages/cc/src/cc/ScheduleEntryLockCC.ts
@@ -99,6 +99,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 			this.assertSupportsCommand(
 				ScheduleEntryLockCommand,
 				ScheduleEntryLockCommand.EnableSet,
+				nameof(ScheduleEntryLockCommand),
 			);
 
 			const cc = new ScheduleEntryLockCCEnableSet(this.applHost, {
@@ -113,6 +114,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 			this.assertSupportsCommand(
 				ScheduleEntryLockCommand,
 				ScheduleEntryLockCommand.EnableAllSet,
+				nameof(ScheduleEntryLockCommand),
 			);
 
 			const cc = new ScheduleEntryLockCCEnableAllSet(this.applHost, {
@@ -130,6 +132,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ScheduleEntryLockCommand,
 			ScheduleEntryLockCommand.SupportedGet,
+			nameof(ScheduleEntryLockCommand),
 		);
 
 		const cc = new ScheduleEntryLockCCSupportedGet(this.applHost, {
@@ -160,6 +163,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ScheduleEntryLockCommand,
 			ScheduleEntryLockCommand.WeekDayScheduleSet,
+			nameof(ScheduleEntryLockCommand),
 		);
 
 		if (this.isSinglecast()) {
@@ -200,6 +204,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ScheduleEntryLockCommand,
 			ScheduleEntryLockCommand.WeekDayScheduleSet,
+			nameof(ScheduleEntryLockCommand),
 		);
 
 		const cc = new ScheduleEntryLockCCWeekDayScheduleGet(this.applHost, {
@@ -232,6 +237,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ScheduleEntryLockCommand,
 			ScheduleEntryLockCommand.YearDayScheduleSet,
+			nameof(ScheduleEntryLockCommand),
 		);
 
 		if (this.isSinglecast()) {
@@ -272,6 +278,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ScheduleEntryLockCommand,
 			ScheduleEntryLockCommand.YearDayScheduleSet,
+			nameof(ScheduleEntryLockCommand),
 		);
 
 		const cc = new ScheduleEntryLockCCYearDayScheduleGet(this.applHost, {
@@ -309,6 +316,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ScheduleEntryLockCommand,
 			ScheduleEntryLockCommand.DailyRepeatingScheduleSet,
+			nameof(ScheduleEntryLockCommand),
 		);
 
 		if (this.isSinglecast()) {
@@ -353,6 +361,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ScheduleEntryLockCommand,
 			ScheduleEntryLockCommand.DailyRepeatingScheduleSet,
+			nameof(ScheduleEntryLockCommand),
 		);
 
 		const cc = new ScheduleEntryLockCCDailyRepeatingScheduleGet(
@@ -384,6 +393,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ScheduleEntryLockCommand,
 			ScheduleEntryLockCommand.TimeOffsetGet,
+			nameof(ScheduleEntryLockCommand),
 		);
 
 		const cc = new ScheduleEntryLockCCTimeOffsetGet(this.applHost, {
@@ -408,6 +418,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ScheduleEntryLockCommand,
 			ScheduleEntryLockCommand.TimeOffsetSet,
+			nameof(ScheduleEntryLockCommand),
 		);
 
 		const cc = new ScheduleEntryLockCCTimeOffsetSet(this.applHost, {

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -140,6 +140,7 @@ export class Security2CCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			Security2Command,
 			Security2Command.NonceReport,
+			nameof(Security2Command),
 		);
 
 		this.assertPhysicalEndpoint(this.endpoint);
@@ -205,6 +206,7 @@ export class Security2CCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			Security2Command,
 			Security2Command.CommandsSupportedGet,
+			nameof(Security2Command),
 		);
 
 		let cc: CommandClass = new Security2CCCommandsSupportedGet(
@@ -278,6 +280,7 @@ export class Security2CCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			Security2Command,
 			Security2Command.KEXReport,
+			nameof(Security2Command),
 		);
 
 		const cc = new Security2CCKEXReport(this.applHost, {
@@ -305,6 +308,7 @@ export class Security2CCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			Security2Command,
 			Security2Command.PublicKeyReport,
+			nameof(Security2Command),
 		);
 
 		const cc = new Security2CCPublicKeyReport(this.applHost, {
@@ -323,6 +327,7 @@ export class Security2CCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			Security2Command,
 			Security2Command.NetworkKeyReport,
+			nameof(Security2Command),
 		);
 
 		const cc = new Security2CCNetworkKeyReport(this.applHost, {
@@ -338,6 +343,7 @@ export class Security2CCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			Security2Command,
 			Security2Command.TransferEnd,
+			nameof(Security2Command),
 		);
 
 		const cc = new Security2CCTransferEnd(this.applHost, {

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -91,11 +91,13 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 			this.assertSupportsCommand(
 				SecurityCommand,
 				SecurityCommand.CommandEncapsulation,
+				nameof(SecurityCommand),
 			);
 		} else {
 			this.assertSupportsCommand(
 				SecurityCommand,
 				SecurityCommand.CommandEncapsulationNonceGet,
+				nameof(SecurityCommand),
 			);
 		}
 
@@ -153,6 +155,7 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			SecurityCommand,
 			SecurityCommand.NonceReport,
+			nameof(SecurityCommand),
 		);
 
 		if (!this.applHost.securityManager) {
@@ -216,6 +219,7 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			SecurityCommand,
 			SecurityCommand.SchemeInherit,
+			nameof(SecurityCommand),
 		);
 
 		const cc = new SecurityCCSchemeInherit(this.applHost, {
@@ -230,6 +234,7 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			SecurityCommand,
 			SecurityCommand.NetworkKeySet,
+			nameof(SecurityCommand),
 		);
 
 		const keySet = new SecurityCCNetworkKeySet(this.applHost, {
@@ -251,6 +256,7 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			SecurityCommand,
 			SecurityCommand.CommandsSupportedGet,
+			nameof(SecurityCommand),
 		);
 
 		const cc = new SecurityCCCommandsSupportedGet(this.applHost, {

--- a/packages/cc/src/cc/SoundSwitchCC.ts
+++ b/packages/cc/src/cc/SoundSwitchCC.ts
@@ -100,6 +100,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SoundSwitchCommand,
 			SoundSwitchCommand.TonesNumberGet,
+			nameof(SoundSwitchCommand),
 		);
 
 		const cc = new SoundSwitchCCTonesNumberGet(this.applHost, {
@@ -120,6 +121,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SoundSwitchCommand,
 			SoundSwitchCommand.ToneInfoGet,
+			nameof(SoundSwitchCommand),
 		);
 
 		const cc = new SoundSwitchCCToneInfoGet(this.applHost, {
@@ -143,6 +145,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SoundSwitchCommand,
 			SoundSwitchCommand.ConfigurationSet,
+			nameof(SoundSwitchCommand),
 		);
 
 		const cc = new SoundSwitchCCConfigurationSet(this.applHost, {
@@ -159,6 +162,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SoundSwitchCommand,
 			SoundSwitchCommand.ConfigurationGet,
+			nameof(SoundSwitchCommand),
 		);
 
 		const cc = new SoundSwitchCCConfigurationGet(this.applHost, {
@@ -183,6 +187,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SoundSwitchCommand,
 			SoundSwitchCommand.TonePlaySet,
+			nameof(SoundSwitchCommand),
 		);
 
 		if (toneId === 0) {
@@ -205,6 +210,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SoundSwitchCommand,
 			SoundSwitchCommand.TonePlaySet,
+			nameof(SoundSwitchCommand),
 		);
 
 		const cc = new SoundSwitchCCTonePlaySet(this.applHost, {
@@ -221,6 +227,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			SoundSwitchCommand,
 			SoundSwitchCommand.TonePlayGet,
+			nameof(SoundSwitchCommand),
 		);
 
 		const cc = new SoundSwitchCCTonePlayGet(this.applHost, {

--- a/packages/cc/src/cc/ThermostatFanModeCC.ts
+++ b/packages/cc/src/cc/ThermostatFanModeCC.ts
@@ -158,6 +158,7 @@ export class ThermostatFanModeCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatFanModeCommand,
 			ThermostatFanModeCommand.Get,
+			nameof(ThermostatFanModeCommand),
 		);
 
 		const cc = new ThermostatFanModeCCGet(this.applHost, {
@@ -182,6 +183,7 @@ export class ThermostatFanModeCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatFanModeCommand,
 			ThermostatFanModeCommand.Set,
+			nameof(ThermostatFanModeCommand),
 		);
 
 		const cc = new ThermostatFanModeCCSet(this.applHost, {
@@ -199,6 +201,7 @@ export class ThermostatFanModeCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatFanModeCommand,
 			ThermostatFanModeCommand.SupportedGet,
+			nameof(ThermostatFanModeCommand),
 		);
 
 		const cc = new ThermostatFanModeCCSupportedGet(this.applHost, {

--- a/packages/cc/src/cc/ThermostatFanStateCC.ts
+++ b/packages/cc/src/cc/ThermostatFanStateCC.ts
@@ -69,6 +69,7 @@ export class ThermostatFanStateCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatFanStateCommand,
 			ThermostatFanStateCommand.Get,
+			nameof(ThermostatFanStateCommand),
 		);
 
 		const cc = new ThermostatFanStateCCGet(this.applHost, {

--- a/packages/cc/src/cc/ThermostatModeCC.ts
+++ b/packages/cc/src/cc/ThermostatModeCC.ts
@@ -111,6 +111,7 @@ export class ThermostatModeCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatModeCommand,
 			ThermostatModeCommand.Get,
+			nameof(ThermostatModeCommand),
 		);
 
 		const cc = new ThermostatModeCCGet(this.applHost, {
@@ -146,6 +147,7 @@ export class ThermostatModeCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatModeCommand,
 			ThermostatModeCommand.Set,
+			nameof(ThermostatModeCommand),
 		);
 
 		const cc = new ThermostatModeCCSet(this.applHost, {
@@ -163,6 +165,7 @@ export class ThermostatModeCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatModeCommand,
 			ThermostatModeCommand.SupportedGet,
+			nameof(ThermostatModeCommand),
 		);
 
 		const cc = new ThermostatModeCCSupportedGet(this.applHost, {

--- a/packages/cc/src/cc/ThermostatOperatingStateCC.ts
+++ b/packages/cc/src/cc/ThermostatOperatingStateCC.ts
@@ -73,6 +73,7 @@ export class ThermostatOperatingStateCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			ThermostatOperatingStateCommand,
 			ThermostatOperatingStateCommand.Get,
+			nameof(ThermostatOperatingStateCommand),
 		);
 
 		const cc = new ThermostatOperatingStateCCGet(this.applHost, {

--- a/packages/cc/src/cc/ThermostatSetbackCC.ts
+++ b/packages/cc/src/cc/ThermostatSetbackCC.ts
@@ -94,6 +94,7 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatSetbackCommand,
 			ThermostatSetbackCommand.Get,
+			nameof(ThermostatSetbackCommand),
 		);
 
 		const cc = new ThermostatSetbackCCGet(this.applHost, {
@@ -118,6 +119,7 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatSetbackCommand,
 			ThermostatSetbackCommand.Get,
+			nameof(ThermostatSetbackCommand),
 		);
 
 		const cc = new ThermostatSetbackCCSet(this.applHost, {

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -185,6 +185,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatSetpointCommand,
 			ThermostatSetpointCommand.Get,
+			nameof(ThermostatSetpointCommand),
 		);
 
 		const cc = new ThermostatSetpointCCGet(this.applHost, {
@@ -217,6 +218,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatSetpointCommand,
 			ThermostatSetpointCommand.Set,
+			nameof(ThermostatSetpointCommand),
 		);
 
 		const cc = new ThermostatSetpointCCSet(this.applHost, {
@@ -235,6 +237,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatSetpointCommand,
 			ThermostatSetpointCommand.CapabilitiesGet,
+			nameof(ThermostatSetpointCommand),
 		);
 
 		const cc = new ThermostatSetpointCCCapabilitiesGet(this.applHost, {
@@ -268,6 +271,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			ThermostatSetpointCommand,
 			ThermostatSetpointCommand.SupportedGet,
+			nameof(ThermostatSetpointCommand),
 		);
 
 		const cc = new ThermostatSetpointCCSupportedGet(this.applHost, {

--- a/packages/cc/src/cc/TimeParametersCC.ts
+++ b/packages/cc/src/cc/TimeParametersCC.ts
@@ -152,6 +152,7 @@ export class TimeParametersCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			TimeParametersCommand,
 			TimeParametersCommand.Get,
+			nameof(TimeParametersCommand),
 		);
 
 		const cc = new TimeParametersCCGet(this.applHost, {
@@ -173,6 +174,7 @@ export class TimeParametersCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			TimeParametersCommand,
 			TimeParametersCommand.Set,
+			nameof(TimeParametersCommand),
 		);
 
 		const useLocalTime = this.endpoint.virtual

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -407,6 +407,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			UserCodeCommand,
 			UserCodeCommand.UsersNumberGet,
+			nameof(UserCodeCommand),
 		);
 
 		const cc = new UserCodeCCUsersNumberGet(this.applHost, {
@@ -439,6 +440,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			this.assertSupportsCommand(
 				UserCodeCommand,
 				UserCodeCommand.ExtendedUserCodeGet,
+				nameof(UserCodeCommand),
 			);
 
 			const cc = new UserCodeCCExtendedUserCodeGet(this.applHost, {
@@ -524,6 +526,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			UserCodeCommand,
 			UserCodeCommand.ExtendedUserCodeSet,
+			nameof(UserCodeCommand),
 		);
 
 		const numUsers = UserCodeCC.getSupportedUsersCached(
@@ -663,6 +666,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			UserCodeCommand,
 			UserCodeCommand.CapabilitiesGet,
+			nameof(UserCodeCommand),
 		);
 
 		const cc = new UserCodeCCCapabilitiesGet(this.applHost, {
@@ -692,6 +696,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			UserCodeCommand,
 			UserCodeCommand.KeypadModeGet,
+			nameof(UserCodeCommand),
 		);
 
 		const cc = new UserCodeCCKeypadModeGet(this.applHost, {
@@ -713,6 +718,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			UserCodeCommand,
 			UserCodeCommand.KeypadModeSet,
+			nameof(UserCodeCommand),
 		);
 
 		const supportedModes = UserCodeCC.getSupportedKeypadModesCached(
@@ -748,6 +754,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			UserCodeCommand,
 			UserCodeCommand.MasterCodeGet,
+			nameof(UserCodeCommand),
 		);
 
 		const cc = new UserCodeCCMasterCodeGet(this.applHost, {
@@ -769,6 +776,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			UserCodeCommand,
 			UserCodeCommand.MasterCodeSet,
+			nameof(UserCodeCommand),
 		);
 
 		const supportedASCIIChars = UserCodeCC.getSupportedASCIICharsCached(
@@ -815,6 +823,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			UserCodeCommand,
 			UserCodeCommand.UserCodeChecksumGet,
+			nameof(UserCodeCommand),
 		);
 
 		const cc = new UserCodeCCUserCodeChecksumGet(this.applHost, {

--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -262,6 +262,7 @@ export class VersionCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			VersionCommand,
 			VersionCommand.CommandClassGet,
+			nameof(VersionCommand),
 		);
 
 		const cc = new VersionCCCommandClassGet(this.applHost, {
@@ -282,6 +283,7 @@ export class VersionCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			VersionCommand,
 			VersionCommand.CapabilitiesGet,
+			nameof(VersionCommand),
 		);
 
 		const cc = new VersionCCCapabilitiesGet(this.applHost, {
@@ -303,6 +305,7 @@ export class VersionCCAPI extends PhysicalCCAPI {
 		this.assertSupportsCommand(
 			VersionCommand,
 			VersionCommand.ZWaveSoftwareGet,
+			nameof(VersionCommand),
 		);
 
 		const cc = new VersionCCZWaveSoftwareGet(this.applHost, {

--- a/packages/cc/src/cc/WakeUpCC.ts
+++ b/packages/cc/src/cc/WakeUpCC.ts
@@ -146,6 +146,7 @@ export class WakeUpCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			WakeUpCommand,
 			WakeUpCommand.IntervalCapabilitiesGet,
+			nameof(WakeUpCommand),
 		);
 
 		const cc = new WakeUpCCIntervalCapabilitiesGet(this.applHost, {
@@ -188,6 +189,7 @@ export class WakeUpCCAPI extends CCAPI {
 		this.assertSupportsCommand(
 			WakeUpCommand,
 			WakeUpCommand.NoMoreInformation,
+			nameof(WakeUpCommand),
 		);
 
 		const cc = new WakeUpCCNoMoreInformation(this.applHost, {

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -301,6 +301,7 @@ export class CCAPI {
 	protected assertSupportsCommand(
 		commandEnum: unknown,
 		command: number,
+		enumName?: string,
 	): void {
 		if (this.supportsCommand(command) !== true) {
 			const hasNodeId = typeof this.endpoint.nodeId === "number";
@@ -314,10 +315,9 @@ export class CCAPI {
 					this.endpoint.index > 0
 						? ` (Endpoint ${this.endpoint.index})`
 						: ""
-				} does not support the command ${getEnumMemberName(
-					commandEnum,
-					command,
-				)}!`,
+				} does not support ${
+					enumName ? `${enumName}.` : "the command "
+				}${getEnumMemberName(commandEnum, command)}!`,
 				ZWaveErrorCodes.CC_NotSupported,
 			);
 		}


### PR DESCRIPTION
fixes: #3042

TODO: fork ts-nameof into `@zwave-js/transformers`. `ts-nameof` uses outdated factory APIs and is unlikely to be updated.