### PR TITLE
fix: force Scene Activation CC as supported on FGD-212

### DIFF
--- a/packages/config/config/devices/0x010f/fgd212.json
+++ b/packages/config/config/devices/0x010f/fgd212.json
@@ -768,5 +768,15 @@
 	"metadata": {
 		"$import": "templates/fibaro_template.json#default_metadata",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2836/FGD-212-EN-T-v1.3.pdf"
+	},
+	"compat": {
+		"commandClasses": {
+			"add": {
+				"Scene Activation": {
+					"isControlled": true,
+					"version": 1
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
https://github.com/zwave-js/zwave-js/pull/1848 was not effectively superseded by #1849. Using compat flag properly advertises "Scene Activation v1" in node's supported CC. Successfully tested with FGD-212 both firmware 3.4 and 3.5.
