### PR TITLE
docs: add documentation for undocumented public API methods

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -188,6 +188,14 @@ async stopInclusion(): Promise<boolean>
 
 Stops the inclusion process for a new node. The returned promise resolves to `true` if stopping the inclusion was successful, `false` if it failed or if it was not active.
 
+#### `cancelSecureBootstrapS2`
+
+```ts
+cancelSecureBootstrapS2(reason: KEXFailType): void
+```
+
+Cancels an ongoing Security S2 bootstrapping process with the given reason. This can be used to abort the S2 key exchange if the application determines that inclusion should not proceed (e.g. the user rejected the DSK).
+
 #### `beginExclusion`
 
 ```ts

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -344,6 +344,49 @@ To get around this:
 2. Batch all `getNodeNeighbors` requests together
 3. Turn the radio back on with `controller.toggleRF(true`)
 
+### `discoverNodeNeighbors`
+
+```ts
+async discoverNodeNeighbors(nodeId: number): Promise<boolean>
+```
+
+Instructs a node to (re-)discover its neighbors. Returns `true` if the update was successful and the new neighbors can be retrieved using [`getNodeNeighbors`](#getNodeNeighbors). `false` if the update failed.
+
+> [!WARNING] On some controllers, this can cause new SUC return routes to be assigned.
+
+### `getLongRangeNodes`
+
+```ts
+async getLongRangeNodes(): Promise<readonly number[]>
+```
+
+Returns the list of Z-Wave Long Range node IDs from the controller.
+
+### `getBackgroundRSSI`
+
+```ts
+async getBackgroundRSSI(): Promise<{
+	rssiChannel0: RSSI;
+	rssiChannel1: RSSI;
+	rssiChannel2?: RSSI;
+	rssiChannel3?: RSSI;
+}>
+```
+
+Requests the most recent background RSSI levels detected by the controller.
+
+> [!NOTE] This only returns useful values if something was transmitted recently.
+
+### `getDSK`
+
+```ts
+async getDSK(): Promise<Buffer>
+```
+
+Returns the **controller's own** device specific key (DSK) in binary format.
+
+> [!NOTE] This is different from the [`dsk` property on `ZWaveNode`](api/node.md), which returns the DSK of an end device that has joined the network. `getDSK` is only for the controller itself.
+
 ### `getKnownLifelineRoutes`
 
 The routing table of the controller is stored in its memory and not easily accessible during normal operation. Z-Wave JS gets around this by keeping statistics for each node that include the last used routes, the used repeaters, protocol and speed, as well as RSSI readings. This information can be read using
@@ -880,6 +923,29 @@ getSupportedRFRegions(filterSubsets: boolean): MaybeNotKnown<readonly RFRegion[]
 
 The `filterSubsets` parameter (`true` by default) can be used to filter out regions that are subsets of other supported regions. For example, if the controller supports both `USA` and `USA (Long Range)`, only `USA (Long Range)` will be returned, since it includes the `USA` region.
 
+##### `querySupportedRFRegions`
+
+```ts
+async querySupportedRFRegions(): Promise<RFRegion[]>
+```
+
+Queries the supported RF regions directly from the Z-Wave API Module.
+
+> [!NOTE] Applications should prefer using [`getSupportedRFRegions`](#configure-rf-region) instead.
+
+##### `queryRFRegionInfo`
+
+```ts
+async queryRFRegionInfo(region: RFRegion): Promise<{
+	region: RFRegion;
+	supportsZWave: boolean;
+	supportsLongRange: boolean;
+	includesRegion?: RFRegion;
+}>
+```
+
+Queries detailed information about a specific RF region from the Z-Wave API Module, including whether it supports Z-Wave Classic and/or Long Range, and whether it includes another region (e.g. `USA (Long Range)` includes `USA`).
+
 #### Configure TX powerlevel
 
 ```ts
@@ -1104,6 +1170,63 @@ externalNVMWriteBuffer700(offset: number, buffer: Buffer): Promise<boolean>
 Writes a buffer to the external NVM at the given offset. If `endOfFile` is `true`, the end of the NVM has been reached and the NVM should be closed with a call to [`externalNVMClose`](#externalNVMClose).
 
 > [!WARNING] This method can write in the full NVM address space and are not offset to start at the application area. Take care not to accidentally overwrite the protocol NVM area!
+
+#### Opening the NVM (700+ series, extended)
+
+```ts
+externalNVMOpenExt(): Promise<{
+	size: number;
+	supportedOperations: ExtendedNVMOperationsCommand[];
+}>
+```
+
+Opens the controller's external NVM for reading/writing and returns the NVM size and supported operations. Unlike `externalNVMOpen`, this supports NVMs larger than 64 KiB.
+
+The supported operations are indicated by the returned enum values:
+
+```ts
+enum ExtendedNVMOperationsCommand {
+	Open = 0x00,
+	Read = 0x01,
+	Write = 0x02,
+	Close = 0x03,
+}
+```
+
+#### Closing the NVM (700+ series, extended)
+
+```ts
+externalNVMCloseExt(): Promise<void>
+```
+
+Closes the controller's external NVM. Unlike `externalNVMClose`, this supports NVMs larger than 64 KiB.
+
+#### Reading from the NVM (700+ series, extended)
+
+```ts
+externalNVMReadBufferExt(offset: number, length: number): Promise<{
+	buffer: Buffer;
+	endOfFile: boolean;
+}>
+```
+
+Reads a buffer from the external NVM at the given offset. The returned `buffer` length is limited by the Serial API capabilities and not guaranteed to equal `length`. If `endOfFile` is `true`, the end of the NVM has been reached and the NVM should be closed with a call to `externalNVMCloseExt`.
+
+Unlike `externalNVMReadBuffer700`, this supports NVMs larger than 64 KiB.
+
+#### Writing to the NVM (700+ series, extended)
+
+```ts
+externalNVMWriteBufferExt(offset: number, buffer: Buffer): Promise<{
+	endOfFile: boolean;
+}>
+```
+
+Writes a buffer to the external NVM at the given offset. If `endOfFile` is `true`, the end of the NVM has been reached and the NVM should be closed with a call to `externalNVMCloseExt`.
+
+Unlike `externalNVMWriteBuffer700`, this supports NVMs larger than 64 KiB.
+
+> [!WARNING] This method can write in the full NVM address space and is not offset to start at the application area. Take care not to accidentally overwrite the protocol NVM area!
 
 ### Updating the firmware of a node (OTA)
 
@@ -1464,14 +1587,6 @@ Returns the ID of the controller in the current network.
 * readonly sucNodeId: number
 * readonly supportsTimers: boolean
 -->
-
-#### `dsk`
-
-```ts
-dsk(): Buffer
-```
-
-Returns the controller's DSK in binary format.
 
 ### `status`
 

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1576,21 +1576,151 @@ Returns the ID of the controller in the current network.
 > [!WARNING]
 > This property is only defined after the controller interview!
 
-<!-- TODO: Document the other properties of the Controller class:
-* readonly isSecondary: boolean
-* readonly isUsingHomeIdFromOtherNetwork: boolean
-* readonly isSISPresent: boolean
-* readonly wasRealPrimary: boolean
-* readonly isStaticUpdateController: boolean
-* readonly isSlave: boolean
-* readonly firmwareVersion: string
-* readonly manufacturerId: number
-* readonly productType: number
-* readonly productId: number
-* readonly supportedFunctionTypes: FunctionType[]
-* readonly sucNodeId: number
-* readonly supportsTimers: boolean
--->
+### `isSISPresent`
+
+```ts
+readonly isSISPresent: MaybeNotKnown<boolean>
+```
+
+Whether a SIS (SUC ID Server) is present in the current network.
+
+### `isSIS`
+
+```ts
+readonly isSIS: MaybeNotKnown<boolean>
+```
+
+Whether this controller is the SIS (SUC ID Server) in the current network.
+
+### `isSUC`
+
+```ts
+readonly isSUC: MaybeNotKnown<boolean>
+```
+
+Whether this controller is a SUC (Static Update Controller).
+
+### `nodeType`
+
+```ts
+readonly nodeType: MaybeNotKnown<NodeType>
+```
+
+The node type of this controller.
+
+<!-- #import NodeType from "@zwave-js/core" -->
+
+```ts
+enum NodeType {
+	Controller,
+	"End Node" = 1,
+}
+```
+
+### `manufacturerId`
+
+```ts
+readonly manufacturerId: MaybeNotKnown<number>
+```
+
+The manufacturer ID of the controller hardware.
+
+### `productType`
+
+```ts
+readonly productType: MaybeNotKnown<number>
+```
+
+The product type of the controller hardware.
+
+### `productId`
+
+```ts
+readonly productId: MaybeNotKnown<number>
+```
+
+The product ID of the controller hardware.
+
+### `firmwareVersion`
+
+```ts
+readonly firmwareVersion: MaybeNotKnown<string>
+```
+
+The firmware version of the controller.
+
+### `zwaveApiVersion`
+
+```ts
+readonly zwaveApiVersion: MaybeNotKnown<ZWaveApiVersion>
+```
+
+The version of the Z-Wave API supported by the controller.
+
+<!-- #import ZWaveApiVersion from "@zwave-js/core" -->
+
+```ts
+interface ZWaveApiVersion {
+	kind: "official" | "legacy";
+	version: number;
+}
+```
+
+### `zwaveChipType`
+
+```ts
+readonly zwaveChipType: MaybeNotKnown<string | UnknownZWaveChipType>
+```
+
+The Z-Wave chip type used by the controller. If the chip type is known, this returns a human-readable string. Otherwise, an object with numeric `type` and `version` fields is returned.
+
+### `supportedFunctionTypes`
+
+```ts
+readonly supportedFunctionTypes: MaybeNotKnown<readonly FunctionType[]>
+```
+
+The Serial API function types supported by the controller.
+
+### `sucNodeId`
+
+```ts
+readonly sucNodeId: MaybeNotKnown<number>
+```
+
+The node ID of the SUC (Static Update Controller) in the current network.
+
+### `supportsTimers`
+
+```ts
+readonly supportsTimers: MaybeNotKnown<boolean>
+```
+
+Whether the controller supports timers.
+
+### `maxPayloadSize`
+
+```ts
+readonly maxPayloadSize: MaybeNotKnown<number>
+```
+
+The maximum payload size that can be transmitted with a Z-Wave explorer frame.
+
+### `maxPayloadSizeLR`
+
+```ts
+readonly maxPayloadSizeLR: MaybeNotKnown<number>
+```
+
+The maximum payload size that can be transmitted with a Z-Wave Long Range frame.
+
+### `statistics`
+
+```ts
+readonly statistics: Readonly<ControllerStatistics>
+```
+
+Returns the current controller statistics. The shape of the statistics object is described in the [`"statistics updated"` event](#statistics-updated).
 
 ### `status`
 

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -385,7 +385,7 @@ async getDSK(): Promise<BytesView>
 
 Returns the **controller's own** device specific key (DSK) in binary format.
 
-> [!NOTE] This is different from the `dsk` property on `ZWaveNode`, which returns the DSK of an end device that has joined the network. `getDSK` is only for the controller itself.
+> [!NOTE] This is different from the [`dsk` property on `ZWaveNode`](api/node.md#dsk), which returns the DSK of an end device that has joined the network. `getDSK` is only for the controller itself.
 
 ### `getKnownLifelineRoutes`
 

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -380,12 +380,12 @@ Requests the most recent background RSSI levels detected by the controller.
 ### `getDSK`
 
 ```ts
-async getDSK(): Promise<Buffer>
+async getDSK(): Promise<BytesView>
 ```
 
 Returns the **controller's own** device specific key (DSK) in binary format.
 
-> [!NOTE] This is different from the [`dsk` property on `ZWaveNode`](api/node.md), which returns the DSK of an end device that has joined the network. `getDSK` is only for the controller itself.
+> [!NOTE] This is different from the `dsk` property on `ZWaveNode`, which returns the DSK of an end device that has joined the network. `getDSK` is only for the controller itself.
 
 ### `getKnownLifelineRoutes`
 
@@ -946,6 +946,8 @@ async queryRFRegionInfo(region: RFRegion): Promise<{
 
 Queries detailed information about a specific RF region from the Z-Wave API Module, including whether it supports Z-Wave Classic and/or Long Range, and whether it includes another region (e.g. `USA (Long Range)` includes `USA`).
 
+> [!NOTE] Applications should prefer using [`getSupportedRFRegions`](#configure-rf-region) instead.
+
 #### Configure TX powerlevel
 
 ```ts
@@ -1171,6 +1173,8 @@ Writes a buffer to the external NVM at the given offset. If `endOfFile` is `true
 
 > [!WARNING] This method can write in the full NVM address space and are not offset to start at the application area. Take care not to accidentally overwrite the protocol NVM area!
 
+> [!NOTE] Applications should prefer using the higher-level [`backupNVMRaw`](#backupnvmraw) and [`restoreNVMRaw`](#restorenvmraw) methods for NVM access.
+
 #### Opening the NVM (700+ series, extended)
 
 ```ts
@@ -1205,7 +1209,7 @@ Closes the controller's external NVM. Unlike `externalNVMClose`, this supports N
 
 ```ts
 externalNVMReadBufferExt(offset: number, length: number): Promise<{
-	buffer: Buffer;
+	buffer: BytesView;
 	endOfFile: boolean;
 }>
 ```
@@ -1217,7 +1221,7 @@ Unlike `externalNVMReadBuffer700`, this supports NVMs larger than 64 KiB.
 #### Writing to the NVM (700+ series, extended)
 
 ```ts
-externalNVMWriteBufferExt(offset: number, buffer: Buffer): Promise<{
+externalNVMWriteBufferExt(offset: number, buffer: BytesView): Promise<{
 	endOfFile: boolean;
 }>
 ```

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -480,6 +480,22 @@ readonly userAgent: string
 
 Returns the user agent string used for service requests.
 
+### `configVersion`
+
+```ts
+readonly configVersion: string
+```
+
+The version of the device configuration package (`@zwave-js/config`) in use by the driver.
+
+### `options`
+
+```ts
+readonly options: Readonly<ZWaveOptions>
+```
+
+Returns the read-only options the driver was initialized with. The shape of `ZWaveOptions` is described [below](#ZWaveOptions).
+
 ## Driver events
 
 The `Driver` class inherits from the Node.js [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) and thus also supports its methods like `on`, `removeListener`, etc. The following events are implemented:

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -330,6 +330,14 @@ Updates a subset of the driver options without having to restart the driver. The
 - `preferences`
 - `userAgent` (behaves like `updateUserAgent`)
 
+### `sendTestFrame`
+
+```ts
+async sendTestFrame(nodeId: number, powerlevel: Powerlevel): Promise<TransmitStatus | undefined>
+```
+
+Sends a NOP Power frame to the given node at the specified powerlevel and returns the transmit status. Returns `undefined` if the frame could not be sent. This is primarily used for testing link quality between nodes.
+
 ### Updating the firmware of the Z-Wave module (OTW)
 
 ```ts

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -134,6 +134,30 @@ Instruct the controller to soft-reset (restart). The returned Promise will resol
 
 > [!WARNING] USB modules will reconnect, meaning that they might get a new address. Make sure to configure your device address in a way that prevents it from changing, e.g. by using `/dev/serial/by-id/...` on Linux.
 
+### `softResetAndRestart`
+
+```ts
+async softResetAndRestart(): Promise<void>
+```
+
+Soft-resets the Z-Wave module and restarts the driver instance.
+
+### `enterBootloader`
+
+```ts
+async enterBootloader(): Promise<void>
+```
+
+Puts the Z-Wave module into bootloader mode. This is useful for performing firmware updates using the bootloader protocol.
+
+### `leaveBootloader`
+
+```ts
+async leaveBootloader(): Promise<void>
+```
+
+Leaves the bootloader by running the application. This restarts the Z-Wave module from bootloader mode back into normal operation.
+
 ### `hardReset`
 
 ```ts

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -117,6 +117,8 @@ maySupportBasicCC(): boolean
 
 Checks if this endpoint is allowed to support Basic CC per the Z-Wave specification. This depends on the device type and the other supported CCs — Basic CC must not be offered if any actuator CC is supported.
 
+> [!NOTE] Z-Wave JS handles this internally and there is generally no need for an application to use this method.
+
 ### `wasCCRemovedViaConfig`
 
 ```ts

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -86,6 +86,45 @@ supportsCCAPI(cc: CommandClasses): boolean
 
 Allows checking whether a CC API is supported before calling it with [`invokeCCAPI`](#invokeCCAPI)
 
+### `getCCs`
+
+```ts
+getCCs(): Iterable<[ccId: CommandClasses, info: CommandClassInfo]>
+```
+
+Returns an iterable of all Command Classes implemented by this endpoint, along with their information. Each entry is a tuple of the CC ID and an info object:
+
+<!-- #import CommandClassInfo from "@zwave-js/core" -->
+
+```ts
+interface CommandClassInfo {
+	/** Whether the endpoint or node can react to this CC */
+	isSupported: boolean;
+	/** Whether the endpoint or node can control other nodes with this CC */
+	isControlled: boolean;
+	/** Whether this CC is ONLY supported securely */
+	secure: boolean;
+	/** The maximum version of the CC that is supported or controlled */
+	version: number;
+}
+```
+
+### `maySupportBasicCC`
+
+```ts
+maySupportBasicCC(): boolean
+```
+
+Checks if this endpoint is allowed to support Basic CC per the Z-Wave specification. This depends on the device type and the other supported CCs — Basic CC must not be offered if any actuator CC is supported.
+
+### `wasCCRemovedViaConfig`
+
+```ts
+wasCCRemovedViaConfig(cc: CommandClasses): boolean
+```
+
+Determines if support for the given CC was force-removed via a device config file.
+
 ## Endpoint properties
 
 ### `nodeId`

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -145,6 +145,14 @@ readonly index: number
 
 The index of this endpoint. 0 for the root device, 1+ otherwise.
 
+### `deviceClass`
+
+```ts
+readonly deviceClass: MaybeNotKnown<DeviceClass>
+```
+
+This property returns the endpoint's **DeviceClass**, which provides further information about the kind of device this endpoint represents. See [`deviceClass` on `ZWaveNode`](api/node.md#deviceClass) for details about the `DeviceClass` type.
+
 ### `endpointLabel`
 
 ```ts

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -109,6 +109,14 @@ interface CommandClassInfo {
 }
 ```
 
+### `getSupportedCCInstances`
+
+```ts
+getSupportedCCInstances(): readonly CommandClass[]
+```
+
+Returns instances for all CCs this endpoint supports that are implemented in this library.
+
 ### `maySupportBasicCC`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1241,6 +1241,14 @@ readonly isSecure: boolean | "unknown";
 
 Whether this node is communicating securely with the controller, meaning that it was granted at least one security class. More specific information can be retrieved with the [`hasSecurityClass`](#hasSecurityClass) or the [`getHighestSecurityClass`](#getHighestSecurityClass) methods.
 
+### `dsk`
+
+```ts
+readonly dsk: BytesView | undefined;
+```
+
+The device specific key (DSK) of this node in binary format. This is only set if the node was included with Security S2.
+
 ### `supportsBeaming`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -994,6 +994,14 @@ Z-Wave JS discovers a lot of device metadata by interviewing the device. However
 
 When a device config file is updated, this information may be stale and and the device must be re-interviewed using `refreshInfo()` to pick up the changes. This method can be used to determine whether a re-interview is necessary.
 
+### `createDump`
+
+```ts
+createDump(): NodeDump
+```
+
+Returns a dump of this node's information for debugging purposes. The dump includes device metadata, endpoint information, and current values.
+
 ## ZWaveNode properties
 
 ### `id`

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -780,6 +780,97 @@ The health rating expressed as a number from 0 (not working at all) to 10 (perfe
 
 > [!NOTE] The test results are also printed to the driver logs. If you want to format the results in the same way in your application, you can use the `formatRouteHealthCheckSummary` and/or `formatRouteHealthCheckRound` methods which are exposed from `zwave-js/Utils`.
 
+### `checkLinkReliability`
+
+```ts
+async checkLinkReliability(
+	options: LinkReliabilityCheckOptions,
+): Promise<LinkReliabilityCheckResult>
+```
+
+Tests the reliability of the link between the controller and this node and returns the results.
+
+The options parameter has the following shape:
+
+<!-- #import LinkReliabilityCheckOptions from "zwave-js" -->
+
+```ts
+interface LinkReliabilityCheckOptions {
+	mode: LinkReliabilityCheckMode;
+	interval: number;
+	rounds?: number;
+	onProgress?: (progress: LinkReliabilityCheckResult) => void;
+}
+```
+
+where the mode is one of the following:
+
+<!-- #import LinkReliabilityCheckMode from "zwave-js" -->
+
+```ts
+enum LinkReliabilityCheckMode {
+	BasicSetOnOff,
+}
+```
+
+The returned result (and progress callback argument) has the following shape:
+
+<!-- #import LinkReliabilityCheckResult from "zwave-js" -->
+
+```ts
+interface LinkReliabilityCheckResult {
+	rounds: number;
+
+	commandsSent: number;
+	commandErrors: number;
+	missingResponses?: number;
+
+	latency?: {
+		min: number;
+		max: number;
+		average: number;
+	};
+
+	rtt: {
+		min: number;
+		max: number;
+		average: number;
+	};
+
+	ackRSSI: {
+		min: number;
+		max: number;
+		average: number;
+	};
+
+	responseRSSI?: {
+		min: number;
+		max: number;
+		average: number;
+	};
+}
+```
+
+> [!NOTE] This call will throw when there is already a link reliability check in progress for this node.
+
+### `isLinkReliabilityCheckInProgress`
+
+```ts
+isLinkReliabilityCheckInProgress(): boolean
+```
+
+Returns whether a link reliability check is currently in progress for this node.
+
+### `abortLinkReliabilityCheck`
+
+```ts
+abortLinkReliabilityCheck(): void
+```
+
+Aborts an ongoing link reliability check if one is currently in progress.
+
+> [!NOTE] The link reliability check may take a few seconds to actually be aborted. When it is, the promise returned by `checkLinkReliability` will be resolved with the results obtained so far.
+
 ### `isFirmwareUpdateInProgress`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -268,6 +268,38 @@ getAllEndpoints(): Endpoint[]
 
 This method returns an array of all endpoints on this node. At each index `i` the returned array contains the endpoint instance that would be returned by `getEndpoint(i)`.
 
+### `endpointCountIsDynamic`
+
+```ts
+readonly endpointCountIsDynamic: MaybeNotKnown<boolean>
+```
+
+Whether the endpoint count is dynamic, i.e. can change at runtime.
+
+### `endpointsHaveIdenticalCapabilities`
+
+```ts
+readonly endpointsHaveIdenticalCapabilities: MaybeNotKnown<boolean>
+```
+
+Whether all endpoints have identical capabilities.
+
+### `individualEndpointCount`
+
+```ts
+readonly individualEndpointCount: MaybeNotKnown<number>
+```
+
+The number of individual endpoints.
+
+### `aggregatedEndpointCount`
+
+```ts
+readonly aggregatedEndpointCount: MaybeNotKnown<number>
+```
+
+The number of aggregated endpoints.
+
 ### `hasSecurityClass`
 
 ```ts
@@ -1028,6 +1060,14 @@ readonly isControllerNode: boolean
 
 Returns whether this node is the controller node, i.e. has the ID of the primary controller.
 
+### `interviewAttempts`
+
+```ts
+readonly interviewAttempts: number
+```
+
+How many attempts to interview this node have already been made.
+
 ### `interviewStage`
 
 ```ts
@@ -1069,6 +1109,14 @@ enum InterviewStage {
 > [!WARNING]
 > DO NOT rely on the numeric values of the enum if you're using it in your application.
 > The ordinal values are likely to change in future updates. Instead, refer to the enum properties directly.
+
+### `nodeType`
+
+```ts
+readonly nodeType: MaybeNotKnown<NodeType>
+```
+
+The node type of this node (Controller or End Node).
 
 ### `deviceClass`
 
@@ -1199,6 +1247,14 @@ readonly canSleep: boolean | undefined;
 
 Whether this node can sleep. If this is the case it must be expected to be asleep most of the time.
 
+### `supportsWakeUpOnDemand`
+
+```ts
+readonly supportsWakeUpOnDemand: MaybeNotKnown<boolean>
+```
+
+Whether this node supports waking up on demand (via a beam).
+
 ### `isRouting`
 
 ```ts
@@ -1292,6 +1348,14 @@ readonly firmwareVersion: string
 
 The version of this node's firmware.
 
+### `hardwareVersion`
+
+```ts
+readonly hardwareVersion: MaybeNotKnown<number>
+```
+
+The hardware version of this node.
+
 ### `manufacturerId`, `productId` and `productType`
 
 ```ts
@@ -1368,6 +1432,22 @@ readonly protocol: Protocols
 ```
 
 Which protocol is used to communicate with this node, Z-Wave (Classic) or Z-Wave Long Range.
+
+### `hasSUCReturnRoute`
+
+```ts
+readonly hasSUCReturnRoute: boolean
+```
+
+Whether a SUC return route was configured for this node.
+
+### `statistics`
+
+```ts
+readonly statistics: Readonly<NodeStatistics>
+```
+
+Returns the current statistics for this node. The shape of the statistics object is described in the [`"statistics updated"` event](#statistics-updated).
 
 ## ZWaveNode events
 

--- a/docs/api/zniffer.md
+++ b/docs/api/zniffer.md
@@ -193,6 +193,44 @@ To change the frequency of the Zniffer, use the `setFrequency` method:
 async setFrequency(frequency: number): Promise<void>;
 ```
 
+## Long Range channel configuration
+
+On 800 series Zniffers with Long Range support, the LR channel configuration can be queried and changed.
+
+### `lrRegions`
+
+```ts
+readonly lrRegions: ReadonlySet<number>
+```
+
+A set of region identifiers that are Long Range capable.
+
+### `currentLRChannelConfig`
+
+```ts
+readonly currentLRChannelConfig: number | undefined
+```
+
+The currently configured Long Range channel configuration, or `undefined` if not yet known.
+
+### `supportedLRChannelConfigs`
+
+```ts
+readonly supportedLRChannelConfigs: ReadonlyMap<number, string>
+```
+
+A map of supported Long Range channel configuration identifiers and their names.
+
+### `setLRChannelConfig`
+
+```ts
+async setLRChannelConfig(channelConfig: number): Promise<void>
+```
+
+Sets the Long Range channel configuration. The `channelConfig` parameter must be one of the keys from `supportedLRChannelConfigs`.
+
+> [!ATTENTION] This will throw if the current frequency is not a Long Range region.
+
 ## Handling frames
 
 A frame is considered corrupt if its checksum is invalid. This can happen if the Zniffer was not able to capture the frame correctly, or if the frame was corrupted in transit:

--- a/packages/cc/tsconfig.build.json
+++ b/packages/cc/tsconfig.build.json
@@ -19,8 +19,13 @@
 		},
 		{
 			"path": "../maintenance/tsconfig.build.json"
+		},
+		{
+			"path": "../transformers/tsconfig.build.json"
 		}
 	],
-	"include": ["src_gen/**/*.ts"],
+	"include": [
+		"src_gen/**/*.ts"
+	],
 	"exclude": []
 }

--- a/packages/cc/tsconfig.build.json
+++ b/packages/cc/tsconfig.build.json
@@ -19,13 +19,8 @@
 		},
 		{
 			"path": "../maintenance/tsconfig.build.json"
-		},
-		{
-			"path": "../transformers/tsconfig.build.json"
 		}
 	],
-	"include": [
-		"src_gen/**/*.ts"
-	],
+	"include": ["src_gen/**/*.ts"],
 	"exclude": []
 }


### PR DESCRIPTION
## Summary

Add API documentation for previously undocumented public methods and properties across multiple classes:

- **Controller** (`controller.md`):
  - Methods: `discoverNodeNeighbors`, `getLongRangeNodes`, `getBackgroundRSSI`, `getDSK`, `querySupportedRFRegions`, `queryRFRegionInfo`, `externalNVMOpenExt`, `externalNVMCloseExt`, `externalNVMReadBufferExt`, `externalNVMWriteBufferExt`, `cancelSecureBootstrapS2`
  - Properties: `isSISPresent`, `isSIS`, `isSUC`, `nodeType`, `manufacturerId`, `productType`, `productId`, `firmwareVersion`, `zwaveApiVersion`, `zwaveChipType`, `supportedFunctionTypes`, `sucNodeId`, `supportsTimers`, `maxPayloadSize`, `maxPayloadSizeLR`, `statistics`
  - Removed duplicate `dsk` property entry (already documented as `getDSK` method above)
  - Replaced TODO comment listing missing controller properties
- **Driver** (`driver.md`):
  - Methods: `softResetAndRestart`, `enterBootloader`, `leaveBootloader`, `sendTestFrame`
  - Properties: `configVersion`, `options`
- **Endpoint** (`endpoint.md`):
  - Methods: `getCCs`, `maySupportBasicCC`, `wasCCRemovedViaConfig`, `getSupportedCCInstances`
  - Properties: `deviceClass`
- **Node** (`node.md`):
  - Methods: `checkLinkReliability`, `isLinkReliabilityCheckInProgress`, `abortLinkReliabilityCheck`, `createDump`
  - Properties: `dsk`, `interviewAttempts`, `nodeType`, `endpointCountIsDynamic`, `endpointsHaveIdenticalCapabilities`, `individualEndpointCount`, `aggregatedEndpointCount`, `supportsWakeUpOnDemand`, `hardwareVersion`, `hasSUCReturnRoute`, `statistics`
- **Zniffer** (`zniffer.md`): `lrRegions`, `currentLRChannelConfig`, `supportedLRChannelConfigs`, `setLRChannelConfig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)