### PR TITLE
feat(config): add Nexa ZPR-111 parameters

### DIFF
--- a/packages/config/config/devices/0x0268/zpr111.json
+++ b/packages/config/config/devices/0x0268/zpr111.json
@@ -13,6 +13,82 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
+		},
+		{
+			"#": "2",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Button",
+			"defaultValue": 1
+		},
+		{
+			"#": "3",
+			"$import": "~/templates/master_template.json#enable_led_indicator",
+			"defaultValue": 1
+		},
+		{
+			"#": "4",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Auto-Off"
+		},
+		{
+			"#": "5",
+			"label": "Auto-Off Delay",
+			"description": "Delay time after the plug is switched off",
+			"valueSize": 2,
+			"unit": "minutes",
+			"minValue": 0,
+			"maxValue": 32767,
+			"defaultValue": 120
+		},
+		{
+			"#": "6",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Meter Reports"
+		},
+		{
+			"#": "7",
+			"label": "Meter Report Interval",
+			"valueSize": 2,
+			"unit": "seconds",
+			"minValue": 30,
+			"maxValue": 32767,
+			"defaultValue": 300
+		},
+		{
+			"#": "8",
+			"label": "Overcurrent Protection Threshold",
+			"description": "Threshold at which the plug enters overcurrent protection mode",
+			"valueSize": 1,
+			"unit": "A",
+			"minValue": 1,
+			"maxValue": 16,
+			"defaultValue": 11
+		},
+		{
+			"#": "9",
+			"label": "Current Report Threshold",
+			"description": "Change in current consumption that triggers a report",
+			"valueSize": 2,
+			"unit": "0.01 A",
+			"minValue": 1,
+			"maxValue": 1600,
+			"defaultValue": 50
+		},
+		{
+			"#": "10",
+			"label": "Overcurrent Alarm Threshold",
+			"description": "Threshold at which the plug sends an overcurrent notification",
+			"valueSize": 1,
+			"unit": "A",
+			"minValue": 1,
+			"maxValue": 16,
+			"defaultValue": 10
+		}
+	],
 	"metadata": {
 		"comments": {
 			"level": "warning",

--- a/packages/config/config/devices/0x0268/zpr111.json
+++ b/packages/config/config/devices/0x0268/zpr111.json
@@ -36,6 +36,7 @@
 		},
 		{
 			"#": "5",
+			"$purpose": "timer.auto_off",
 			"label": "Auto-Off Delay",
 			"description": "Delay time after the plug is switched off",
 			"valueSize": 2,
@@ -60,6 +61,7 @@
 		},
 		{
 			"#": "8",
+			"$purpose": "overload_protection.threshold",
 			"label": "Overcurrent Protection Threshold",
 			"description": "Threshold at which the plug enters overcurrent protection mode",
 			"valueSize": 1,
@@ -70,6 +72,7 @@
 		},
 		{
 			"#": "9",
+			"$purpose": "reporting_threshold.current",
 			"label": "Current Report Threshold",
 			"description": "Change in current consumption that triggers a report",
 			"valueSize": 2,


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

Adding parameters for Nexa ZPR-111 smart switch. Note that Nexa have published a configuration file on their webpage, but it is incorrect (as of Dec 13th, 2025). [Nexa ZPR-111](https://nexa.se/smarta-hem/z-wave/zpr-111-2)

The correct parameters are the same as 0x0258/nas-wr01ze. However, since Nexa specifies that ZPR-111 can only handle 2300 W, I have set the default values for power cut-off at 11A and alarm at 10A, just to be sure.

ZPR-111 only reports voltage when the relay is on (reports 0 Volt when the relay is off). I guess that is a feature...
