### PR TITLE
feat(config): add Bulk Set Parameter to Inovelli Switches for LED Notifications

### DIFF
--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -17,7 +17,7 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "templates/inovelli_templates.json#state_after_power_failure_prev_on_off"
 		},
 		{
 			"#": "2",
@@ -208,83 +208,8 @@
 			]
 		},
 		{
-			"#": "9",
-			"label": "LED Strip Timeout",
-			"valueSize": 1,
-			"unit": "seconds",
-			"minValue": 0,
-			"maxValue": 10,
-			"defaultValue": 0,
-			"options": [
-				{
-					"label": "Stay off",
-					"value": 0
-				}
-			]
-		},
-		{
-			"#": "10",
-			"label": "Active Power Reports",
-			"valueSize": 1,
-			"unit": "%",
-			"minValue": 0,
-			"maxValue": 100,
-			"defaultValue": 10
-		},
-		{
-			"#": "11",
-			"label": "Periodic Power & Energy Reports",
-			"valueSize": 2,
-			"unit": "seconds",
-			"minValue": 0,
-			"maxValue": 32767,
-			"defaultValue": 3600
-		},
-		{
-			"#": "12",
-			"label": "Energy Reports",
-			"valueSize": 1,
-			"unit": "%",
-			"minValue": 0,
-			"maxValue": 100,
-			"defaultValue": 10
-		},
-		{
-			"#": "13",
-			"$if": "firmwareVersion >= 1.17",
-			"label": "Load Type",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Automatically detect load type",
-					"value": 0
-				},
-				{
-					"label": "Manually set for special load type",
-					"value": 1
-				}
-			]
-		},
-		{
-			"#": "51",
-			"$if": "firmwareVersion >= 1.19",
-			"label": "Instant On",
-			"description": "Enabling this disables the 700ms button delay and multi-tap scenes.",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Enabled",
-					"value": 0
-				},
-				{
-					"label": "Disabled",
-					"value": 1
-				}
-			]
+			"#": "8",
+			"$import": "templates/inovelli_templates.json#bulk_set_led_effect"
 		},
 		{
 			"#": "8[0xff]",
@@ -419,6 +344,85 @@
 				{
 					"label": "Pulse",
 					"value": 4
+				}
+			]
+		},
+		{
+			"#": "9",
+			"label": "LED Strip Timeout",
+			"valueSize": 1,
+			"unit": "seconds",
+			"minValue": 0,
+			"maxValue": 10,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Stay off",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "10",
+			"label": "Active Power Reports",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 10
+		},
+		{
+			"#": "11",
+			"label": "Periodic Power & Energy Reports",
+			"valueSize": 2,
+			"unit": "seconds",
+			"minValue": 0,
+			"maxValue": 32767,
+			"defaultValue": 3600
+		},
+		{
+			"#": "12",
+			"label": "Energy Reports",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 10
+		},
+		{
+			"#": "13",
+			"$if": "firmwareVersion >= 1.17",
+			"label": "Load Type",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Automatically detect load type",
+					"value": 0
+				},
+				{
+					"label": "Manually set for special load type",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "51",
+			"$if": "firmwareVersion >= 1.19",
+			"label": "Instant On",
+			"description": "Enabling this disables the 700ms button delay and multi-tap scenes.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enabled",
+					"value": 0
+				},
+				{
+					"label": "Disabled",
+					"value": 1
 				}
 			]
 		}

--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -17,7 +17,7 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"$import": "templates/inovelli_templates.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		{
 			"#": "2",

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -377,12 +377,14 @@
 			"defaultValue": 1
 		},
 		{
+			"#": "16",
+			"$import": "templates/inovelli_templates.json#bulk_set_led_effect"
+		},
+		{
 			"#": "16[0xff]",
 			"$import": "#paramInformation/13",
 			"label": "LED Indicator: Effect Color",
 			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 255,
 			"defaultValue": 0,
 			"unsigned": true,
 			"options": [

--- a/packages/config/config/devices/0x031e/lzw36.json
+++ b/packages/config/config/devices/0x031e/lzw36.json
@@ -595,48 +595,53 @@
 			]
 		},
 		{
-			"#": "24[0x7f000000]",
-			"label": "Light LED Effect Type",
-			"valueSize": 4,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "Solid",
-					"value": 1
-				},
-				{
-					"label": "Chase",
-					"value": 2
-				},
-				{
-					"label": "Fast blink",
-					"value": 3
-				},
-				{
-					"label": "Slow blink",
-					"value": 4
-				},
-				{
-					"label": "Pulse",
-					"value": 5
-				}
-			]
+			"#": "24",
+			"$import": "templates/inovelli_templates.json#bulk_set_led_effect",
+			"label": "Bulk Set Light LED Effect"
 		},
 		{
-			"#": "24[0xff0000]",
-			"label": "Light LED Effect Duration",
-			"description": "0 = disabled, 1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
+			"#": "24[0xff]",
+			"label": "Light LED Effect Color",
+			"description": "Uses a scaled hue value (realHue / 360 * 255).",
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255,
-			"unsigned": true
+			"defaultValue": 0,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Red",
+					"value": 0
+				},
+				{
+					"label": "Orange",
+					"value": 21
+				},
+				{
+					"label": "Yellow",
+					"value": 42
+				},
+				{
+					"label": "Green",
+					"value": 85
+				},
+				{
+					"label": "Cyan",
+					"value": 127
+				},
+				{
+					"label": "Blue",
+					"value": 170
+				},
+				{
+					"label": "Violet",
+					"value": 212
+				},
+				{
+					"label": "Pink",
+					"value": 234
+				}
+			]
 		},
 		{
 			"#": "24[0xff00]",
@@ -693,52 +698,18 @@
 			]
 		},
 		{
-			"#": "24[0xff]",
-			"label": "Light LED Effect Color",
-			"description": "Uses a scaled hue value (realHue / 360 * 255).",
+			"#": "24[0xff0000]",
+			"label": "Light LED Effect Duration",
+			"description": "0 = disabled, 1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"options": [
-				{
-					"label": "Red",
-					"value": 0
-				},
-				{
-					"label": "Orange",
-					"value": 21
-				},
-				{
-					"label": "Yellow",
-					"value": 42
-				},
-				{
-					"label": "Green",
-					"value": 85
-				},
-				{
-					"label": "Cyan",
-					"value": 127
-				},
-				{
-					"label": "Blue",
-					"value": 170
-				},
-				{
-					"label": "Violet",
-					"value": 212
-				},
-				{
-					"label": "Pink",
-					"value": 234
-				}
-			]
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
-			"#": "25[0x7f000000]",
-			"label": "Fan LED Effect Type",
+			"#": "24[0x7f000000]",
+			"label": "Light LED Effect Type",
 			"valueSize": 4,
 			"defaultValue": 0,
 			"unsigned": true,
@@ -771,112 +742,29 @@
 			]
 		},
 		{
-			"#": "25[0xff0000]",
-			"label": "Fan LED Effect Duration",
-			"description": "0 = disabled, 1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 255,
-			"unsigned": true
-		},
-		{
-			"#": "25[0xff00]",
-			"label": "Fan LED Effect Brightness",
-			"valueSize": 4,
-			"defaultValue": 3,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "10%",
-					"value": 1
-				},
-				{
-					"label": "20%",
-					"value": 2
-				},
-				{
-					"label": "30%",
-					"value": 3
-				},
-				{
-					"label": "40%",
-					"value": 4
-				},
-				{
-					"label": "50%",
-					"value": 5
-				},
-				{
-					"label": "60%",
-					"value": 6
-				},
-				{
-					"label": "70%",
-					"value": 7
-				},
-				{
-					"label": "80%",
-					"value": 8
-				},
-				{
-					"label": "90%",
-					"value": 9
-				},
-				{
-					"label": "100%",
-					"value": 10
-				}
-			]
+			"#": "25",
+			"$import": "templates/inovelli_templates.json#bulk_set_led_effect",
+			"label": "Bulk Set Fan LED Effect"
 		},
 		{
 			"#": "25[0xff]",
 			"label": "Fan LED Effect Color",
-			"description": "Uses a scaled hue value (realHue / 360 * 255).",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"options": [
-				{
-					"label": "Red",
-					"value": 0
-				},
-				{
-					"label": "Orange",
-					"value": 21
-				},
-				{
-					"label": "Yellow",
-					"value": 42
-				},
-				{
-					"label": "Green",
-					"value": 85
-				},
-				{
-					"label": "Cyan",
-					"value": 127
-				},
-				{
-					"label": "Blue",
-					"value": 170
-				},
-				{
-					"label": "Violet",
-					"value": 212
-				},
-				{
-					"label": "Pink",
-					"value": 234
-				}
-			]
+			"$import": "#paramInformation/24[0xff]"
+		},
+		{
+			"#": "25[0xff00]",
+			"label": "Fan LED Effect Brightness",
+			"$import": "#paramInformation/24[0xff00]"
+		},
+		{
+			"#": "25[0xff0000]",
+			"label": "Fan LED Effect Duration",
+			"$import": "#paramInformation/24[0xff0000]"
+		},
+		{
+			"#": "25[0x7f000000]",
+			"label": "Fan LED Effect Type",
+			"$import": "#paramInformation/24[0x7f000000]"
 		},
 		{
 			"#": "26",

--- a/packages/config/config/devices/0x031e/lzw36.json
+++ b/packages/config/config/devices/0x031e/lzw36.json
@@ -748,23 +748,23 @@
 		},
 		{
 			"#": "25[0xff]",
-			"label": "Fan LED Effect Color",
-			"$import": "#paramInformation/24[0xff]"
+			"$import": "#paramInformation/24[0xff]",
+			"label": "Fan LED Effect Color"
 		},
 		{
 			"#": "25[0xff00]",
-			"label": "Fan LED Effect Brightness",
-			"$import": "#paramInformation/24[0xff00]"
+			"$import": "#paramInformation/24[0xff00]",
+			"label": "Fan LED Effect Brightness"
 		},
 		{
 			"#": "25[0xff0000]",
-			"label": "Fan LED Effect Duration",
-			"$import": "#paramInformation/24[0xff0000]"
+			"$import": "#paramInformation/24[0xff0000]",
+			"label": "Fan LED Effect Duration"
 		},
 		{
 			"#": "25[0x7f000000]",
-			"label": "Fan LED Effect Type",
-			"$import": "#paramInformation/24[0x7f000000]"
+			"$import": "#paramInformation/24[0x7f000000]",
+			"label": "Fan LED Effect Type"
 		},
 		{
 			"#": "26",

--- a/packages/config/config/devices/0x031e/templates/inovelli_templates.json
+++ b/packages/config/config/devices/0x031e/templates/inovelli_templates.json
@@ -395,7 +395,7 @@
 		"label": "Bulk Set LED Effect",
 		"valueSize": 4,
 		"minValue": 0,
-		"maxValue": 4294967296,
+		"maxValue": 4294967295,
 		"defaultValue": 0,
 		"description": "Set the LED Effect using the sum of each individual effect parameter (color + (brightness * 256) + (duration * 65536) + (effect * 16777216))",
 		"unsigned": true

--- a/packages/config/config/devices/0x031e/templates/inovelli_templates.json
+++ b/packages/config/config/devices/0x031e/templates/inovelli_templates.json
@@ -398,6 +398,7 @@
 		"maxValue": 4294967295,
 		"defaultValue": 0,
 		"description": "Set the LED Effect using the sum of each individual effect parameter (color + (brightness * 256) + (duration * 65536) + (effect * 16777216))",
-		"unsigned": true
+		"unsigned": true,
+		"lintSkip": ["duplicatedPartials"]
 	}
 }

--- a/packages/config/config/devices/0x031e/templates/inovelli_templates.json
+++ b/packages/config/config/devices/0x031e/templates/inovelli_templates.json
@@ -390,5 +390,14 @@
 				"value": 255
 			}
 		]
+	},
+	"bulk_set_led_effect": {
+		"label": "Bulk Set LED Effect",
+		"valueSize": 4,
+		"minValue": 0,
+		"maxValue": 4294967296,
+		"defaultValue": 0,
+		"description": "Set the LED Effect using the sum of each individual effect parameter (color + (brightness * 256) + (duration * 65536) + (effect * 16777216))",
+		"unsigned": true
 	}
 }

--- a/packages/config/config/devices/0x031e/vzw31-sn.json
+++ b/packages/config/config/devices/0x031e/vzw31-sn.json
@@ -590,6 +590,11 @@
 			"label": "Default All LED Strip Brightness When Off"
 		},
 		{
+			"#": "99",
+			"$import": "templates/inovelli_templates.json#bulk_set_led_effect",
+			"label": "Bulk Set LED Strip Effect"
+		},
+		{
 			"#": "99[0xff]",
 			"$import": "templates/inovelli_templates.json#led_effect_duration",
 			"label": "All LED Strip Effect - Duration"

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -1048,7 +1048,15 @@ Consider converting this parameter to unsigned using ${
 	// Check if there are partial parameters and non-partials with the same number
 	const duplicatedPartials = distinct(
 		partialParams.map(([key]) => key.parameter),
-	).filter((parameter) => paramInformation.has({ parameter }));
+	).filter((parameter) => {
+		// Check if any parameter has the lintSkip flag for duplicatedPartials
+		const param = paramInformation.get({ parameter });
+		if (param?.lintSkip?.includes("duplicatedPartials")) {
+			return false;
+		}
+		return paramInformation.has({ parameter });
+	});
+	
 	if (duplicatedPartials.length) {
 		addError(
 			file,

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -1055,13 +1055,13 @@ Consider converting this parameter to unsigned using ${
 			addWarning(
 				file,
 				`Skipping "duplicatedPartials" lint check for parameter #${parameter} due to "lintSkip" configuration.`,
-				variant
-			);			
+				variant,
+			);
 			return false;
 		}
 		return paramInformation.has({ parameter });
 	});
-	
+
 	if (duplicatedPartials.length) {
 		addError(
 			file,

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -1052,6 +1052,11 @@ Consider converting this parameter to unsigned using ${
 		// Check if any parameter has the lintSkip flag for duplicatedPartials
 		const param = paramInformation.get({ parameter });
 		if (param?.lintSkip?.includes("duplicatedPartials")) {
+			addWarning(
+				file,
+				`Skipping "duplicatedPartials" lint check for parameter #${parameter} due to "lintSkip" configuration.`,
+				variant
+			);			
 			return false;
 		}
 		return paramInformation.has({ parameter });

--- a/packages/config/src/devices/ParamInformation.ts
+++ b/packages/config/src/devices/ParamInformation.ts
@@ -165,6 +165,18 @@ Parameter #${parameterNumber}: allowManualEntry must be false or omitted!`,
 			?? (this.readOnly ? false : true);
 
 		if (
+			definition.lintSkip != undefined
+			&& (!isArray(definition.lintSkip) || !definition.lintSkip.every((rule: unknown) => typeof rule === "string"))
+		) {
+			throwInvalidConfig(
+				"devices",
+				`packages/config/config/devices/${parent.filename}:
+Parameter #${parameterNumber} has an invalid lintSkip property. It must be an array of strings.`,
+			);
+		}
+		this.lintSkip = definition.lintSkip ?? [];
+
+		if (
 			isArray(definition.options)
 			&& !definition.options.every(
 				(opt: unknown) =>
@@ -200,6 +212,7 @@ Parameter #${parameterNumber}: options is malformed!`,
 	public readonly readOnly?: true;
 	public readonly writeOnly?: true;
 	public readonly allowManualEntry: boolean;
+	public readonly lintSkip?: string[];
 	public readonly options: readonly ConditionalConfigOption[];
 
 	public readonly condition?: string;
@@ -224,6 +237,7 @@ Parameter #${parameterNumber}: options is malformed!`,
 				"readOnly",
 				"writeOnly",
 				"allowManualEntry",
+				"lintSkip",
 			]),
 			options: evaluateDeep(this.options, deviceId, true),
 		};

--- a/packages/config/src/devices/ParamInformation.ts
+++ b/packages/config/src/devices/ParamInformation.ts
@@ -166,7 +166,10 @@ Parameter #${parameterNumber}: allowManualEntry must be false or omitted!`,
 
 		if (
 			definition.lintSkip != undefined
-			&& (!isArray(definition.lintSkip) || !definition.lintSkip.every((rule: unknown) => typeof rule === "string"))
+			&& (!isArray(definition.lintSkip)
+				|| !definition.lintSkip.every((rule: unknown) =>
+					typeof rule === "string"
+				))
 		) {
 			throwInvalidConfig(
 				"devices",


### PR DESCRIPTION
This adds a new parameter to Inovelli's LZW30-SN, LZW31-SN, LZW36, and VZW31-SN devices to allow setting the LED notification/event in one parameter instead of multiple. The use case here would be easier multicast event commands that have just a calculated value for the notification/effect (ex. [site for calculating this value](https://inovelliusa.github.io/inovelli-switch-toolbox/))

I was unaware that there was a hard rule on allowing partial parameters and "parent" parameters for the same config. I do believe there are some use cases where they can coexist (I've been running this setup for over a year now without issue). If that is not within the scope of this project I understand! For sake of this PR I added a new `lintSkip` config field that allows skipping a specific lint check for a given parameter.