### PR TITLE
feat(config): update firmware version for parameter 17 and add parameters 18, 19, and 20 for Zooz ZEN76

### DIFF
--- a/packages/config/config/devices/0x027a/zen76.json
+++ b/packages/config/config/devices/0x027a/zen76.json
@@ -99,8 +99,26 @@
 		},
 		{
 			"#": "17",
-			"$if": "firmwareVersion >= 10.0",
+			"$if": "firmwareVersion >= 10.00 || firmwareVersion >= 2.0 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#local_programming"
+		},
+		{
+			"#": "18",
+			"$if": "firmwareVersion >= 10.20 || firmwareVersion >= 3.10 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_confirm_config_change"
+		},
+		{
+			"#": "19",
+			"$if": "firmwareVersion >= 3.60 && firmwareVersion < 10.0",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "Scene Control Multi-Tap",
+			"description": "When disabled, only single taps report via central scene.",
+			"defaultValue": 0
+		},
+		{
+			"#": "20",
+			"$if": "firmwareVersion >= 3.60 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_multi_color"
 		}
 	],
 	"compat": {


### PR DESCRIPTION
- Parameter 17 was introduced in firmware 10.0 and then 2.0 when it was based on 10.0.
- Parameter 18 was introduced in firmware 10.20 and then 2.20 when it was based on 10.20.
- Parameters 19 and 20 were introduced in 3.60.
See change log here: 
PR description [here](https://www.support.getzooz.com/kb/article/1151-zen76-s2-on-off-switch-change-log/)
