### PR TITLE
fix(config): added parameter 99 to Zooz ZAC36

### DIFF
--- a/packages/config/config/devices/0x027a/zac36.json
+++ b/packages/config/config/devices/0x027a/zac36.json
@@ -318,11 +318,12 @@
 			"defaultValue": 1
 		},
 		{
+			"$if": "firmwareVersion >= 1.15",
 			"#": "99",
 			"label": "Manual Calibration Offset",
 			"description": "If the valve doesn't fully open after manual calibration, adjust the open angle with an offset.",
 			"valueSize": 1,
-			"unit": "percent",
+			"unit": "%",
 			"minValue": 1,
 			"maxValue": 10,
 			"defaultValue": 9,

--- a/packages/config/config/devices/0x027a/zac36.json
+++ b/packages/config/config/devices/0x027a/zac36.json
@@ -316,6 +316,17 @@
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Notification Report: Local Water Leak Sensor Probe Detection",
 			"defaultValue": 1
+		},
+		{
+			"#": "99",
+			"label": "Manual Calibration Offset",
+			"description": "If the valve doesn't fully open after manual calibration, adjust the open angle with an offset.",
+			"valueSize": 1,
+			"unit": "percent",
+			"minValue": 1,
+			"maxValue": 10,
+			"defaultValue": 9,
+			"unsigned": true
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
Added parameter 99 to Zooz ZAC36 (see https://www.support.getzooz.com/kb/article/733-zac36-valve-actuator-advanced-settings/).