### PR TITLE
build: migrate codegen to TS transformers

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@zwave-js/serial": "workspace:*",
     "@zwave-js/shared": "workspace:*",
     "@zwave-js/testing": "workspace:*",
+    "@zwave-js/ts-plugins": "workspace:*",
     "alcalzone-shared": "^4.0.8",
     "ansi-colors": "^4.1.3",
     "chokidar": "^3.5.3",

--- a/packages/ts-plugins/package.json
+++ b/packages/ts-plugins/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@zwave-js/ts-plugins",
+  "version": "11.3.0",
+  "description": "zwave-js: TypeScript plugins",
+  "private": true,
+  "keywords": [],
+  "main": "build/index.js",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json",
+    "./tsc": "./build/index_tsc.js",
+    "./lsp": "./build/index_lsp.js"
+  },
+  "types": "build/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "tsc": [
+        "build/index_tsc.d.ts"
+      ],
+      "lsp": [
+        "build/index_lsp.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "build/**/*.{js,d.ts,map}"
+  ],
+  "author": {
+    "name": "AlCalzone",
+    "email": "d.griesel@gmx.net"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/AlCalzone/node-zwave-js#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AlCalzone/node-zwave-js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/AlCalzone/node-zwave-js/issues"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/AlCalzone/"
+  },
+  "engines": {
+    "node": ">=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
+  },
+  "scripts": {
+    "build": "tsc -b tsconfig.build.json --pretty",
+    "clean": "del-cli build/ \"*.tsbuildinfo\"",
+    "lint:ts": "eslint --ext .ts --rule \"prettier/prettier: off\" \"src/**/*.ts\"",
+    "lint:ts:fix": "yarn run lint:ts --fix",
+    "lint:prettier": "prettier -c \"src/**/*.ts\"",
+    "lint:prettier:fix": "yarn run lint:prettier -w",
+    "//test:ts": "ava",
+    "//test:dirty": "node -r ../../maintenance/esbuild-register.js ../maintenance/src/resolveDirtyTests.ts --run"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^9.0.13",
+    "@types/node": "^14.18.52",
+    "del-cli": "^5.0.0",
+    "esbuild": "0.15.18",
+    "esbuild-register": "^3.4.2",
+    "prettier": "^2.8.8",
+    "typescript": "5.1.6"
+  }
+}

--- a/packages/ts-plugins/src/index.ts
+++ b/packages/ts-plugins/src/index.ts
@@ -1,0 +1,130 @@
+import type tslib from "typescript/lib/tsserverlibrary";
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+function init(modules: { typescript: typeof tslib }) {
+	const ts = modules.typescript;
+
+	function findChildContainingPosition(
+		sourceFile: tslib.SourceFile,
+		position: number,
+	): tslib.Node | undefined {
+		function find(node: tslib.Node): tslib.Node | undefined {
+			const text = sourceFile.text.slice(node.getStart(), node.getEnd());
+			if (position >= node.getStart() && position <= node.getEnd()) {
+				return ts.forEachChild(node, find) || node;
+			}
+		}
+		return find(sourceFile);
+	}
+
+	function create(info: tslib.server.PluginCreateInfo) {
+		// Get a list of things to remove from the completion list from the config object.
+		// If nothing was specified, we'll just remove 'caller'
+		const whatToRemove: string[] = info.config.remove || ["caller"];
+
+		// Diagnostic logging
+		info.project.projectService.logger.info(
+			"I'm getting set up now! Check the log for this message.",
+		);
+
+		// Set up decorator object
+		const proxy: tslib.LanguageService = Object.create(null);
+		for (const k of Object.keys(info.languageService) as Array<
+			keyof tslib.LanguageService
+		>) {
+			const x = info.languageService[k]!;
+			// @ts-expect-error - JS runtime trickery which is tricky to type tersely
+			// prettier-ignore
+			// eslint-disable-next-line @typescript-eslint/ban-types
+			proxy[k] = (...args: Array<{}>) => x.apply(info.languageService, args);
+		}
+
+		// Remove specified entries from completion list
+		proxy.getCompletionsAtPosition = (fileName, position, options) => {
+			const prior = info.languageService.getCompletionsAtPosition(
+				fileName,
+				position,
+				options,
+			);
+			if (!prior) return;
+
+			const program = info.languageService.getProgram();
+			const sourceFile = program?.getSourceFile(fileName);
+			const checker = program?.getTypeChecker();
+
+			if (!sourceFile || !checker) return;
+
+			const node = findChildContainingPosition(sourceFile, position);
+			if (!node) return;
+
+			const siblings = node.parent.getChildren();
+			const index = siblings.indexOf(node);
+			let dot: tslib.Node | undefined;
+			let thing: tslib.Node | undefined;
+			if (
+				index >= 2 &&
+				siblings[index - 1]?.kind === ts.SyntaxKind.DotToken
+			) {
+				dot = siblings[index - 1];
+				thing = siblings[index - 2];
+			} else {
+				return prior;
+			}
+
+			// What is being auto-completed on?
+			const typeOfThing = checker.getTypeAtLocation(thing);
+			const symbolOfThing = typeOfThing.getSymbol();
+
+			const isCCAPIs =
+				symbolOfThing?.name === "CCAPIs" &&
+				symbolOfThing.flags === ts.SymbolFlags.Interface &&
+				symbolOfThing.declarations?.[0].getSourceFile().fileName ===
+					"/home/dominic/Repositories/node-zwave-js/packages/cc/build/lib/API.d.ts";
+
+			// const isZWaveController =
+			// 	symbolOfThing?.name === "ZWaveController" &&
+			// 	symbolOfThing.valueDeclaration?.kind ===
+			// 		ts.SyntaxKind.ClassDeclaration &&
+			// 	symbolOfThing.valueDeclaration.getSourceFile().fileName ===
+			// 		"/home/dominic/Repositories/node-zwave-js/packages/zwave-js/src/lib/controller/Controller.ts";
+
+			if (isCCAPIs) {
+				return {
+					...prior,
+					entries: [
+						...prior.entries,
+						{
+							name: "AAABB",
+							kind: ts.ScriptElementKind.memberVariableElement,
+							kindModifiers:
+								ts.ScriptElementKindModifier.ambientModifier,
+							insertText: `["AAA BB"]`,
+							sortText: "AAA BB",
+							replacementSpan: {
+								start: dot.getStart(),
+								length: position - dot.getStart(),
+							},
+						},
+						{
+							name: "AAACC",
+							kind: ts.ScriptElementKind.memberVariableElement,
+							kindModifiers:
+								ts.ScriptElementKindModifier.ambientModifier,
+							insertText: "AAACC",
+							sortText: "AAACC",
+						},
+					],
+				};
+			} else {
+				return prior;
+			}
+		};
+
+		return proxy;
+	}
+
+	return { create };
+}
+
+/** from given position we find the child node that contains it */
+export = init;

--- a/packages/ts-plugins/tsconfig.build.json
+++ b/packages/ts-plugins/tsconfig.build.json
@@ -1,0 +1,11 @@
+// tsconfig for building - only applies to the src directory
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "build"
+	},
+	"references": [],
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/packages/ts-plugins/tsconfig.json
+++ b/packages/ts-plugins/tsconfig.json
@@ -1,0 +1,8 @@
+// tsconfig for IntelliSense - active in all files in the current package
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {},
+	"references": [],
+	"include": ["src/**/*.ts"],
+	"exclude": ["build/**", "node_modules/**"]
+}

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -123,6 +123,7 @@
     "@xstate/test": "^0.5.1",
     "@zwave-js/maintenance": "workspace:*",
     "@zwave-js/transformers": "workspace:*",
+    "@zwave-js/ts-plugins": "workspace:*",
     "ava": "^4.3.3",
     "del-cli": "^5.0.0",
     "esbuild": "0.15.18",

--- a/packages/zwave-js/tsconfig.build.json
+++ b/packages/zwave-js/tsconfig.build.json
@@ -40,6 +40,9 @@
 		},
 		{
 			"path": "../transformers/tsconfig.build.json"
+		},
+		{
+			"path": "../ts-plugins/tsconfig.build.json"
 		}
 	],
 	"include": ["src/**/*.ts"],

--- a/packages/zwave-js/tsconfig.json
+++ b/packages/zwave-js/tsconfig.json
@@ -9,6 +9,9 @@
 			{
 				"transform": "ts-nameof",
 				"type": "raw"
+			},
+			{
+				"name": "@zwave-js/ts-plugins"
 			}
 		],
 		"typeRoots": [
@@ -47,6 +50,9 @@
 		},
 		{
 			"path": "../transformers"
+		},
+		{
+			"path": "../ts-plugins"
 		}
 	],
 	"include": ["src/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
 	"extends": "@tsconfig/node14/tsconfig.json",
 	"compilerOptions": {
+		"plugins": [
+			{
+				"name": "@zwave-js/ts-plugins"
+			}
+		],
 		"composite": true,
 		"incremental": true,
 		"declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,6 +2012,7 @@ __metadata:
     "@zwave-js/serial": "workspace:*"
     "@zwave-js/shared": "workspace:*"
     "@zwave-js/testing": "workspace:*"
+    "@zwave-js/ts-plugins": "workspace:*"
     alcalzone-shared: ^4.0.8
     ansi-colors: ^4.1.3
     chokidar: ^3.5.3
@@ -2124,6 +2125,20 @@ __metadata:
     fs-extra: ^10.1.0
     prettier: ^2.8.8
     tsutils: ^3.21.0
+    typescript: 5.1.6
+  languageName: unknown
+  linkType: soft
+
+"@zwave-js/ts-plugins@workspace:*, @zwave-js/ts-plugins@workspace:packages/ts-plugins":
+  version: 0.0.0-use.local
+  resolution: "@zwave-js/ts-plugins@workspace:packages/ts-plugins"
+  dependencies:
+    "@types/fs-extra": ^9.0.13
+    "@types/node": ^14.18.52
+    del-cli: ^5.0.0
+    esbuild: 0.15.18
+    esbuild-register: ^3.4.2
+    prettier: ^2.8.8
     typescript: 5.1.6
   languageName: unknown
   linkType: soft
@@ -9121,6 +9136,7 @@ __metadata:
     "@zwave-js/shared": "workspace:*"
     "@zwave-js/testing": "workspace:*"
     "@zwave-js/transformers": "workspace:*"
+    "@zwave-js/ts-plugins": "workspace:*"
     alcalzone-shared: ^4.0.8
     ansi-colors: ^4.1.3
     ava: ^4.3.3


### PR DESCRIPTION
When done, this will allow us to go back to simply invoking TypeScript to build the entire project.

Further reading: https://github.com/nonara/ts-patch/discussions/29