### PR TITLE
feat(config): improve multi-level sensor reporting for Remotec ZXT-800

### DIFF
--- a/packages/config/config/devices/0x5254/zxt-800.json
+++ b/packages/config/config/devices/0x5254/zxt-800.json
@@ -234,5 +234,29 @@
 		"exclusion": "Refer to your primary controller to enter into the Inclusion Mode or Exclusion Mode\nOnce the primary controller is ready to include/exclude the device, press the “PROG” button once",
 		"reset": "Please use this procedure only when the network primary controller is missing or otherwise inoperable\nPress and keep holding “PROG” button not less than 10 seconds:\nLED will light up at first 5 seconds, LED flashes twice then stay off after reset process completed",
 		"manual": "https://remotec.com.hk/wp-content/uploads/2023/07/ZXT-800_USER_MANUAL_V1.0.pdf"
-	}
+	},
+	"compat": [
+		{
+			"$if": "productId === 0x8493",
+			// This device exposes the Multilevel Sensor on endpoint 1 (root endpoint is 0)
+			"preserveEndpoints": "*",
+			"mapRootReportsToEndpoint": 1,
+			"overrideQueries": {
+				"Multilevel Sensor": [
+					{
+						// This device is reporting "Absolute humidity" (0x01) as the supported scale.
+						// This is an off-by-one error. "Percentage" (0x00) is the correct scale.
+						// "5" is the humidity scale, see packages/core/src/registries/Sensors.ts
+						"endpoint": 1,
+						"method": "getSupportedScales",
+						"matchArgs": [5],
+						"result": [0],
+						"persistValues": {
+							"supportedScales(5)": [0]
+						}
+					}
+				]
+			}
+		}
+	]
 }


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

Improvements for newer Remotec ZXT-800 (BW8493) devices.

Originally reported in the discussions thread: https://github.com/zwave-js/zwave-js/discussions/7532.

### Issue 1: Unsolicited air temperature updates are ignored

Adding the following to `compat` helped:

```json
"preserveEndpoints": "*",
"mapRootReportsToEndpoint": 1,
```

My understanding:

- By default, zwave-js hides all non-root endpoints. `"preserveEndpoints": "*"` tells zwave-js to keep all endpoints accessible.
- By default, zwave-js silently drops any reports received on the root (endpoint 0) if other endpoints exist. `"mapRootReportsToEndpoint": 1` tells zwave-js to treat reports sent to the root as if they are coming from endpoint 1, which is where the multi-level sensors live.


### Issue 2: Missing humidity sensor

Adding the following to `compat` helped:

```json
"overrideQueries": {
  "Multilevel Sensor": [
    {
      "endpoint": 1,
      "method": "getSupportedScales",
      "matchArgs": [5],
      "result": [0],
      "persistValues": {
        "supportedScales(5)": [0]
      }
    }
  ]
}
```

My understanding:

- The device reports humidity as a percentage scale, "Relative humidity" (`0x00`).
- When calling `getSupportedScales` on the humidity sensor, it incorrectly returned "Absolute humidity" (`0x01`).
- When zwave-js issues a "get" using scale `0x01`, the device returns no value (or an error response?). Zwave-js ignores it, and, therefore, the humidity sensor is never registered.
- `overrideQueries` overrides `getSupportedScales` to return `0x00` instead of `0x01`.


### Testing

Using Z-Wave JS UI in Home Assistant, I added `store/config/zxt-800.json` with the above changes. After re-interviewing the device, the humidity sensor appeared, and Home Assistant started recording unsolicited air temperature ~~and humidity~~ updates❗😄  

Please let me know if I missed anything, or my conclusions are incorrect or misguided. Thanks.