### PR TITLE
feat(config): allow manual entry for LED intensity parameters for Inovelli LZW30

### DIFF
--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -1,247 +1,159 @@
 {
-	"manufacturer": "Inovelli",
-	"manufacturerId": "0x031e",
-	"label": "LZW30",
-	"description": "Black Series On/Off Switch",
-	"devices": [
-		{
-			"productType": "0x0004",
-			"productId": "0x0001"
-		}
-	],
-	"firmwareVersion": {
-		"min": "0.0",
-		"max": "255.255"
-	},
-	"paramInformation": [
-		{
-			"#": "1",
-			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
-		},
-		{
-			"#": "2",
-			"label": "Invert Switch",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disabled",
-					"value": 0
-				},
-				{
-					"label": "Enabled",
-					"value": 1
-				}
-			]
-		},
-		{
-			"#": "3",
-			"label": "Auto Off Timer",
-			"valueSize": 2,
-			"unit": "seconds",
-			"minValue": 0,
-			"maxValue": 32767,
-			"defaultValue": 0
-		},
-		{
-			"#": "4",
-			"label": "Association Behavior",
-			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 15,
-			"defaultValue": 15
-		},
-		{
-			"#": "5",
-			"label": "LED Indicator Color",
-			"description": "Uses a scaled hue value (realHue / 360 * 255).",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 170,
-			"options": [
-				{
-					"label": "Red",
-					"value": 0
-				},
-				{
-					"label": "Orange",
-					"value": 21
-				},
-				{
-					"label": "Yellow",
-					"value": 42
-				},
-				{
-					"label": "Green",
-					"value": 85
-				},
-				{
-					"label": "Cyan",
-					"value": 127
-				},
-				{
-					"label": "Blue",
-					"value": 170
-				},
-				{
-					"label": "Violet",
-					"value": 212
-				},
-				{
-					"label": "Pink",
-					"value": 234
-				},
-				{
-					"$if": "firmwareVersion >= 1.19",
-					"label": "White",
-					"value": 255
-				}
-			]
-		},
-		{
-			"#": "6",
-			"label": "LED Indicator Intensity (When on)",
-			"valueSize": 1,
-			"defaultValue": 5,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "10 %",
-					"value": 1
-				},
-				{
-					"label": "20 %",
-					"value": 2
-				},
-				{
-					"label": "30 %",
-					"value": 3
-				},
-				{
-					"label": "40 %",
-					"value": 4
-				},
-				{
-					"label": "50 %",
-					"value": 5
-				},
-				{
-					"label": "60 %",
-					"value": 6
-				},
-				{
-					"label": "70 %",
-					"value": 7
-				},
-				{
-					"label": "80 %",
-					"value": 8
-				},
-				{
-					"label": "90%",
-					"value": 9
-				},
-				{
-					"label": "100 %",
-					"value": 10
-				}
-			]
-		},
-		{
-			"#": "7",
-			"label": "LED Indicator Intensity (When Off)",
-			"valueSize": 1,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "10 %",
-					"value": 1
-				},
-				{
-					"label": "20 %",
-					"value": 2
-				},
-				{
-					"label": "30 %",
-					"value": 3
-				},
-				{
-					"label": "40 %",
-					"value": 4
-				},
-				{
-					"label": "50 %",
-					"value": 5
-				},
-				{
-					"label": "60 %",
-					"value": 6
-				},
-				{
-					"label": "70 %",
-					"value": 7
-				},
-				{
-					"label": "80 %",
-					"value": 8
-				},
-				{
-					"label": "90 %",
-					"value": 9
-				},
-				{
-					"label": "100 %",
-					"value": 10
-				}
-			]
-		},
-		{
-			"#": "13",
-			"$if": "firmwareVersion >= 1.17",
-			"label": "Special Load Type",
-			"description": "Can be used in certain 3-way dumb switch setups where the load is confusing the switch as to which state it should be in.",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Detect load type",
-					"value": 0
-				},
-				{
-					"label": "Manually set for special load type",
-					"value": 1
-				}
-			]
-		},
-		{
-			"#": "51",
-			"$if": "firmwareVersion >= 1.19",
-			"label": "Instant On",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Enabled (No delay)",
-					"value": 0
-				},
-				{
-					"label": "Disabled (700ms delay)",
-					"value": 1
-				}
-			]
-		}
-	]
+  "manufacturer": "Inovelli",
+  "manufacturerId": "0x031e",
+  "label": "LZW30",
+  "description": "Black Series On/Off Switch",
+  "devices": [
+    {
+      "productType": "0x0004",
+      "productId": "0x0001"
+    }
+  ],
+  "firmwareVersion": {
+    "min": "0.0",
+    "max": "255.255"
+  },
+  "paramInformation": [
+    {
+      "#": "1",
+      "$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
+    },
+    {
+      "#": "2",
+      "label": "Invert Switch",
+      "valueSize": 1,
+      "defaultValue": 0,
+      "allowManualEntry": false,
+      "options": [
+        {
+          "label": "Disabled",
+          "value": 0
+        },
+        {
+          "label": "Enabled",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "#": "3",
+      "label": "Auto Off Timer",
+      "valueSize": 2,
+      "unit": "seconds",
+      "minValue": 0,
+      "maxValue": 32767,
+      "defaultValue": 0
+    },
+    {
+      "#": "4",
+      "label": "Association Behavior",
+      "valueSize": 1,
+      "minValue": 1,
+      "maxValue": 15,
+      "defaultValue": 15
+    },
+    {
+      "#": "5",
+      "label": "LED Indicator Color",
+      "description": "Uses a scaled hue value (realHue / 360 * 255).",
+      "valueSize": 2,
+      "minValue": 0,
+      "maxValue": 255,
+      "defaultValue": 170,
+      "options": [
+        {
+          "label": "Red",
+          "value": 0
+        },
+        {
+          "label": "Orange",
+          "value": 21
+        },
+        {
+          "label": "Yellow",
+          "value": 42
+        },
+        {
+          "label": "Green",
+          "value": 85
+        },
+        {
+          "label": "Cyan",
+          "value": 127
+        },
+        {
+          "label": "Blue",
+          "value": 170
+        },
+        {
+          "label": "Violet",
+          "value": 212
+        },
+        {
+          "label": "Pink",
+          "value": 234
+        },
+        {
+          "$if": "firmwareVersion >= 1.19",
+          "label": "White",
+          "value": 255
+        }
+      ]
+    },
+    {
+      "#": "6",
+      "label": "LED Indicator Intensity (When on)",
+      "valueSize": 1,
+      "defaultValue": 5,
+      "allowManualEntry": true,
+      "minValue": 0,
+      "maxValue": 10
+    },
+    {
+      "#": "7",
+      "label": "LED Indicator Intensity (When Off)",
+      "valueSize": 1,
+      "defaultValue": 1,
+      "allowManualEntry": true,
+      "minValue": 0,
+      "maxValue": 10
+    },
+    {
+      "#": "13",
+      "$if": "firmwareVersion >= 1.17",
+      "label": "Special Load Type",
+      "description": "Can be used in certain 3-way dumb switch setups where the load is confusing the switch as to which state it should be in.",
+      "valueSize": 1,
+      "defaultValue": 0,
+      "allowManualEntry": false,
+      "options": [
+        {
+          "label": "Detect load type",
+          "value": 0
+        },
+        {
+          "label": "Manually set for special load type",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "#": "51",
+      "$if": "firmwareVersion >= 1.19",
+      "label": "Instant On",
+      "valueSize": 1,
+      "defaultValue": 1,
+      "allowManualEntry": false,
+      "options": [
+        {
+          "label": "Enabled (No delay)",
+          "value": 0
+        },
+        {
+          "label": "Disabled (700ms delay)",
+          "value": 1
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the LED intensity parameters for the Inovelli LZW30 switch.
The changes allow manual entry of values between 0 and 10 for parameters 6 and 7, 
providing more granular control over LED brightness. This change aligns with 
Inovelli's documentation and improves consistency across devices.