### PR TITLE
fix: handle serial port reopen failure during controller recovery

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4683,7 +4683,12 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 			);
 			if (this.serial.isOpen) await this.serial.close();
 			await wait(1000);
-			await this.openSerialport();
+			try {
+				await this.openSerialport();
+			} catch (e) {
+				void this.destroyWithMessage(getErrorMessage(e));
+				return;
+			}
 
 			this.driverLog.print(
 				"Serial port reopened. Returning to normal operation and hoping for the best...",


### PR DESCRIPTION
When recovering an unresponsive controller by reopening the serial port, `openSerialport()` could throw (e.g. TCP connection timeout) leaving the rejection unhandled. Wrap the call in a try/catch and call `destroyWithMessage()` on failure, matching the pattern used in `handleSerialPortClosedUnexpectedly()`. This emits an "error" event so consumers can react and cleans up the driver.
