### PR TITLE
feat(device): add productType and productCode for ASSA ABLOY version of Yale YRC-226

### DIFF
--- a/packages/config/config/devices/0x0129/yrc_yrd_226_246_256_446-zw2.json
+++ b/packages/config/config/devices/0x0129/yrc_yrd_226_246_256_446-zw2.json
@@ -16,6 +16,10 @@
 		{
 			"productType": "0x8002",
 			"productId": "0x4600"
+		},
+		{
+			"productType": "0x8109",
+			"productId": "0x0dc2"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
…26, etc.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

PR description here

Adding productType and productCode for ASSA ABLOY version of Yale YRC-226, etc