### PR TITLE
fix(config): missing and invalid partial config parameters for Aeotec Water Sensors

### DIFF
--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -3226,6 +3226,11 @@
 		"label": "LED Indicator: Open/Close Change",
 		"defaultValue": 1
 	},
+	"led_indicator_water_leak": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "LED Indicator: Water Leak",
+		"defaultValue": 1
+	},
 	"led_indicator_wake": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "LED Indicator: Wake Up",

--- a/packages/config/config/devices/0x0371/zwa018.json
+++ b/packages/config/config/devices/0x0371/zwa018.json
@@ -38,12 +38,17 @@
 	},
 	"paramInformation": [
 		{
-			"#": "3[0x04]",
+			"#": "3[0x01]",
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_water_leak"
+		},
+		{
+			"#": "3[0x02]",
 			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_wake"
 		},
 		{
-			"#": "3[0x10]",
-			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper"
+			"#": "3[0x04]",
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper",
+			"defaultValue": 1
 		},
 		{
 			"#": "4",

--- a/packages/config/config/devices/0x0371/zwa019.json
+++ b/packages/config/config/devices/0x0371/zwa019.json
@@ -40,12 +40,17 @@
 	},
 	"paramInformation": [
 		{
-			"#": "3[0x04]",
+			"#": "3[0x01]",
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_water_leak"
+		},
+		{
+			"#": "3[0x02]",
 			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_wake"
 		},
 		{
-			"#": "3[0x10]",
-			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper"
+			"#": "3[0x04]",
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper",
+			"defaultValue": 1
 		},
 		{
 			"#": "4",


### PR DESCRIPTION
###  Turn off LED indicator on water leakage detection
I was not able to turn off the LED indicator for water leak detection on an Aeotec Water Sensor 7 (ZWA018) exclusively because the '0x01' hex value was not included the device's config file as partial parameter.

### Turn off sleep/wake up and tamper LED
However the LED can be turned of entirely for all events setting the configuration parameter (3) value to 0 but the sleep/awake and tamper led indicators neither could be turned off separately due to invalid bitmaps presented in device's config.

I am not sure if the partial parameter keys were changed by a recent firmware update but the manufacturer's documentation I found already included the keys I added to the config.

[ZWA018 docs](https://manual.zwave.eu/backend/make.php?lang=en&sku=AEOEZWA018&cert=&type=mini#:~:text=Parameter%203%3A%20Visual%20LED%20Indications)
[ZWA019 docs](https://manual.zwave.eu/backend/make.php?lang=en&sku=AEOEZWA019&cert=&type=mini#:~:text=Parameter%203%3A%20Visual%20LED%20Indications)

> Parameter 3: Visual LED Indications
> This parameter defines when LEDs will indicate events. Disabling all indications may extend battery life. 
> Value 0 means - No Indications.
> Size: 1 Byte, Default Value: 7 (values 1 + 2 + 4 summarized)
> 
> Setting	Description
> 1	Water Leakage Status Change
> 2	Wake Up
> 4	Device Tampering

#### Water Leak LED in Manufacturer config
Additionally I added a new value to the Aeotec manufacturer config json to have a standard labeling of water leak detection LED indicator states.

### Devices used for testing
Please note that this was tested on a ZWA018 (fw version 2.3) but but I also updated the similar Pro version's config (ZWA019) according to it's documentation.

[inclusion_zwa018.log](https://github.com/user-attachments/files/21204217/inclusion_zwa018.log)

