### PR TITLE
fix(config): persist CC 43 for 3 Fibaro devices

### DIFF
--- a/packages/config/config/devices/0x010f/fgbs001.json
+++ b/packages/config/config/devices/0x010f/fgbs001.json
@@ -319,6 +319,11 @@
 				"Alarm Sensor": {
 					"endpoints": "*"
 				}
+			},
+			"add": {
+				"Scene Activation": {
+					"isControlled": true
+				}
 			}
 		}
 	}

--- a/packages/config/config/devices/0x010f/fgd212.json
+++ b/packages/config/config/devices/0x010f/fgd212.json
@@ -765,6 +765,15 @@
 			"defaultValue": 0
 		}
 	],
+	"compat": {
+		"commandClasses": {
+			"add": {
+				"Scene Activation": {
+					"isControlled": true
+				}
+			}
+		}
+	},
 	"metadata": {
 		"$import": "templates/fibaro_template.json#default_metadata",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2836/FGD-212-EN-T-v1.3.pdf"

--- a/packages/config/config/devices/0x010f/fgr222_24.24_255.255.json
+++ b/packages/config/config/devices/0x010f/fgr222_24.24_255.255.json
@@ -365,5 +365,14 @@
 				}
 			]
 		}
-	]
+	],
+	"compat": {
+		"commandClasses": {
+			"add": {
+				"Scene Activation": {
+					"isControlled": true
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Persist the Scene Activation CC (43) for fgd212, fgbs001, fgr222_24.24_255.255 to be able to control using ZUI and the OH websocket binding.  Closes #7983 and #7546, Supersedes #7848.

Comment: I have an Aeotec, GE and Zooz device where CC 43 is shown in ZUI, so it is not some global rule. EDIT: Some food for thought.  All these devices that show CC43 in my ZUI have the V1 CC. I do not have the problem devices, but from the opensmarthouse DB, all the problem devices show V0 CC. Maybe there is some global fix if the CC 43 is V0. Maybe V0 just means it isn't specified?

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->