### PR TITLE
feat(config): add Minoston MP21ZP variant - productId: 0xfe0e

### DIFF
--- a/packages/config/config/devices/0x0312/mp21zp_mp31zp.json
+++ b/packages/config/config/devices/0x0312/mp21zp_mp31zp.json
@@ -5,6 +5,11 @@
 	"description": "Mini Plug with Power Meter",
 	"devices": [
 		{
+			"productType": "0xfe00",
+			"productId": "0xfe0e",
+			"zwaveAllianceId": 4247
+		},
+		{
 			"productType": "0xff00",
 			"productId": "0xff0e",
 			"zwaveAllianceId": 4247


### PR DESCRIPTION
I was able to add these MP21ZPs in the past so I'm not sure if this got removed at some point, but adding it in here allowed them to be recognized again.

I don't have a MP31ZP to compare to so not sure if these should be two different configs now if `MP21ZP=0xfe0e` and `MP31ZP=0xff0e`.