### PR TITLE
feat(config): update parameters for Zooz ZEN7x line

### DIFF
--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -1145,5 +1145,57 @@
 		"inclusion": "Tap up 3 times quickly. The LED indicator will blink green. It will turn green for 2 seconds if inclusion is successful or turn red for 2 seconds if the pairing attempt fails.",
 		"exclusion": "Click the Z-Wave button 3 times quickly. The LED indicator will start blinking green. It will turn green for 2 seconds when exclusion is successful.",
 		"reset": "Click the Z-Wave button twice and hold it for 15 seconds. The LED indicator will flash during the process and turn red for 3 seconds to confirm successful reset."
+	},
+	"custom_brightness_zwave": {
+		"$import": "#custom_brightness",
+		"label": "Custom Brightness Level (Z-Wave Control)",
+		"description": "Set the custom brightness level (or leave the last brightness level) for Basic Set ON commands when the device is triggered by another device in direct association."
+	},
+	"scene_control_multi_tap": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Scene Control: Multi-Tap",
+		"description": "Disable multi-tap scene control so that only single taps report via central scene. Once this functionality is disabled, double taps, held, released, 3-tap, 4-tap, and 5-tap scene events will be ignored and won't be reported to the hub.",
+		"defaultValue": 0
+	},
+	"gamma_factor": {
+		"label": "Gamma Factor",
+		"description": "Adjusts the gamma factor to improve dimming performance. A higher gamma results in more gradual dimming at low levels, while a lower gamma leads to a more linear or abrupt transition in perceived light intensity. Values 10-50 correspond to gamma 1.0-5.0.",
+		"valueSize": 1,
+		"minValue": 10,
+		"maxValue": 50,
+		"defaultValue": 20,
+		"unsigned": true
+	},
+	"led_indicator_color_opposite": {
+		"label": "LED Indicator Color (Opposite State)",
+		"description": "Choose the color of the LED indicator in opposite switch state (instead of off) when the LED indicator mode (parameter 2) is set to values 0 or 1. The color chosen in this setting will apply instead of the default 'off' value (LED doesn't light up).",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 4,
+		"defaultValue": 0,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Off",
+				"value": 0
+			},
+			{
+				"label": "White",
+				"value": 1
+			},
+			{
+				"label": "Blue",
+				"value": 2
+			},
+			{
+				"label": "Green",
+				"value": 3
+			},
+			{
+				"label": "Red",
+				"value": 4
+			}
+		]
 	}
 }

--- a/packages/config/config/devices/0x027a/zen71.json
+++ b/packages/config/config/devices/0x027a/zen71.json
@@ -124,6 +124,16 @@
 			"$import": "templates/zooz_template.json#led_confirm_config_change"
 		},
 		{
+			"#": "20",
+			"$if": "firmwareVersion >= 3.60 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#scene_control_multi_tap"
+		},
+		{
+			"#": "21",
+			"$if": "firmwareVersion >= 3.60 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_color_opposite"
+		},
+		{
 			"#": "16",
 			"$import": "templates/zooz_template.json#association_reports_binary"
 		},

--- a/packages/config/config/devices/0x027a/zen72.json
+++ b/packages/config/config/devices/0x027a/zen72.json
@@ -209,8 +209,22 @@
 		{
 			"#": "34",
 			"$if": "firmwareVersion >= 3.50 && firmwareVersion < 10.0",
-			"$import": "templates/zooz_template.json#custom_brightness",
-			"label": "Custom Brightness Level (Z-Wave Control)"
+			"$import": "templates/zooz_template.json#custom_brightness_zwave"
+		},
+		{
+			"#": "35",
+			"$if": "firmwareVersion >= 3.60 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#scene_control_multi_tap"
+		},
+		{
+			"#": "36",
+			"$if": "firmwareVersion >= 3.60 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_color_opposite"
+		},
+		{
+			"#": "37",
+			"$if": "firmwareVersion >= 3.60 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#gamma_factor"
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/0x027a/zen73.json
+++ b/packages/config/config/devices/0x027a/zen73.json
@@ -67,6 +67,21 @@
 			"#": "17",
 			"$if": "firmwareVersion >= 10.0",
 			"$import": "templates/zooz_template.json#local_programming"
+		},
+		{
+			"#": "18",
+			"$if": "firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_confirm_config_change"
+		},
+		{
+			"#": "19",
+			"$if": "firmwareVersion >= 2.40 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#scene_control_multi_tap"
+		},
+		{
+			"#": "20",
+			"$if": "firmwareVersion >= 2.40 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_color_opposite"
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/0x027a/zen74.json
+++ b/packages/config/config/devices/0x027a/zen74.json
@@ -127,6 +127,21 @@
 			"#": "30",
 			"$if": "firmwareVersion >= 2.10 && firmwareVersion < 10.0 || firmwareVersion >= 10.10",
 			"$import": "templates/zooz_template.json#local_dimming_speed_group_3_and_4"
+		},
+		{
+			"#": "35",
+			"$if": "firmwareVersion >= 2.40 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#scene_control_multi_tap"
+		},
+		{
+			"#": "36",
+			"$if": "firmwareVersion >= 2.40 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#gamma_factor"
+		},
+		{
+			"#": "37",
+			"$if": "firmwareVersion >= 2.40 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_color_opposite"
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/0x027a/zen76.json
+++ b/packages/config/config/devices/0x027a/zen76.json
@@ -105,6 +105,21 @@
 			"#": "17",
 			"$if": "firmwareVersion >= 10.0",
 			"$import": "templates/zooz_template.json#local_programming"
+		},
+		{
+			"#": "18",
+			"$if": "firmwareVersion >= 10.20 || firmwareVersion >= 2.20 && firmwareVersion < 3.0 || firmwareVersion >= 3.10 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_confirm_config_change"
+		},
+		{
+			"#": "19",
+			"$if": "firmwareVersion >= 3.60 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#scene_control_multi_tap"
+		},
+		{
+			"#": "20",
+			"$if": "firmwareVersion >= 3.60 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_color_opposite"
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/0x027a/zen77.json
+++ b/packages/config/config/devices/0x027a/zen77.json
@@ -184,6 +184,31 @@
 			"#": "30",
 			"$if": "firmwareVersion >= 10.20 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#local_dimming_speed_group_3_and_4"
+		},
+		{
+			"#": "33",
+			"$if": "firmwareVersion >= 4.50 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#on_off_switch_mode"
+		},
+		{
+			"#": "34",
+			"$if": "firmwareVersion >= 4.60 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#custom_brightness_zwave"
+		},
+		{
+			"#": "35",
+			"$if": "firmwareVersion >= 4.70 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#scene_control_multi_tap"
+		},
+		{
+			"#": "36",
+			"$if": "firmwareVersion >= 4.70 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_color_opposite"
+		},
+		{
+			"#": "37",
+			"$if": "firmwareVersion >= 4.70 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#gamma_factor"
 		}
 	],
 	"compat": {


### PR DESCRIPTION
This PR updates configuration files for several Zooz ZEN devices to add new parameters.

## Changes:
- New Templates (`zooz_template.json`):
  - Introduced reusable templates for `custom_brightness_zwave`, `scene_control_multi_tap`, `gamma_factor`, and `led_indicator_color_opposite`
- ZEN71:
    - Added 20 (Scene Control Multi-Tap) 
    - Added 21 (LED Indicator Color - Opposite State)
- ZEN72:
    - Added 35 (Scene Control Multi-Tap)
    - Added 36 (LED Indicator Color - Opposite State)
    - Added 37 (Gamma Factor)
    - Updated the description for parameter 34 (Custom Brightness - Z-Wave Control)
- ZEN73:
    - Added 18 (LED Indicator: Confirm Configuration Change)
    - Added 19 (Scene Control Multi-Tap)
    - Added 20 (LED Indicator Color - Opposite State)
- ZEN74:
    - Added 35 (Scene Control Multi-Tap)
    - Added 36 (Gamma Factor)
    - Added 37 (LED Indicator Color - Opposite State)
- ZEN76:
    - Added 18 (LED Indicator: Confirm Configuration Change)
    - Added 19 (Scene Control Multi-Tap)
    - Added 20 (LED Indicator Color - Opposite State)
- ZEN77:
    - Added 33 (On/Off Switch Mode)
    - Added 34 (Custom Brightness - Z-Wave Control)
    - Added 35 (Scene Control Multi-Tap)
    - Added 36 (LED Indicator Color - Opposite State)
    - Added 37 (Gamma Factor)