### PR TITLE
feat: implement proprietary Z-Wave.Me SAPI commands

### DIFF
--- a/packages/zwave-js/src/lib/controller/Proprietary.ts
+++ b/packages/zwave-js/src/lib/controller/Proprietary.ts
@@ -4,9 +4,11 @@ import type { Message } from "@zwave-js/serial";
 import type { Driver } from "../driver/Driver.js";
 import type { ZWaveController } from "./Controller.js";
 import { ControllerProprietary_NabuCasa } from "./proprietary/NabuCasa.js";
+import { ControllerProprietary_ZWaveMeUZB1 } from "./proprietary/ZWaveMeUZB1.js";
 
 export interface ControllerProprietary {
 	"Nabu Casa"?: ControllerProprietary_NabuCasa;
+	"Z-Wave.me UZB1"?: ControllerProprietary_ZWaveMeUZB1;
 }
 
 export function getControllerProprietary(
@@ -24,6 +26,21 @@ export function getControllerProprietary(
 			"Nabu Casa": new ControllerProprietary_NabuCasa(driver, controller),
 		};
 	}
+
+	// Z-Wave.me UZB1
+	if (
+		controller.manufacturerId === 0x0115
+		&& controller.productType === 0x0000
+		&& controller.productId === 0x0000
+	) {
+		return {
+			"Z-Wave.me UZB1": new ControllerProprietary_ZWaveMeUZB1(
+				driver,
+				controller,
+			),
+		};
+	}
+
 	return {};
 }
 

--- a/packages/zwave-js/src/lib/controller/proprietary/ZWaveMeUZB1.ts
+++ b/packages/zwave-js/src/lib/controller/proprietary/ZWaveMeUZB1.ts
@@ -1,0 +1,101 @@
+import {
+	MessagePriority,
+	RFRegion,
+	type TranslatedValueID,
+	type ValueID,
+} from "@zwave-js/core";
+import { FunctionType, Message, MessageType } from "@zwave-js/serial";
+import { Bytes } from "@zwave-js/shared";
+import type { Driver } from "../../driver/Driver.js";
+import type { ZWaveController } from "../Controller.js";
+import type { ControllerProprietaryCommon } from "../Proprietary.js";
+
+export const FUNC_ID_ZME_SET_REGION = FunctionType.Proprietary_F2;
+
+/**
+ * Mapping from standard RFRegion enum to Z-Wave.me UZB1 frequency bytes
+ * Based on Z-Wave.me UZB1 documentation
+ */
+const UZB1_FREQUENCY_MAPPING = new Map<RFRegion, number>([
+	[RFRegion.Europe, 0x00],
+	[RFRegion.Russia, 0x01],
+	[RFRegion.India, 0x02],
+	[RFRegion.USA, 0x03],
+	[RFRegion["Australia/New Zealand"], 0x04],
+	[RFRegion["Hong Kong"], 0x05],
+	[RFRegion.Japan, 0x07],
+	[RFRegion.Korea, 0x08],
+	[RFRegion.Israel, 0x09],
+]);
+
+/**
+ * Proprietary controller implementation for Z-Wave.me UZB1
+ */
+export class ControllerProprietary_ZWaveMeUZB1
+	implements ControllerProprietaryCommon
+{
+	public constructor(
+		private readonly driver: Driver,
+		private readonly controller: ZWaveController,
+	) {}
+
+	public async interview(): Promise<void> {
+		// Nothing to do
+	}
+
+	public getDefinedValueIDs(): TranslatedValueID[] {
+		// None
+		return [];
+	}
+
+	public pollValue(_valueId: ValueID): Promise<unknown> {
+		throw new Error("Polling values is not supported for Z-Wave.me UZB1");
+	}
+
+	public setValue(_valueId: ValueID, _value: unknown): Promise<any> {
+		throw new Error("Setting values is not supported for Z-Wave.me UZB1");
+	}
+
+	public handleUnsolicited(_msg: Message): Promise<boolean> {
+		// Nothing to handle
+		return Promise.resolve(false);
+	}
+
+	public async setRFRegion(region: RFRegion): Promise<boolean> {
+		const frequencyByte = UZB1_FREQUENCY_MAPPING.get(region);
+		if (frequencyByte == undefined) {
+			throw new Error(
+				`RF region ${
+					RFRegion[region]
+				} (${region}) is not supported by Z-Wave.me UZB1`,
+			);
+		}
+
+		// Create the proprietary command message directly following NabuCasa pattern
+		const setRFRegionCmd = new Message({
+			type: MessageType.Request,
+			functionType: FUNC_ID_ZME_SET_REGION,
+			payload: Bytes.from([frequencyByte]),
+			// UZB1 command is fire-and-forget (does not expect a response)
+		});
+
+		try {
+			await this.driver.sendMessage(
+				setRFRegionCmd,
+				{
+					priority: MessagePriority.Controller,
+					supportCheck: true,
+				},
+			);
+			return true;
+		} catch (error) {
+			this.driver.controllerLog.print(
+				`Error setting RF region to ${RFRegion[region]}: ${
+					String(error)
+				}`,
+				"error",
+			);
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
TODO: Decide how to call the proprietary API
TODO: Add support for 700 series hardware --> https://z-wave.me/support/serial-api-commands/
TODO: Decide whether this should be integrated with the standard setRFRegion functionality

fixes: https://github.com/zwave-js/zwave-js/issues/3803