### PR TITLE
fix: separate U3C users from credential slots, improve error handling

### DIFF
--- a/docs/api/CCs/UserCredential.md
+++ b/docs/api/CCs/UserCredential.md
@@ -74,7 +74,7 @@ async cancelCredentialLearn(): Promise<
 
 ```ts
 async setUserCredentialAssociation(
-	options: UserCredentialCCUserCredentialAssociationSetOptions,
+	options: UserCredentialCCAssociationSetOptions,
 ): Promise<SupervisionResult | undefined>;
 ```
 
@@ -183,7 +183,7 @@ async sendCredentialLearnReport(
 
 ```ts
 async sendUserCredentialAssociationReport(
-	options: UserCredentialCCUserCredentialAssociationReportOptions,
+	options: UserCredentialCCAssociationReportOptions,
 ): Promise<SupervisionResult | undefined>;
 ```
 

--- a/docs/api/CCs/UserCredential.md
+++ b/docs/api/CCs/UserCredential.md
@@ -27,22 +27,33 @@ async getKeyLockerCapabilities(): Promise<Map<UserCredentialKeyLockerEntryType, 
 ```ts
 async setUser(
 	options: UserCredentialCCUserSetOptions,
-): Promise<SupervisionResult | undefined>;
+): Promise<UserCredentialCCUserReport | undefined>;
 ```
+
+Applications should not use this method directly. Prefer the
+`endpoint.accessControl` API for managing users.
 
 ### `getUser`
 
 ```ts
-async getUser(userId: number): Promise<Pick<UserCredentialCCUserReport, "nextUserId" | "modifierType" | "modifierNodeId" | "userId" | "userType" | "active" | "credentialRule" | "expiringTimeoutMinutes" | "nameEncoding" | "userName"> | undefined>;
+async getUser(
+	userId: number,
+): Promise<UserCredentialCCUserReport | undefined>;
 ```
+
+Applications should not use this method directly. Prefer the
+`endpoint.accessControl` API for querying users.
 
 ### `setCredential`
 
 ```ts
 async setCredential(
 	options: UserCredentialCCCredentialSetOptions,
-): Promise<SupervisionResult | undefined>;
+): Promise<UserCredentialCCCredentialReport | undefined>;
 ```
+
+Applications should not use this method directly. Prefer the
+`endpoint.accessControl` API for managing credentials.
 
 ### `getCredential`
 
@@ -51,8 +62,11 @@ async getCredential(
 	userId: number,
 	credentialType: UserCredentialType,
 	credentialSlot: number,
-): Promise<Pick<UserCredentialCCCredentialReport, "userId" | "credentialType" | "credentialSlot" | "credentialReadBack" | "credentialLength" | "credentialData" | "modifierType" | "modifierNodeId" | "nextCredentialType" | "nextCredentialSlot"> | undefined>;
+): Promise<UserCredentialCCCredentialReport | undefined>;
 ```
+
+Applications should not use this method directly. Prefer the
+`endpoint.accessControl` API for querying credentials.
 
 ### `startCredentialLearn`
 
@@ -75,8 +89,11 @@ async cancelCredentialLearn(): Promise<
 ```ts
 async setUserCredentialAssociation(
 	options: UserCredentialCCAssociationSetOptions,
-): Promise<SupervisionResult | undefined>;
+): Promise<UserCredentialCCAssociationReport | undefined>;
 ```
+
+Applications should not use this method directly. Prefer the
+`endpoint.accessControl` API for reassigning credentials between users.
 
 ### `getAllUsersChecksum`
 

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -303,7 +303,7 @@ if (endpoint.accessControl) {
 }
 ```
 
-> [!NOTE] For nodes using the **User Code CC**, only a subset of the functionality is available. Each user supports a single credential in slot 1, user names and credential rules are not supported, and credential learning is unavailable.
+> [!NOTE] For nodes using the **User Code CC**, only a subset of the functionality is available. Each user maps to a single credential of the device's unified credential type, and the unified credential slot matches the user slot. User names and credential rules are not supported, and credential learning is unavailable.
 
 ### Querying capabilities
 
@@ -469,13 +469,12 @@ Deletes all users and their credentials.
 
 ```ts
 getCredential(
-	userId: number,
 	type: UserCredentialType,
 	slot: number,
 ): Promise<CredentialData | undefined>
 ```
 
-Returns the data for a specific credential. Returns `undefined` if the credential does not exist. Throws if the credential slot is out of range.
+Returns the data for a specific credential identified by its type and slot. Returns `undefined` if the credential does not exist. Throws if the credential slot is out of range.
 
 > [!NOTE] This communicates with the node to retrieve fresh information.
 
@@ -483,13 +482,12 @@ Returns the data for a specific credential. Returns `undefined` if the credentia
 
 ```ts
 getCredentialCached(
-	userId: number,
 	type: UserCredentialType,
 	slot: number,
 ): CredentialData | undefined
 ```
 
-Returns the data for a specific credential. Returns `undefined` if the credential does not exist. Throws if the credential slot is out of range.
+Returns the data for a specific credential identified by its type and slot. Returns `undefined` if the credential does not exist. Throws if the credential slot is out of range.
 
 > [!NOTE] This method uses cached information from the most recent interview.
 
@@ -507,20 +505,66 @@ interface CredentialData {
 #### `getCredentials`
 
 ```ts
-getCredentials(userId: number): Promise<CredentialData[]>
+getCredentialsForUser(
+	userId: number,
+	type?: UserCredentialType,
+): Promise<CredentialData[]>
 ```
 
-Returns all credentials for the given user.
+Returns all credentials for the given user, optionally filtered to a specific type.
 
 > [!NOTE] This communicates with the node to retrieve fresh information.
 
-#### `getCredentialsCached`
+#### `getCredentialsForUserCached`
 
 ```ts
-getCredentialsCached(userId: number): CredentialData[]
+getCredentialsForUserCached(
+	userId: number,
+	type?: UserCredentialType,
+): CredentialData[]
 ```
 
-Returns all credentials for the given user.
+Returns all credentials for the given user, optionally filtered to a specific type.
+
+> [!NOTE] This method uses cached information from the most recent interview.
+
+#### `getCredentialsByType`
+
+```ts
+getCredentialsByType(type: UserCredentialType): Promise<CredentialData[]>
+```
+
+Returns all credentials of the given type, regardless of ownership.
+
+> [!NOTE] This communicates with the node to retrieve fresh information.
+
+#### `getCredentialsByTypeCached`
+
+```ts
+getCredentialsByTypeCached(type: UserCredentialType): CredentialData[]
+```
+
+Returns all credentials of the given type, regardless of ownership.
+
+> [!NOTE] This method uses cached information from the most recent interview.
+
+#### `getAllCredentials`
+
+```ts
+getAllCredentials(): Promise<CredentialData[]>
+```
+
+Returns all credentials, regardless of ownership or type.
+
+> [!NOTE] This communicates with the node to retrieve fresh information.
+
+#### `getAllCredentialsCached`
+
+```ts
+getAllCredentialsCached(): CredentialData[]
+```
+
+Returns all credentials, regardless of ownership or type.
 
 > [!NOTE] This method uses cached information from the most recent interview.
 

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -344,8 +344,11 @@ interface CredentialCapabilities {
 	>;
 	supportsAdminCode: boolean;
 	supportsAdminCodeDeactivation: boolean;
+	supportsCredentialAssignment: boolean;
 }
 ```
+
+`supportsCredentialAssignment` is `true` if existing credentials can be re-assigned between users via [`assignCredential`](#assigncredential) without re-enrolling them. Only supported on nodes using the **User Credential CC**.
 
 Each entry in `supportedCredentialTypes` maps a `UserCredentialType` to its capabilities:
 
@@ -595,6 +598,33 @@ Deletes the given credential. Throws if the credential slot is out of range.
 
 > [!NOTE] For nodes using the **User Code CC**, deleting a credential also deletes the associated user, because User Code CC does not distinguish between users and their credentials.
 
+#### `assignCredential`
+
+```ts
+assignCredential(
+	type: UserCredentialType,
+	slot: number,
+	destinationUserId: number,
+): Promise<AssignCredentialStatus>
+```
+
+Re-assigns an existing credential to a different user without re-enrolling it. Useful for credentials that were added locally on the device (e.g. a biometric) and need to be attached to an existing user that already has other credentials.
+
+Only supported on nodes using the **User Credential CC**. Check the `supportsCredentialAssignment` property of [`getCredentialCapabilitiesCached`](#getcredentialcapabilitiescached) before calling. Throws `CC_NotSupported` on nodes that do not support the User Credential CC.
+
+On success, a [`"credential modified"`](#quotcredential-modifiedquot) event is emitted so UIs can stay in sync.
+
+<!-- #import AssignCredentialStatus from "zwave-js" -->
+
+```ts
+enum AssignCredentialStatus {
+	OK = 0,
+	Error_InvalidCredential = 1,
+	Error_InvalidUser = 2,
+	Error_Unknown = 0xff,
+}
+```
+
 ### Credential learning
 
 Some devices support learning credentials directly from user input (e.g. scanning a fingerprint on a biometric lock). This functionality is only available on nodes using the **User Credential CC** and will throw on other nodes.
@@ -685,7 +715,7 @@ interface UserDeletedArgs {
 (endpoint: Endpoint, args: CredentialChangedArgs) => void
 ```
 
-A credential was added or modified. The `args` object contains the credential data after the change:
+A credential was added or modified. The `args` object contains the credential data after the change. `"credential modified"` is also emitted when an existing credential is re-assigned to a different user via [`assignCredential`](#assigncredential); in that case `args.data` may be `undefined` because re-assignment does not carry the credential data.
 
 <!-- #import CredentialChangedArgs from "zwave-js" -->
 

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -344,6 +344,10 @@ interface CredentialCapabilities {
 	>;
 	supportsAdminCode: boolean;
 	supportsAdminCodeDeactivation: boolean;
+	/**
+	 * Whether existing credentials can be reassigned between users via
+	 * {@link AccessControlAPI.assignCredential} without re-enrolling them.
+	 */
 	supportsCredentialAssignment: boolean;
 }
 ```
@@ -505,7 +509,7 @@ interface CredentialData {
 }
 ```
 
-#### `getCredentials`
+#### `getCredentialsForUser`
 
 ```ts
 getCredentialsForUser(
@@ -619,7 +623,9 @@ On success, a [`"credential modified"`](#quotcredential-modifiedquot) event is e
 ```ts
 enum AssignCredentialStatus {
 	OK = 0,
+	/** Spec statuses 0x01 / 0x02 / 0x03 — credential type / slot invalid or empty */
 	Error_InvalidCredential = 1,
+	/** Spec statuses 0x04 / 0x05 — destination user invalid or nonexistent */
 	Error_InvalidUser = 2,
 	Error_Unknown = 0xff,
 }

--- a/packages/cc/src/cc/UserCredentialCC.ts
+++ b/packages/cc/src/cc/UserCredentialCC.ts
@@ -535,7 +535,6 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 				"credentialType",
 				"credentialSlot",
 				"credentialReadBack",
-				"credentialLength",
 				"credentialData",
 				"modifierType",
 				"modifierNodeId",
@@ -1164,7 +1163,7 @@ export class UserCredentialCC extends CommandClass {
 				}
 
 				previousUserId = currentUserId;
-				nextUserId = user.nextUserId;
+				nextUserId = user.nextUserId ?? 0;
 			} while (nextUserId > 0);
 		}
 
@@ -1279,8 +1278,8 @@ export class UserCredentialCC extends CommandClass {
 				nextCredSlot,
 			);
 			if (!cred?.credentialSlot) break; // No credential found, stop iterating
-			nextCredType = cred.nextCredentialType;
-			nextCredSlot = cred.nextCredentialSlot;
+			nextCredType = cred.nextCredentialType ?? UserCredentialType.None;
+			nextCredSlot = cred.nextCredentialSlot ?? 0;
 		} while (
 			nextCredType !== UserCredentialType.None || nextCredSlot !== 0
 		);
@@ -2137,19 +2136,31 @@ export class UserCredentialCCUserSet extends UserCredentialCC {
 }
 
 // @publicAPI
-export interface UserCredentialCCUserReportOptions {
-	reportType: UserCredentialUserReportType;
-	nextUserId: number;
-	modifierType: UserCredentialModifierType;
-	modifierNodeId: number;
-	userId: number;
-	userType: UserCredentialUserType;
-	active: boolean;
-	credentialRule: UserCredentialRule;
-	expiringTimeoutMinutes: number;
-	nameEncoding: UserCredentialNameEncoding;
-	userName: string;
-}
+export type UserCredentialCCUserReportOptions =
+	& {
+		modifierType: UserCredentialModifierType;
+		modifierNodeId: number;
+		userId: number;
+		userType: UserCredentialUserType;
+		active: boolean;
+		credentialRule: UserCredentialRule;
+		expiringTimeoutMinutes: number;
+		nameEncoding: UserCredentialNameEncoding;
+		userName: string;
+	}
+	& (
+		| {
+			reportType: UserCredentialUserReportType.ResponseToGet;
+			nextUserId: number;
+		}
+		| {
+			reportType: Exclude<
+				UserCredentialUserReportType,
+				UserCredentialUserReportType.ResponseToGet
+			>;
+			nextUserId?: undefined;
+		}
+	);
 
 @CCCommand(UserCredentialCommand.UserReport)
 export class UserCredentialCCUserReport extends UserCredentialCC {
@@ -2158,7 +2169,11 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 	) {
 		super(options);
 		this.reportType = options.reportType;
-		this.nextUserId = options.nextUserId;
+		if (
+			options.reportType === UserCredentialUserReportType.ResponseToGet
+		) {
+			this.nextUserId = options.nextUserId;
+		}
 		this.modifierType = options.modifierType;
 		this.modifierNodeId = options.modifierNodeId;
 		this.userId = options.userId;
@@ -2201,10 +2216,8 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 				.toString("ascii");
 		}
 
-		return new this({
+		const common = {
 			nodeId: ctx.sourceNodeId,
-			reportType,
-			nextUserId,
 			modifierType,
 			modifierNodeId,
 			userId,
@@ -2214,11 +2227,16 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 			expiringTimeoutMinutes,
 			nameEncoding,
 			userName,
-		});
+		};
+
+		if (reportType === UserCredentialUserReportType.ResponseToGet) {
+			return new this({ ...common, reportType, nextUserId });
+		}
+		return new this({ ...common, reportType });
 	}
 
 	public readonly reportType: UserCredentialUserReportType;
-	public readonly nextUserId: number;
+	public readonly nextUserId?: number;
 	public readonly modifierType: UserCredentialModifierType;
 	public readonly modifierNodeId: number;
 	public readonly userId: number;
@@ -2238,7 +2256,7 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 		}
 		this.payload = Bytes.alloc(15 + nameBuffer.length);
 		this.payload[0] = this.reportType;
-		this.payload.writeUInt16BE(this.nextUserId, 1);
+		this.payload.writeUInt16BE(this.nextUserId ?? 0, 1);
 		this.payload[3] = this.modifierType;
 		this.payload.writeUInt16BE(this.modifierNodeId, 4);
 		this.payload.writeUInt16BE(this.userId, 6);
@@ -2376,37 +2394,37 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
-		return {
-			...super.toLogEntry(ctx),
-			message: {
-				"report type": getEnumMemberName(
-					UserCredentialUserReportType,
-					this.reportType,
-				),
-				"next user ID": this.nextUserId,
-				"modifier type": getEnumMemberName(
-					UserCredentialModifierType,
-					this.modifierType,
-				),
-				"modifier node id": this.modifierNodeId,
-				"user ID": this.userId,
-				"user type": getEnumMemberName(
-					UserCredentialUserType,
-					this.userType,
-				),
-				active: this.active,
-				"credential rule": getEnumMemberName(
-					UserCredentialRule,
-					this.credentialRule,
-				),
-				"expiring timeout (minutes)": this.expiringTimeoutMinutes,
-				"name encoding": getEnumMemberName(
-					UserCredentialNameEncoding,
-					this.nameEncoding,
-				),
-				"user name": this.userName,
-			},
+		const message: MessageRecord = {
+			"report type": getEnumMemberName(
+				UserCredentialUserReportType,
+				this.reportType,
+			),
 		};
+		if (this.nextUserId != undefined) {
+			message["next user ID"] = this.nextUserId;
+		}
+		message["modifier type"] = getEnumMemberName(
+			UserCredentialModifierType,
+			this.modifierType,
+		);
+		message["modifier node id"] = this.modifierNodeId;
+		message["user ID"] = this.userId;
+		message["user type"] = getEnumMemberName(
+			UserCredentialUserType,
+			this.userType,
+		);
+		message.active = this.active;
+		message["credential rule"] = getEnumMemberName(
+			UserCredentialRule,
+			this.credentialRule,
+		);
+		message["expiring timeout (minutes)"] = this.expiringTimeoutMinutes;
+		message["name encoding"] = getEnumMemberName(
+			UserCredentialNameEncoding,
+			this.nameEncoding,
+		);
+		message["user name"] = this.userName;
+		return { ...super.toLogEntry(ctx), message };
 	}
 }
 
@@ -2607,19 +2625,39 @@ export class UserCredentialCCCredentialSet extends UserCredentialCC {
 }
 
 // @publicAPI
-export interface UserCredentialCCCredentialReportOptions {
-	reportType: UserCredentialCredentialReportType;
-	userId: number;
-	credentialType: UserCredentialType;
-	credentialSlot: number;
-	credentialReadBack: boolean;
-	credentialLength: number;
-	credentialData: Bytes;
-	modifierType: UserCredentialModifierType;
-	modifierNodeId: number;
-	nextCredentialType: UserCredentialType;
-	nextCredentialSlot: number;
-}
+export type UserCredentialCCCredentialReportOptions =
+	& {
+		userId: number;
+		credentialType: UserCredentialType;
+		credentialSlot: number;
+		modifierType: UserCredentialModifierType;
+		modifierNodeId: number;
+	}
+	& (
+		| {
+			credentialReadBack: true;
+			credentialData: Bytes;
+		}
+		| {
+			credentialReadBack: false;
+			credentialData?: undefined;
+		}
+	)
+	& (
+		| {
+			reportType: UserCredentialCredentialReportType.ResponseToGet;
+			nextCredentialType: UserCredentialType;
+			nextCredentialSlot: number;
+		}
+		| {
+			reportType: Exclude<
+				UserCredentialCredentialReportType,
+				UserCredentialCredentialReportType.ResponseToGet
+			>;
+			nextCredentialType?: undefined;
+			nextCredentialSlot?: undefined;
+		}
+	);
 
 @CCCommand(UserCredentialCommand.CredentialReport)
 export class UserCredentialCCCredentialReport extends UserCredentialCC {
@@ -2632,12 +2670,18 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 		this.credentialType = options.credentialType;
 		this.credentialSlot = options.credentialSlot;
 		this.credentialReadBack = options.credentialReadBack;
-		this.credentialLength = options.credentialLength;
-		this.credentialData = options.credentialData;
+		if (options.credentialReadBack) {
+			this.credentialData = options.credentialData;
+		}
 		this.modifierType = options.modifierType;
 		this.modifierNodeId = options.modifierNodeId;
-		this.nextCredentialType = options.nextCredentialType;
-		this.nextCredentialSlot = options.nextCredentialSlot;
+		if (
+			options.reportType
+				=== UserCredentialCredentialReportType.ResponseToGet
+		) {
+			this.nextCredentialType = options.nextCredentialType;
+			this.nextCredentialSlot = options.nextCredentialSlot;
+		}
 	}
 
 	public static from(
@@ -2652,31 +2696,43 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 		const credentialReadBack = !!(raw.payload[6] & 0b1000_0000);
 		const credentialLength = raw.payload[7];
 		validatePayload(raw.payload.length >= 8 + credentialLength + 6);
-		const credentialData = Bytes.from(
-			raw.payload.subarray(8, 8 + credentialLength),
-		);
 
-		let offset = 8 + credentialLength;
+		const offset = 8 + credentialLength;
 		const modifierType: UserCredentialModifierType = raw.payload[offset];
-		const modifierNodeId = raw.payload.readUInt16BE(
-			offset + 1,
-		);
-		const nextCredentialType: UserCredentialType = raw.payload[offset + 3];
-		const nextCredentialSlot = raw.payload.readUInt16BE(offset + 4);
+		const modifierNodeId = raw.payload.readUInt16BE(offset + 1);
 
-		return new this({
+		const common = {
 			nodeId: ctx.sourceNodeId,
-			reportType,
 			userId,
 			credentialType,
 			credentialSlot,
-			credentialReadBack,
-			credentialLength,
-			credentialData,
 			modifierType,
 			modifierNodeId,
-			nextCredentialType,
-			nextCredentialSlot,
+		};
+		const dataOptions = credentialReadBack
+			? {
+				credentialReadBack: true,
+				credentialData: Bytes.from(
+					raw.payload.subarray(8, 8 + credentialLength),
+				),
+			} as const
+			: { credentialReadBack: false } as const;
+
+		if (
+			reportType === UserCredentialCredentialReportType.ResponseToGet
+		) {
+			return new this({
+				...common,
+				...dataOptions,
+				reportType,
+				nextCredentialType: raw.payload[offset + 3],
+				nextCredentialSlot: raw.payload.readUInt16BE(offset + 4),
+			});
+		}
+		return new this({
+			...common,
+			...dataOptions,
+			reportType,
 		});
 	}
 
@@ -2685,29 +2741,33 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 	public readonly credentialType: UserCredentialType;
 	public readonly credentialSlot: number;
 	public readonly credentialReadBack: boolean;
-	public readonly credentialLength: number;
-	public readonly credentialData: Bytes;
+	public readonly credentialData?: Bytes;
 	public readonly modifierType: UserCredentialModifierType;
 	public readonly modifierNodeId: number;
-	public readonly nextCredentialType: UserCredentialType;
-	public readonly nextCredentialSlot: number;
+	public readonly nextCredentialType?: UserCredentialType;
+	public readonly nextCredentialSlot?: number;
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
-		this.payload = Bytes.alloc(14 + this.credentialData.length);
+		const credentialData = this.credentialData ?? new Bytes();
+		this.payload = Bytes.alloc(14 + credentialData.length);
 		this.payload[0] = this.reportType;
 		this.payload.writeUInt16BE(this.userId, 1);
 		this.payload[3] = this.credentialType;
 		this.payload.writeUInt16BE(this.credentialSlot, 4);
 		this.payload[6] = this.credentialReadBack ? 0x80 : 0x00;
-		this.payload[7] = this.credentialData.length;
-		if (this.credentialData.length > 0) {
-			this.payload.set(this.credentialData, 8);
+		this.payload[7] = credentialData.length;
+		if (credentialData.length > 0) {
+			this.payload.set(credentialData, 8);
 		}
-		let offset = 8 + this.credentialData.length;
+		const offset = 8 + credentialData.length;
 		this.payload[offset] = this.modifierType;
 		this.payload.writeUInt16BE(this.modifierNodeId, offset + 1);
-		this.payload[offset + 3] = this.nextCredentialType;
-		this.payload.writeUInt16BE(this.nextCredentialSlot, offset + 4);
+		this.payload[offset + 3] = this.nextCredentialType
+			?? UserCredentialType.None;
+		this.payload.writeUInt16BE(
+			this.nextCredentialSlot ?? 0,
+			offset + 4,
+		);
 		return super.serialize(ctx);
 	}
 
@@ -2776,23 +2836,28 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 			return true;
 		}
 
-		this.ensureMetadata(
-			ctx,
-			UserCredentialCCValues.credential(
-				this.userId,
-				this.credentialType,
-				this.credentialSlot,
-			),
-		);
-		this.setValue(
-			ctx,
-			UserCredentialCCValues.credential(
-				this.userId,
-				this.credentialType,
-				this.credentialSlot,
-			),
-			normalizeCredentialData(this.credentialType, this.credentialData),
-		);
+		if (this.credentialData != undefined) {
+			this.ensureMetadata(
+				ctx,
+				UserCredentialCCValues.credential(
+					this.userId,
+					this.credentialType,
+					this.credentialSlot,
+				),
+			);
+			this.setValue(
+				ctx,
+				UserCredentialCCValues.credential(
+					this.userId,
+					this.credentialType,
+					this.credentialSlot,
+				),
+				normalizeCredentialData(
+					this.credentialType,
+					this.credentialData,
+				),
+			);
+		}
 		this.setValue(
 			ctx,
 			UserCredentialCCValues.credentialModifierType(
@@ -2816,35 +2881,39 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
-		return {
-			...super.toLogEntry(ctx),
-			message: {
-				"report type": getEnumMemberName(
-					UserCredentialCredentialReportType,
-					this.reportType,
-				),
-				"user ID": this.userId,
-				"credential type": getEnumMemberName(
-					UserCredentialType,
-					this.credentialType,
-				),
-				"credential slot": this.credentialSlot,
-				"credential read-back": this.credentialReadBack,
-				"credential data": credentialToLogString(
-					this.credentialData,
-				),
-				"modifier type": getEnumMemberName(
-					UserCredentialModifierType,
-					this.modifierType,
-				),
-				"modifier node id": this.modifierNodeId,
-				"next credential type": getEnumMemberName(
-					UserCredentialType,
-					this.nextCredentialType,
-				),
-				"next credential slot": this.nextCredentialSlot,
-			},
+		const message: MessageRecord = {
+			"report type": getEnumMemberName(
+				UserCredentialCredentialReportType,
+				this.reportType,
+			),
+			"user ID": this.userId,
+			"credential type": getEnumMemberName(
+				UserCredentialType,
+				this.credentialType,
+			),
+			"credential slot": this.credentialSlot,
+			"credential read-back": this.credentialReadBack,
 		};
+		if (this.credentialData != undefined) {
+			message["credential data"] = credentialToLogString(
+				this.credentialData,
+			);
+		}
+		message["modifier type"] = getEnumMemberName(
+			UserCredentialModifierType,
+			this.modifierType,
+		);
+		message["modifier node id"] = this.modifierNodeId;
+		if (this.nextCredentialType != undefined) {
+			message["next credential type"] = getEnumMemberName(
+				UserCredentialType,
+				this.nextCredentialType,
+			);
+		}
+		if (this.nextCredentialSlot != undefined) {
+			message["next credential slot"] = this.nextCredentialSlot;
+		}
+		return { ...super.toLogEntry(ctx), message };
 	}
 }
 

--- a/packages/cc/src/cc/UserCredentialCC.ts
+++ b/packages/cc/src/cc/UserCredentialCC.ts
@@ -449,7 +449,7 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 	@validateArgs()
 	public async setUser(
 		options: UserCredentialCCUserSetOptions,
-	): Promise<UserCredentialCCUserSetResult | undefined> {
+	): Promise<UserCredentialCCUserReport | undefined> {
 		this.assertSupportsCommand(
 			UserCredentialCommand,
 			UserCredentialCommand.UserSet,
@@ -460,24 +460,10 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 			endpointIndex: this.endpoint.index,
 			...options,
 		});
-		const response = await this.host.sendCommand<
-			UserCredentialCCUserReport
-		>(cc, this.commandOptions);
-		if (response) {
-			return pick(response, [
-				"endpointIndex",
-				"reportType",
-				"userId",
-				"modifierType",
-				"modifierNodeId",
-				"userType",
-				"active",
-				"credentialRule",
-				"expiringTimeoutMinutes",
-				"nameEncoding",
-				"userName",
-			]);
-		}
+		return this.host.sendCommand<UserCredentialCCUserReport>(
+			cc,
+			this.commandOptions,
+		);
 	}
 
 	@validateArgs()
@@ -516,7 +502,7 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 	@validateArgs()
 	public async setCredential(
 		options: UserCredentialCCCredentialSetOptions,
-	): Promise<UserCredentialCCCredentialSetResult | undefined> {
+	): Promise<UserCredentialCCCredentialReport | undefined> {
 		this.assertSupportsCommand(
 			UserCredentialCommand,
 			UserCredentialCommand.CredentialSet,
@@ -527,22 +513,10 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 			endpointIndex: this.endpoint.index,
 			...options,
 		});
-		const response = await this.host.sendCommand<
-			UserCredentialCCCredentialReport
-		>(cc, this.commandOptions);
-		if (response) {
-			return pick(response, [
-				"endpointIndex",
-				"reportType",
-				"userId",
-				"credentialType",
-				"credentialSlot",
-				"credentialReadBack",
-				"credentialData",
-				"modifierType",
-				"modifierNodeId",
-			]);
-		}
+		return this.host.sendCommand<UserCredentialCCCredentialReport>(
+			cc,
+			this.commandOptions,
+		);
 	}
 
 	@validateArgs()
@@ -638,19 +612,21 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 
 	@validateArgs()
 	public async setUserCredentialAssociation(
-		options: UserCredentialCCUserCredentialAssociationSetOptions,
-	): Promise<SupervisionResult | undefined> {
+		options: UserCredentialCCAssociationSetOptions,
+	): Promise<UserCredentialCCAssociationReport | undefined> {
 		this.assertSupportsCommand(
 			UserCredentialCommand,
 			UserCredentialCommand.UserCredentialAssociationSet,
 		);
 
-		const cc = new UserCredentialCCUserCredentialAssociationSet({
+		const cc = new UserCredentialCCAssociationSet({
 			nodeId: this.endpoint.nodeId,
 			endpointIndex: this.endpoint.index,
 			...options,
 		});
-		return this.host.sendCommand(cc, this.commandOptions);
+		return this.host.sendCommand<
+			UserCredentialCCAssociationReport
+		>(cc, this.commandOptions);
 	}
 
 	// oxlint-disable-next-line typescript/explicit-module-boundary-types
@@ -914,14 +890,14 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 
 	@validateArgs()
 	public async sendUserCredentialAssociationReport(
-		options: UserCredentialCCUserCredentialAssociationReportOptions,
+		options: UserCredentialCCAssociationReportOptions,
 	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			UserCredentialCommand,
 			UserCredentialCommand.UserCredentialAssociationReport,
 		);
 
-		const cc = new UserCredentialCCUserCredentialAssociationReport({
+		const cc = new UserCredentialCCAssociationReport({
 			nodeId: this.endpoint.nodeId,
 			endpointIndex: this.endpoint.index,
 			...options,
@@ -1992,22 +1968,6 @@ export type UserCredentialCCUserSetOptions =
 		}
 	);
 
-// @publicAPI
-export type UserCredentialCCUserSetResult = Pick<
-	UserCredentialCCUserReport,
-	| "endpointIndex"
-	| "reportType"
-	| "userId"
-	| "modifierType"
-	| "modifierNodeId"
-	| "userType"
-	| "active"
-	| "credentialRule"
-	| "expiringTimeoutMinutes"
-	| "nameEncoding"
-	| "userName"
->;
-
 function testResponseForUserCredentialUserSet(
 	sent: UserCredentialCCUserSet,
 	received: UserCredentialCCUserReport,
@@ -2604,20 +2564,6 @@ export type UserCredentialCCCredentialSetOptions =
 			credentialData?: undefined;
 		}
 	);
-
-// @publicAPI
-export type UserCredentialCCCredentialSetResult = Pick<
-	UserCredentialCCCredentialReport,
-	| "endpointIndex"
-	| "reportType"
-	| "userId"
-	| "credentialType"
-	| "credentialSlot"
-	| "credentialReadBack"
-	| "credentialData"
-	| "modifierType"
-	| "modifierNodeId"
->;
 
 function testResponseForUserCredentialCredentialSet(
 	_sent: UserCredentialCCCredentialSet,
@@ -3306,79 +3252,7 @@ export class UserCredentialCCCredentialLearnReport extends UserCredentialCC {
 // ============================================================
 
 // @publicAPI
-export interface UserCredentialCCUserCredentialAssociationSetOptions {
-	credentialType: UserCredentialType;
-	credentialSlot: number;
-	destinationUserId: number;
-}
-
-@CCCommand(UserCredentialCommand.UserCredentialAssociationSet)
-@useSupervision()
-export class UserCredentialCCUserCredentialAssociationSet
-	extends UserCredentialCC
-{
-	public constructor(
-		options: WithAddress<
-			UserCredentialCCUserCredentialAssociationSetOptions
-		>,
-	) {
-		super(options);
-		this.credentialType = options.credentialType;
-		this.credentialSlot = options.credentialSlot;
-		this.destinationUserId = options.destinationUserId;
-	}
-
-	public credentialType: UserCredentialType;
-	public credentialSlot: number;
-	public destinationUserId: number;
-
-	public static from(
-		raw: CCRaw,
-		ctx: CCParsingContext,
-	): UserCredentialCCUserCredentialAssociationSet {
-		validatePayload(raw.payload.length >= 5);
-		const credentialType: UserCredentialType = raw.payload[0];
-		const credentialSlot = raw.payload.readUInt16BE(1);
-		const destinationUserId = raw.payload.readUInt16BE(
-			3,
-		);
-
-		return new this({
-			nodeId: ctx.sourceNodeId,
-			credentialType,
-			credentialSlot,
-			destinationUserId,
-		});
-	}
-
-	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
-		this.payload = Bytes.alloc(5);
-		this.payload[0] = this.credentialType;
-		this.payload.writeUInt16BE(this.credentialSlot, 1);
-		this.payload.writeUInt16BE(
-			this.destinationUserId,
-			3,
-		);
-		return super.serialize(ctx);
-	}
-
-	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
-		return {
-			...super.toLogEntry(ctx),
-			message: {
-				"credential type": getEnumMemberName(
-					UserCredentialType,
-					this.credentialType,
-				),
-				"credential slot": this.credentialSlot,
-				"destination user ID": this.destinationUserId,
-			},
-		};
-	}
-}
-
-// @publicAPI
-export interface UserCredentialCCUserCredentialAssociationReportOptions {
+export interface UserCredentialCCAssociationReportOptions {
 	credentialType: UserCredentialType;
 	credentialSlot: number;
 	destinationUserId: number;
@@ -3386,13 +3260,9 @@ export interface UserCredentialCCUserCredentialAssociationReportOptions {
 }
 
 @CCCommand(UserCredentialCommand.UserCredentialAssociationReport)
-export class UserCredentialCCUserCredentialAssociationReport
-	extends UserCredentialCC
-{
+export class UserCredentialCCAssociationReport extends UserCredentialCC {
 	public constructor(
-		options: WithAddress<
-			UserCredentialCCUserCredentialAssociationReportOptions
-		>,
+		options: WithAddress<UserCredentialCCAssociationReportOptions>,
 	) {
 		super(options);
 		this.credentialType = options.credentialType;
@@ -3404,7 +3274,7 @@ export class UserCredentialCCUserCredentialAssociationReport
 	public static from(
 		raw: CCRaw,
 		ctx: CCParsingContext,
-	): UserCredentialCCUserCredentialAssociationReport {
+	): UserCredentialCCAssociationReport {
 		validatePayload(raw.payload.length >= 6);
 		const credentialType: UserCredentialType = raw.payload[0];
 		const credentialSlot = raw.payload.readUInt16BE(1);
@@ -3473,6 +3343,87 @@ export class UserCredentialCCUserCredentialAssociationReport
 				"credential slot": this.credentialSlot,
 				"destination user ID": this.destinationUserId,
 				status: this.status,
+			},
+		};
+	}
+}
+
+// @publicAPI
+export interface UserCredentialCCAssociationSetOptions {
+	credentialType: UserCredentialType;
+	credentialSlot: number;
+	destinationUserId: number;
+}
+
+function testResponseForUserCredentialAssociationSet(
+	sent: UserCredentialCCAssociationSet,
+	received: UserCredentialCCAssociationReport,
+) {
+	return (
+		sent.credentialType === received.credentialType
+		&& sent.credentialSlot === received.credentialSlot
+	);
+}
+
+@CCCommand(UserCredentialCommand.UserCredentialAssociationSet)
+@expectedCCResponse(
+	UserCredentialCCAssociationReport,
+	testResponseForUserCredentialAssociationSet,
+)
+export class UserCredentialCCAssociationSet extends UserCredentialCC {
+	public constructor(
+		options: WithAddress<UserCredentialCCAssociationSetOptions>,
+	) {
+		super(options);
+		this.credentialType = options.credentialType;
+		this.credentialSlot = options.credentialSlot;
+		this.destinationUserId = options.destinationUserId;
+	}
+
+	public credentialType: UserCredentialType;
+	public credentialSlot: number;
+	public destinationUserId: number;
+
+	public static from(
+		raw: CCRaw,
+		ctx: CCParsingContext,
+	): UserCredentialCCAssociationSet {
+		validatePayload(raw.payload.length >= 5);
+		const credentialType: UserCredentialType = raw.payload[0];
+		const credentialSlot = raw.payload.readUInt16BE(1);
+		const destinationUserId = raw.payload.readUInt16BE(
+			3,
+		);
+
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			credentialType,
+			credentialSlot,
+			destinationUserId,
+		});
+	}
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.alloc(5);
+		this.payload[0] = this.credentialType;
+		this.payload.writeUInt16BE(this.credentialSlot, 1);
+		this.payload.writeUInt16BE(
+			this.destinationUserId,
+			3,
+		);
+		return super.serialize(ctx);
+	}
+
+	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(ctx),
+			message: {
+				"credential type": getEnumMemberName(
+					UserCredentialType,
+					this.credentialType,
+				),
+				"credential slot": this.credentialSlot,
+				"destination user ID": this.destinationUserId,
 			},
 		};
 	}

--- a/packages/cc/src/cc/UserCredentialCC.ts
+++ b/packages/cc/src/cc/UserCredentialCC.ts
@@ -65,6 +65,24 @@ function credentialToLogString(credential: string | Bytes): string {
 	return "*".repeat(credential.length);
 }
 
+/**
+ * Returns the canonical form of a credential for storage and reporting:
+ * text credentials (PIN codes, passwords) are returned as strings, binary
+ * credentials (biometric data, BLE/NFC/RFID identifiers, ...) as raw bytes.
+ */
+export function normalizeCredentialData(
+	credentialType: UserCredentialType,
+	credentialData: Bytes,
+): string | Bytes {
+	if (
+		credentialType === UserCredentialType.PINCode
+		|| credentialType === UserCredentialType.Password
+	) {
+		return credentialData.toString("utf8");
+	}
+	return credentialData;
+}
+
 // All of these values are internal, and not meant to be used by applications directly.
 // To interact with user credentials, use the functionality on the ZWaveNode class.
 export const UserCredentialCCValues = V.defineCCValues(
@@ -2241,10 +2259,13 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 
 		if (this.userId === 0) return true;
 
-		// Only persist data for successful responses
+		// A UserModifyRejectedLocationEmpty report means we have a stale cache
+		// entry for a user that no longer exists on the device.
 		if (
 			this.reportType
 				=== UserCredentialUserReportType.UserDeleted
+			|| this.reportType
+				=== UserCredentialUserReportType.UserModifyRejectedLocationEmpty
 		) {
 			// Remove all values for this user
 			const userId = this.userId;
@@ -2279,6 +2300,8 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 			return true;
 		}
 
+		// A UserAddRejectedLocationOccupied report contains the data for the
+		// existing user, so we can update our cache with the actual state.
 		if (
 			this.reportType
 				!== UserCredentialUserReportType.ResponseToGet
@@ -2286,6 +2309,8 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 				!== UserCredentialUserReportType.UserAdded
 			&& this.reportType
 				!== UserCredentialUserReportType.UserModified
+			&& this.reportType
+				!== UserCredentialUserReportType.UserAddRejectedLocationOccupied
 		) {
 			return true;
 		}
@@ -2696,9 +2721,14 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 			return true;
 		}
 
+		// A CredentialModifyRejectedLocationEmpty report means we have a stale
+		// cache entry for a credential that no longer exists on the device.
 		if (
 			this.reportType
 				=== UserCredentialCredentialReportType.CredentialDeleted
+			|| this.reportType
+				=== UserCredentialCredentialReportType
+					.CredentialModifyRejectedLocationEmpty
 		) {
 			this.removeValue(
 				ctx,
@@ -2727,6 +2757,13 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 			return true;
 		}
 
+		// A CredentialAddRejectedLocationOccupied report includes the actual
+		// credential data in the read-back field when the device chooses to
+		// reveal it, so we can update our cache with the real state.
+		const isRejectionWithReadback = this.reportType
+				=== UserCredentialCredentialReportType
+					.CredentialAddRejectedLocationOccupied
+			&& this.credentialReadBack;
 		if (
 			this.reportType
 				!== UserCredentialCredentialReportType.ResponseToGet
@@ -2734,6 +2771,7 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 				!== UserCredentialCredentialReportType.CredentialAdded
 			&& this.reportType
 				!== UserCredentialCredentialReportType.CredentialModified
+			&& !isRejectionWithReadback
 		) {
 			return true;
 		}
@@ -2753,7 +2791,7 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 				this.credentialType,
 				this.credentialSlot,
 			),
-			this.credentialData,
+			normalizeCredentialData(this.credentialType, this.credentialData),
 		);
 		this.setValue(
 			ctx,

--- a/packages/cc/src/cc/UserCredentialCC.ts
+++ b/packages/cc/src/cc/UserCredentialCC.ts
@@ -446,6 +446,10 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 	}
 
 	// User Management
+	/**
+	 * Applications should not use this method directly. Prefer the
+	 * `endpoint.accessControl` API for managing users.
+	 */
 	@validateArgs()
 	public async setUser(
 		options: UserCredentialCCUserSetOptions,
@@ -466,9 +470,14 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 		);
 	}
 
+	/**
+	 * Applications should not use this method directly. Prefer the
+	 * `endpoint.accessControl` API for querying users.
+	 */
 	@validateArgs()
-	// oxlint-disable-next-line typescript/explicit-module-boundary-types
-	public async getUser(userId: number) {
+	public async getUser(
+		userId: number,
+	): Promise<UserCredentialCCUserReport | undefined> {
 		this.assertSupportsCommand(
 			UserCredentialCommand,
 			UserCredentialCommand.UserGet,
@@ -479,26 +488,17 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 			endpointIndex: this.endpoint.index,
 			userId,
 		});
-		const response = await this.host.sendCommand<
-			UserCredentialCCUserReport
-		>(cc, this.commandOptions);
-		if (response) {
-			return pick(response, [
-				"nextUserId",
-				"modifierType",
-				"modifierNodeId",
-				"userId",
-				"userType",
-				"active",
-				"credentialRule",
-				"expiringTimeoutMinutes",
-				"nameEncoding",
-				"userName",
-			]);
-		}
+		return this.host.sendCommand<UserCredentialCCUserReport>(
+			cc,
+			this.commandOptions,
+		);
 	}
 
 	// Credential Management
+	/**
+	 * Applications should not use this method directly. Prefer the
+	 * `endpoint.accessControl` API for managing credentials.
+	 */
 	@validateArgs()
 	public async setCredential(
 		options: UserCredentialCCCredentialSetOptions,
@@ -519,13 +519,16 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 		);
 	}
 
+	/**
+	 * Applications should not use this method directly. Prefer the
+	 * `endpoint.accessControl` API for querying credentials.
+	 */
 	@validateArgs()
-	// oxlint-disable-next-line typescript/explicit-module-boundary-types
 	public async getCredential(
 		userId: number,
 		credentialType: UserCredentialType,
 		credentialSlot: number,
-	) {
+	): Promise<UserCredentialCCCredentialReport | undefined> {
 		this.assertSupportsCommand(
 			UserCredentialCommand,
 			UserCredentialCommand.CredentialGet,
@@ -538,25 +541,10 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 			credentialType,
 			credentialSlot,
 		});
-		const response = await this.host.sendCommand<
-			UserCredentialCCCredentialReport
-		>(cc, this.commandOptions);
-		if (response) {
-			return pick(response, [
-				// UserId, credential type and slot can be zero in the
-				// request to return the first credential, so we cannot
-				// simply omit them here
-				"userId",
-				"credentialType",
-				"credentialSlot",
-				"credentialReadBack",
-				"credentialData",
-				"modifierType",
-				"modifierNodeId",
-				"nextCredentialType",
-				"nextCredentialSlot",
-			]);
-		}
+		return this.host.sendCommand<UserCredentialCCCredentialReport>(
+			cc,
+			this.commandOptions,
+		);
 	}
 
 	@validateArgs()
@@ -610,6 +598,10 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 		return this.host.sendCommand(cc, this.commandOptions);
 	}
 
+	/**
+	 * Applications should not use this method directly. Prefer the
+	 * `endpoint.accessControl` API for reassigning credentials between users.
+	 */
 	@validateArgs()
 	public async setUserCredentialAssociation(
 		options: UserCredentialCCAssociationSetOptions,
@@ -2566,18 +2558,20 @@ export type UserCredentialCCCredentialSetOptions =
 	);
 
 function testResponseForUserCredentialCredentialSet(
-	_sent: UserCredentialCCCredentialSet,
+	sent: UserCredentialCCCredentialSet,
 	received: UserCredentialCCCredentialReport,
 ) {
 	// CC:0083.01.0A.11.010, CC:0083.01.0A.11.011, CC:0083.01.0A.11.012,
 	// CC:0083.01.0A.11.013: CredentialSet MUST be answered by a
-	// CredentialReport. Match any report type other than ResponseToGet.
-	// Rejection reports like DuplicateCredential or WrongUserUniqueIdentifier
-	// may reference a *different* slot/type than the one we sent, so we match
-	// purely on report type.
+	// CredentialReport. We correlate responses on the targeted (type, slot)
+	// but not on userId, because rejection reports like DuplicateCredential
+	// or WrongUserUniqueIdentifier may legitimately reference a different
+	// user at the same credential location.
 	return (
 		received.reportType
 			!== UserCredentialCredentialReportType.ResponseToGet
+		&& received.credentialType === sent.credentialType
+		&& received.credentialSlot === sent.credentialSlot
 	);
 }
 

--- a/packages/cc/src/cc/UserCredentialCC.ts
+++ b/packages/cc/src/cc/UserCredentialCC.ts
@@ -234,12 +234,23 @@ export const UserCredentialCCValues = V.defineCCValues(
 			{ internal: true },
 		),
 
-		// Per-credential modifier info (keyed by userId << 24 | type << 16 | slot)
+		// Per-credential owner info (keyed by type << 16 | slot)
+		...V.dynamicPropertyAndKeyWithName(
+			"credentialOwner",
+			"credentialOwner",
+			(type: UserCredentialType, slot: number) => (type << 16) | slot,
+			({ property, propertyKey }) =>
+				property === "credentialOwner"
+				&& typeof propertyKey === "number",
+			undefined,
+			{ internal: true },
+		),
+
+		// Per-credential modifier info (keyed by type << 16 | slot)
 		...V.dynamicPropertyAndKeyWithName(
 			"credentialModifierType",
 			"credentialModifierType",
-			(userId: number, type: UserCredentialType, slot: number) =>
-				(userId << 24) | (type << 16) | slot,
+			(type: UserCredentialType, slot: number) => (type << 16) | slot,
 			({ property, propertyKey }) =>
 				property === "credentialModifierType"
 				&& typeof propertyKey === "number",
@@ -249,8 +260,7 @@ export const UserCredentialCCValues = V.defineCCValues(
 		...V.dynamicPropertyAndKeyWithName(
 			"credentialModifierNodeId",
 			"credentialModifierNodeId",
-			(userId: number, type: UserCredentialType, slot: number) =>
-				(userId << 24) | (type << 16) | slot,
+			(type: UserCredentialType, slot: number) => (type << 16) | slot,
 			({ property, propertyKey }) =>
 				property === "credentialModifierNodeId"
 				&& typeof propertyKey === "number",
@@ -258,12 +268,11 @@ export const UserCredentialCCValues = V.defineCCValues(
 			{ internal: true },
 		),
 
-		// Per-credential values (keyed by userId << 24 | type << 16 | slot)
+		// Per-credential values (keyed by type << 16 | slot)
 		...V.dynamicPropertyAndKeyWithName(
 			"credential",
 			"credential",
-			(userId: number, type: UserCredentialType, slot: number) =>
-				(userId << 24) | (type << 16) | slot,
+			(type: UserCredentialType, slot: number) => (type << 16) | slot,
 			({ property, propertyKey }) =>
 				property === "credential"
 				&& typeof propertyKey === "number",
@@ -440,7 +449,7 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 	@validateArgs()
 	public async setUser(
 		options: UserCredentialCCUserSetOptions,
-	): Promise<SupervisionResult | undefined> {
+	): Promise<UserCredentialCCUserSetResult | undefined> {
 		this.assertSupportsCommand(
 			UserCredentialCommand,
 			UserCredentialCommand.UserSet,
@@ -451,7 +460,24 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 			endpointIndex: this.endpoint.index,
 			...options,
 		});
-		return this.host.sendCommand(cc, this.commandOptions);
+		const response = await this.host.sendCommand<
+			UserCredentialCCUserReport
+		>(cc, this.commandOptions);
+		if (response) {
+			return pick(response, [
+				"endpointIndex",
+				"reportType",
+				"userId",
+				"modifierType",
+				"modifierNodeId",
+				"userType",
+				"active",
+				"credentialRule",
+				"expiringTimeoutMinutes",
+				"nameEncoding",
+				"userName",
+			]);
+		}
 	}
 
 	@validateArgs()
@@ -490,7 +516,7 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 	@validateArgs()
 	public async setCredential(
 		options: UserCredentialCCCredentialSetOptions,
-	): Promise<SupervisionResult | undefined> {
+	): Promise<UserCredentialCCCredentialSetResult | undefined> {
 		this.assertSupportsCommand(
 			UserCredentialCommand,
 			UserCredentialCommand.CredentialSet,
@@ -501,7 +527,22 @@ export class UserCredentialCCAPI extends PhysicalCCAPI {
 			endpointIndex: this.endpoint.index,
 			...options,
 		});
-		return this.host.sendCommand(cc, this.commandOptions);
+		const response = await this.host.sendCommand<
+			UserCredentialCCCredentialReport
+		>(cc, this.commandOptions);
+		if (response) {
+			return pick(response, [
+				"endpointIndex",
+				"reportType",
+				"userId",
+				"credentialType",
+				"credentialSlot",
+				"credentialReadBack",
+				"credentialData",
+				"modifierType",
+				"modifierNodeId",
+			]);
+		}
 	}
 
 	@validateArgs()
@@ -1235,24 +1276,42 @@ export class UserCredentialCC extends CommandClass {
 
 		// Remove all credential values for this user
 		const valueDB = this.getValueDB(ctx);
-		const credentialValues = valueDB.findValues(
+		const credentialOwners = valueDB.findValues(
 			(vid) =>
-				(UserCredentialCCValues.credential.is(vid)
-					|| UserCredentialCCValues.credentialModifierType.is(vid)
-					|| UserCredentialCCValues.credentialModifierNodeId.is(vid))
-				// The property key is constructed as (userId << 24) | (type << 16) | slot, so we can filter by userId
-				&& (vid.propertyKey as number >> 24) === userId,
+				UserCredentialCCValues.credentialOwner.is(vid)
+				&& vid.endpoint === this.endpointIndex,
 		);
-		for (
-			const { commandClass, endpoint, property, propertyKey }
-				of credentialValues
-		) {
-			valueDB.removeValue({
-				commandClass,
-				endpoint,
-				property,
-				propertyKey,
-			});
+		for (const { endpoint, propertyKey, value } of credentialOwners) {
+			if (value !== userId) continue;
+
+			const key = propertyKey as number;
+			const credentialType = key >>> 16;
+			const credentialSlot = key & 0xffff;
+
+			valueDB.removeValue(
+				UserCredentialCCValues.credential(
+					credentialType,
+					credentialSlot,
+				).endpoint(endpoint),
+			);
+			valueDB.removeValue(
+				UserCredentialCCValues.credentialOwner(
+					credentialType,
+					credentialSlot,
+				).endpoint(endpoint),
+			);
+			valueDB.removeValue(
+				UserCredentialCCValues.credentialModifierType(
+					credentialType,
+					credentialSlot,
+				).endpoint(endpoint),
+			);
+			valueDB.removeValue(
+				UserCredentialCCValues.credentialModifierNodeId(
+					credentialType,
+					credentialSlot,
+				).endpoint(endpoint),
+			);
 		}
 	}
 
@@ -1933,8 +1992,44 @@ export type UserCredentialCCUserSetOptions =
 		}
 	);
 
+// @publicAPI
+export type UserCredentialCCUserSetResult = Pick<
+	UserCredentialCCUserReport,
+	| "endpointIndex"
+	| "reportType"
+	| "userId"
+	| "modifierType"
+	| "modifierNodeId"
+	| "userType"
+	| "active"
+	| "credentialRule"
+	| "expiringTimeoutMinutes"
+	| "nameEncoding"
+	| "userName"
+>;
+
+function testResponseForUserCredentialUserSet(
+	sent: UserCredentialCCUserSet,
+	received: UserCredentialCCUserReport,
+) {
+	// CC:0083.01.05.11.010, CC:0083.01.05.11.011, CC:0083.01.05.11.012,
+	// CC:0083.01.05.11.013: UserSet MUST be answered by a UserReport.
+	// Match any report type other than ResponseToGet. For Add/Modify/Delete
+	// the report echoes the requested userId; for DeleteAll (userId 0) the
+	// report contains userId 0.
+	return (
+		received.reportType !== UserCredentialUserReportType.ResponseToGet
+		&& received.userId === sent.userId
+	);
+}
+
 @CCCommand(UserCredentialCommand.UserSet)
-@useSupervision()
+// The response class is forward-declared here, so use a dynamic CC response
+// that resolves the class lazily.
+@expectedCCResponse(
+	() => UserCredentialCCUserReport,
+	testResponseForUserCredentialUserSet,
+)
 export class UserCredentialCCUserSet extends UserCredentialCC {
 	public constructor(
 		options: WithAddress<UserCredentialCCUserSetOptions>,
@@ -2510,8 +2605,41 @@ export type UserCredentialCCCredentialSetOptions =
 		}
 	);
 
+// @publicAPI
+export type UserCredentialCCCredentialSetResult = Pick<
+	UserCredentialCCCredentialReport,
+	| "endpointIndex"
+	| "reportType"
+	| "userId"
+	| "credentialType"
+	| "credentialSlot"
+	| "credentialReadBack"
+	| "credentialData"
+	| "modifierType"
+	| "modifierNodeId"
+>;
+
+function testResponseForUserCredentialCredentialSet(
+	_sent: UserCredentialCCCredentialSet,
+	received: UserCredentialCCCredentialReport,
+) {
+	// CC:0083.01.0A.11.010, CC:0083.01.0A.11.011, CC:0083.01.0A.11.012,
+	// CC:0083.01.0A.11.013: CredentialSet MUST be answered by a
+	// CredentialReport. Match any report type other than ResponseToGet.
+	// Rejection reports like DuplicateCredential or WrongUserUniqueIdentifier
+	// may reference a *different* slot/type than the one we sent, so we match
+	// purely on report type.
+	return (
+		received.reportType
+			!== UserCredentialCredentialReportType.ResponseToGet
+	);
+}
+
 @CCCommand(UserCredentialCommand.CredentialSet)
-@useSupervision()
+@expectedCCResponse(
+	() => UserCredentialCCCredentialReport,
+	testResponseForUserCredentialCredentialSet,
+)
 export class UserCredentialCCCredentialSet extends UserCredentialCC {
 	public constructor(
 		options: WithAddress<UserCredentialCCCredentialSetOptions>,
@@ -2793,7 +2921,13 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 			this.removeValue(
 				ctx,
 				UserCredentialCCValues.credential(
-					this.userId,
+					this.credentialType,
+					this.credentialSlot,
+				),
+			);
+			this.removeValue(
+				ctx,
+				UserCredentialCCValues.credentialOwner(
 					this.credentialType,
 					this.credentialSlot,
 				),
@@ -2801,7 +2935,6 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 			this.removeValue(
 				ctx,
 				UserCredentialCCValues.credentialModifierType(
-					this.userId,
 					this.credentialType,
 					this.credentialSlot,
 				),
@@ -2809,7 +2942,6 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 			this.removeValue(
 				ctx,
 				UserCredentialCCValues.credentialModifierNodeId(
-					this.userId,
 					this.credentialType,
 					this.credentialSlot,
 				),
@@ -2840,7 +2972,6 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 			this.ensureMetadata(
 				ctx,
 				UserCredentialCCValues.credential(
-					this.userId,
 					this.credentialType,
 					this.credentialSlot,
 				),
@@ -2848,7 +2979,6 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 			this.setValue(
 				ctx,
 				UserCredentialCCValues.credential(
-					this.userId,
 					this.credentialType,
 					this.credentialSlot,
 				),
@@ -2860,8 +2990,15 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 		}
 		this.setValue(
 			ctx,
+			UserCredentialCCValues.credentialOwner(
+				this.credentialType,
+				this.credentialSlot,
+			),
+			this.userId,
+		);
+		this.setValue(
+			ctx,
 			UserCredentialCCValues.credentialModifierType(
-				this.userId,
 				this.credentialType,
 				this.credentialSlot,
 			),
@@ -2870,7 +3007,6 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 		this.setValue(
 			ctx,
 			UserCredentialCCValues.credentialModifierNodeId(
-				this.userId,
 				this.credentialType,
 				this.credentialSlot,
 			),
@@ -3301,6 +3437,29 @@ export class UserCredentialCCUserCredentialAssociationReport
 		);
 		this.payload[5] = this.status;
 		return super.serialize(ctx);
+	}
+
+	public persistValues(ctx: PersistValuesContext): boolean {
+		if (!super.persistValues(ctx)) return false;
+
+		if (
+			this.status !== 0
+			|| this.credentialType === UserCredentialType.None
+			|| this.credentialSlot === 0
+		) {
+			return true;
+		}
+
+		this.setValue(
+			ctx,
+			UserCredentialCCValues.credentialOwner(
+				this.credentialType,
+				this.credentialSlot,
+			),
+			this.destinationUserId,
+		);
+
+		return true;
 	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -9794,46 +9794,6 @@ export const UserCredentialCCValues = Object.freeze({
 			} as const satisfies CCValueOptions,
 		},
 	),
-	credentialModifierType: Object.assign(
-		(type: UserCredentialType, slot: number) => {
-			const property = "credentialModifierType";
-			const propertyKey = (type << 16) | slot;
-
-			return {
-				id: {
-					commandClass: CommandClasses["User Credential"],
-					property,
-					propertyKey,
-				} as const,
-				endpoint: (endpoint: number = 0) => ({
-					commandClass: CommandClasses["User Credential"],
-					endpoint,
-					property: property,
-					propertyKey: propertyKey,
-				} as const),
-				get meta() {
-					return ValueMetadata.Any;
-				},
-			};
-		},
-		{
-			is: (valueId: ValueID): boolean => {
-				return valueId.commandClass
-						=== CommandClasses["User Credential"]
-					&& (({ property, propertyKey }) =>
-						property === "credentialModifierType"
-						&& typeof propertyKey === "number")(valueId);
-			},
-			options: {
-				internal: true,
-				minVersion: 1,
-				secret: false,
-				stateful: true,
-				supportsEndpoints: true,
-				autoCreate: true,
-			} as const satisfies CCValueOptions,
-		},
-	),
 	credentialOwner: Object.assign(
 		(type: UserCredentialType, slot: number) => {
 			const property = "credentialOwner";
@@ -9862,6 +9822,46 @@ export const UserCredentialCCValues = Object.freeze({
 						=== CommandClasses["User Credential"]
 					&& (({ property, propertyKey }) =>
 						property === "credentialOwner"
+						&& typeof propertyKey === "number")(valueId);
+			},
+			options: {
+				internal: true,
+				minVersion: 1,
+				secret: false,
+				stateful: true,
+				supportsEndpoints: true,
+				autoCreate: true,
+			} as const satisfies CCValueOptions,
+		},
+	),
+	credentialModifierType: Object.assign(
+		(type: UserCredentialType, slot: number) => {
+			const property = "credentialModifierType";
+			const propertyKey = (type << 16) | slot;
+
+			return {
+				id: {
+					commandClass: CommandClasses["User Credential"],
+					property,
+					propertyKey,
+				} as const,
+				endpoint: (endpoint: number = 0) => ({
+					commandClass: CommandClasses["User Credential"],
+					endpoint,
+					property: property,
+					propertyKey: propertyKey,
+				} as const),
+				get meta() {
+					return ValueMetadata.Any;
+				},
+			};
+		},
+		{
+			is: (valueId: ValueID): boolean => {
+				return valueId.commandClass
+						=== CommandClasses["User Credential"]
+					&& (({ property, propertyKey }) =>
+						property === "credentialModifierType"
 						&& typeof propertyKey === "number")(valueId);
 			},
 			options: {

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -9795,9 +9795,9 @@ export const UserCredentialCCValues = Object.freeze({
 		},
 	),
 	credentialModifierType: Object.assign(
-		(userId: number, type: UserCredentialType, slot: number) => {
+		(type: UserCredentialType, slot: number) => {
 			const property = "credentialModifierType";
-			const propertyKey = (userId << 24) | (type << 16) | slot;
+			const propertyKey = (type << 16) | slot;
 
 			return {
 				id: {
@@ -9834,10 +9834,50 @@ export const UserCredentialCCValues = Object.freeze({
 			} as const satisfies CCValueOptions,
 		},
 	),
+	credentialOwner: Object.assign(
+		(type: UserCredentialType, slot: number) => {
+			const property = "credentialOwner";
+			const propertyKey = (type << 16) | slot;
+
+			return {
+				id: {
+					commandClass: CommandClasses["User Credential"],
+					property,
+					propertyKey,
+				} as const,
+				endpoint: (endpoint: number = 0) => ({
+					commandClass: CommandClasses["User Credential"],
+					endpoint,
+					property: property,
+					propertyKey: propertyKey,
+				} as const),
+				get meta() {
+					return ValueMetadata.Any;
+				},
+			};
+		},
+		{
+			is: (valueId: ValueID): boolean => {
+				return valueId.commandClass
+						=== CommandClasses["User Credential"]
+					&& (({ property, propertyKey }) =>
+						property === "credentialOwner"
+						&& typeof propertyKey === "number")(valueId);
+			},
+			options: {
+				internal: true,
+				minVersion: 1,
+				secret: false,
+				stateful: true,
+				supportsEndpoints: true,
+				autoCreate: true,
+			} as const satisfies CCValueOptions,
+		},
+	),
 	credentialModifierNodeId: Object.assign(
-		(userId: number, type: UserCredentialType, slot: number) => {
+		(type: UserCredentialType, slot: number) => {
 			const property = "credentialModifierNodeId";
-			const propertyKey = (userId << 24) | (type << 16) | slot;
+			const propertyKey = (type << 16) | slot;
 
 			return {
 				id: {
@@ -9875,9 +9915,9 @@ export const UserCredentialCCValues = Object.freeze({
 		},
 	),
 	credential: Object.assign(
-		(userId: number, type: UserCredentialType, slot: number) => {
+		(type: UserCredentialType, slot: number) => {
 			const property = "credential";
-			const propertyKey = (userId << 24) | (type << 16) | slot;
+			const propertyKey = (type << 16) | slot;
 
 			return {
 				id: {

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -1514,6 +1514,7 @@ export type {
 	UserCredentialCCCredentialLearnStartOptions,
 	UserCredentialCCCredentialReportOptions,
 	UserCredentialCCCredentialSetOptions,
+	UserCredentialCCCredentialSetResult,
 	UserCredentialCCKeyLockerCapabilitiesReportOptions,
 	UserCredentialCCKeyLockerEntryGetOptions,
 	UserCredentialCCKeyLockerEntryReportOptions,
@@ -1526,6 +1527,7 @@ export type {
 	UserCredentialCCUserGetOptions,
 	UserCredentialCCUserReportOptions,
 	UserCredentialCCUserSetOptions,
+	UserCredentialCCUserSetResult,
 } from "./UserCredentialCC.js";
 import {
 	UserCredentialCC,

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -1506,6 +1506,8 @@ export type {
 	UserCredentialCCAdminPinCodeReportOptions,
 	UserCredentialCCAdminPinCodeSetOptions,
 	UserCredentialCCAllUsersChecksumReportOptions,
+	UserCredentialCCAssociationReportOptions,
+	UserCredentialCCAssociationSetOptions,
 	UserCredentialCCCredentialCapabilitiesReportOptions,
 	UserCredentialCCCredentialChecksumGetOptions,
 	UserCredentialCCCredentialChecksumReportOptions,
@@ -1514,7 +1516,6 @@ export type {
 	UserCredentialCCCredentialLearnStartOptions,
 	UserCredentialCCCredentialReportOptions,
 	UserCredentialCCCredentialSetOptions,
-	UserCredentialCCCredentialSetResult,
 	UserCredentialCCKeyLockerCapabilitiesReportOptions,
 	UserCredentialCCKeyLockerEntryGetOptions,
 	UserCredentialCCKeyLockerEntryReportOptions,
@@ -1522,12 +1523,9 @@ export type {
 	UserCredentialCCUserCapabilitiesReportOptions,
 	UserCredentialCCUserChecksumGetOptions,
 	UserCredentialCCUserChecksumReportOptions,
-	UserCredentialCCUserCredentialAssociationReportOptions,
-	UserCredentialCCUserCredentialAssociationSetOptions,
 	UserCredentialCCUserGetOptions,
 	UserCredentialCCUserReportOptions,
 	UserCredentialCCUserSetOptions,
-	UserCredentialCCUserSetResult,
 } from "./UserCredentialCC.js";
 import {
 	UserCredentialCC,
@@ -1536,6 +1534,8 @@ import {
 	UserCredentialCCAdminPinCodeSet,
 	UserCredentialCCAllUsersChecksumGet,
 	UserCredentialCCAllUsersChecksumReport,
+	UserCredentialCCAssociationReport,
+	UserCredentialCCAssociationSet,
 	UserCredentialCCCredentialCapabilitiesGet,
 	UserCredentialCCCredentialCapabilitiesReport,
 	UserCredentialCCCredentialChecksumGet,
@@ -1555,8 +1555,6 @@ import {
 	UserCredentialCCUserCapabilitiesReport,
 	UserCredentialCCUserChecksumGet,
 	UserCredentialCCUserChecksumReport,
-	UserCredentialCCUserCredentialAssociationReport,
-	UserCredentialCCUserCredentialAssociationSet,
 	UserCredentialCCUserGet,
 	UserCredentialCCUserReport,
 	UserCredentialCCUserSet,
@@ -1569,6 +1567,8 @@ export {
 	UserCredentialCCAdminPinCodeSet,
 	UserCredentialCCAllUsersChecksumGet,
 	UserCredentialCCAllUsersChecksumReport,
+	UserCredentialCCAssociationReport,
+	UserCredentialCCAssociationSet,
 	UserCredentialCCCredentialCapabilitiesGet,
 	UserCredentialCCCredentialCapabilitiesReport,
 	UserCredentialCCCredentialChecksumGet,
@@ -1588,8 +1588,6 @@ export {
 	UserCredentialCCUserCapabilitiesReport,
 	UserCredentialCCUserChecksumGet,
 	UserCredentialCCUserChecksumReport,
-	UserCredentialCCUserCredentialAssociationReport,
-	UserCredentialCCUserCredentialAssociationSet,
 	UserCredentialCCUserGet,
 	UserCredentialCCUserReport,
 	UserCredentialCCUserSet,
@@ -2331,8 +2329,8 @@ export function registerCCs(): void {
 	void UserCredentialCCCredentialLearnStart;
 	void UserCredentialCCCredentialLearnCancel;
 	void UserCredentialCCCredentialLearnReport;
-	void UserCredentialCCUserCredentialAssociationSet;
-	void UserCredentialCCUserCredentialAssociationReport;
+	void UserCredentialCCAssociationReport;
+	void UserCredentialCCAssociationSet;
 	void UserCredentialCCAllUsersChecksumReport;
 	void UserCredentialCCAllUsersChecksumGet;
 	void UserCredentialCCUserChecksumReport;

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -21,6 +21,7 @@ export type { VirtualValueID } from "./lib/node/VirtualNode.js";
 export * from "./lib/node/_Types.js";
 export {
 	AccessControlAPI,
+	AssignCredentialStatus,
 	SetCredentialStatus,
 	SetUserStatus,
 } from "./lib/node/feature-apis/AccessControl.js";

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -19,7 +19,11 @@ export { VirtualEndpoint } from "./lib/node/VirtualEndpoint.js";
 export { VirtualNode } from "./lib/node/VirtualNode.js";
 export type { VirtualValueID } from "./lib/node/VirtualNode.js";
 export * from "./lib/node/_Types.js";
-export { AccessControlAPI } from "./lib/node/feature-apis/AccessControl.js";
+export {
+	AccessControlAPI,
+	SetCredentialStatus,
+	SetUserStatus,
+} from "./lib/node/feature-apis/AccessControl.js";
 export type {
 	CredentialCapabilities,
 	CredentialData,

--- a/packages/zwave-js/src/lib/node/CCHandlers/UserCredentialCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/UserCredentialCC.ts
@@ -7,6 +7,7 @@ import {
 	type UserCredentialCCCredentialLearnReport,
 	type UserCredentialCCCredentialReport,
 	type UserCredentialCCUserReport,
+	normalizeCredentialData,
 } from "@zwave-js/cc/UserCredentialCC";
 import type { ZWaveNode } from "../Node.js";
 
@@ -30,12 +31,19 @@ export function handleUserCredentialUserReport(
 	// Trust the reportType from the device
 	switch (report.reportType) {
 		case UserCredentialUserReportType.UserAdded:
+		// The device rejected an Add because the slot was already occupied,
+		// but reported the actual user data. Notify applications about the
+		// previously-unknown user.
+		case UserCredentialUserReportType.UserAddRejectedLocationOccupied:
 			node.emit("user added", endpoint, buildUserArgs(report));
 			break;
 		case UserCredentialUserReportType.UserModified:
 			node.emit("user modified", endpoint, buildUserArgs(report));
 			break;
 		case UserCredentialUserReportType.UserDeleted:
+		// The device rejected a Modify because the slot was empty, meaning
+		// our cache was stale. Notify applications that the user is gone.
+		case UserCredentialUserReportType.UserModifyRejectedLocationEmpty:
 			node.emit("user deleted", endpoint, {
 				userId: report.userId,
 			});
@@ -49,6 +57,10 @@ export function handleUserCredentialCredentialReport(
 ): void {
 	const endpoint = node.getEndpoint(report.endpointIndex) ?? node;
 
+	const normalizedData = report.credentialData
+		? normalizeCredentialData(report.credentialType, report.credentialData)
+		: undefined;
+
 	// Trust the reportType from the device
 	switch (report.reportType) {
 		case UserCredentialCredentialReportType.CredentialAdded:
@@ -56,7 +68,7 @@ export function handleUserCredentialCredentialReport(
 				userId: report.userId,
 				credentialType: report.credentialType,
 				credentialSlot: report.credentialSlot,
-				data: report.credentialData ?? undefined,
+				data: normalizedData,
 			});
 			break;
 		case UserCredentialCredentialReportType.CredentialModified:
@@ -64,15 +76,33 @@ export function handleUserCredentialCredentialReport(
 				userId: report.userId,
 				credentialType: report.credentialType,
 				credentialSlot: report.credentialSlot,
-				data: report.credentialData ?? undefined,
+				data: normalizedData,
 			});
 			break;
 		case UserCredentialCredentialReportType.CredentialDeleted:
+		// The device rejected a Modify because the slot was empty, meaning
+		// our cache was stale. Notify applications that the credential is gone.
+		case UserCredentialCredentialReportType
+			.CredentialModifyRejectedLocationEmpty:
 			node.emit("credential deleted", endpoint, {
 				userId: report.userId,
 				credentialType: report.credentialType,
 				credentialSlot: report.credentialSlot,
 			});
+			break;
+		case UserCredentialCredentialReportType
+			.CredentialAddRejectedLocationOccupied:
+			// The device rejected an Add because the slot was already occupied.
+			// When read-back is set, the report contains the actual credential
+			// data — notify applications about the previously-unknown credential.
+			if (report.credentialReadBack) {
+				node.emit("credential added", endpoint, {
+					userId: report.userId,
+					credentialType: report.credentialType,
+					credentialSlot: report.credentialSlot,
+					data: normalizedData,
+				});
+			}
 			break;
 	}
 }

--- a/packages/zwave-js/src/lib/node/CCHandlers/UserCredentialCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/UserCredentialCC.ts
@@ -4,6 +4,7 @@ import {
 	UserCredentialUserReportType,
 } from "@zwave-js/cc";
 import {
+	type UserCredentialCCAssociationReport,
 	type UserCredentialCCCredentialLearnReport,
 	type UserCredentialCCCredentialReport,
 	type UserCredentialCCUserReport,
@@ -105,6 +106,23 @@ export function handleUserCredentialCredentialReport(
 			}
 			break;
 	}
+}
+
+export function handleUserCredentialAssociationReport(
+	node: ZWaveNode,
+	report: UserCredentialCCAssociationReport,
+): void {
+	// A successful association is semantically a modification of the credential's
+	// owner. Applications can observe it via the existing "credential modified"
+	// event. Failure statuses are delivered to the initiating node via the
+	// command response and do not fan out to listeners.
+	if (report.status !== 0) return;
+	const endpoint = node.getEndpoint(report.endpointIndex) ?? node;
+	node.emit("credential modified", endpoint, {
+		userId: report.destinationUserId,
+		credentialType: report.credentialType,
+		credentialSlot: report.credentialSlot,
+	});
 }
 
 export function handleUserCredentialCredentialLearnReport(

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -74,6 +74,7 @@ import { Security2CCNonceGet } from "@zwave-js/cc/Security2CC";
 import { SecurityCCNonceGet } from "@zwave-js/cc/SecurityCC";
 import { ThermostatModeCCSet } from "@zwave-js/cc/ThermostatModeCC";
 import {
+	UserCredentialCCAssociationReport,
 	UserCredentialCCCredentialLearnReport,
 	UserCredentialCCCredentialReport,
 	UserCredentialCCUserReport,
@@ -238,6 +239,7 @@ import {
 	handleTimeOffsetGet,
 } from "./CCHandlers/TimeCC.js";
 import {
+	handleUserCredentialAssociationReport,
 	handleUserCredentialCredentialLearnReport,
 	handleUserCredentialCredentialReport,
 	handleUserCredentialUserReport,
@@ -2477,6 +2479,10 @@ protocol version:      ${this.protocolVersion}`;
 			return handleUserCredentialCredentialReport(this, command);
 		} else if (command instanceof UserCredentialCCCredentialLearnReport) {
 			return handleUserCredentialCredentialLearnReport(this, command);
+		} else if (
+			command instanceof UserCredentialCCAssociationReport
+		) {
+			return handleUserCredentialAssociationReport(this, command);
 		} else if (command instanceof TimeCCTimeGet) {
 			return handleTimeGet(this.driver, this, command);
 		} else if (command instanceof TimeCCDateGet) {

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -1,14 +1,20 @@
 import {
 	type UserCredentialCapability,
+	UserCredentialCredentialReportType,
 	UserCredentialOperationType,
 	UserCredentialRule,
 	UserCredentialType,
+	UserCredentialUserReportType,
 	UserCredentialUserType,
 	UserIDStatus,
 } from "@zwave-js/cc";
 import { type UserCodeCCAPI, UserCodeCCValues } from "@zwave-js/cc/UserCodeCC";
 import {
 	type UserCredentialCCAPI,
+	type UserCredentialCCCredentialReport,
+	type UserCredentialCCCredentialSetResult,
+	type UserCredentialCCUserReport,
+	type UserCredentialCCUserSetResult,
 	UserCredentialCCValues,
 	normalizeCredentialData,
 } from "@zwave-js/cc/UserCredentialCC";
@@ -17,10 +23,13 @@ import {
 	type SupervisionResult,
 	ZWaveError,
 	ZWaveErrorCodes,
-	isUnsupervisedOrSucceeded,
 	supervisedCommandSucceeded,
 } from "@zwave-js/core";
 import { Bytes, getEnumMemberName } from "@zwave-js/shared";
+import {
+	handleUserCredentialCredentialReport,
+	handleUserCredentialUserReport,
+} from "../CCHandlers/UserCredentialCC.js";
 import { FeatureAPI } from "./FeatureAPI.js";
 
 export interface UserCapabilities {
@@ -61,6 +70,109 @@ export interface SetUserOptions {
 	userName?: string;
 	credentialRule?: UserCredentialRule;
 	expiringTimeoutMinutes?: number;
+}
+
+type UserCredentialGetResult = Awaited<
+	ReturnType<UserCredentialCCAPI["getCredential"]>
+>;
+
+/** Result status of a setUser / deleteUser / deleteAllUsers call */
+export enum SetUserStatus {
+	OK = 0,
+	Error_AddRejectedLocationOccupied = 1,
+	Error_ModifyRejectedLocationEmpty = 2,
+	Error_Unknown = 0xff,
+}
+
+/** Result status of a setCredential / deleteCredential call */
+export enum SetCredentialStatus {
+	OK = 0,
+	Error_AddRejectedLocationOccupied = 1,
+	Error_ModifyRejectedLocationEmpty = 2,
+	Error_DuplicateCredential = 3,
+	Error_ManufacturerSecurityRules = 4,
+	Error_DuplicateAdminPINCode = 5,
+	Error_WrongUserUniqueIdentifier = 6,
+	Error_Unknown = 0xff,
+}
+
+function u3cUserSetResultToStatus(
+	result: UserCredentialCCUserSetResult | undefined,
+): SetUserStatus {
+	if (!result) return SetUserStatus.Error_Unknown;
+	switch (result.reportType) {
+		case UserCredentialUserReportType.UserAdded:
+		case UserCredentialUserReportType.UserModified:
+		case UserCredentialUserReportType.UserDeleted:
+		case UserCredentialUserReportType.UserUnchanged:
+			return SetUserStatus.OK;
+		case UserCredentialUserReportType.UserAddRejectedLocationOccupied:
+			return SetUserStatus.Error_AddRejectedLocationOccupied;
+		case UserCredentialUserReportType.UserModifyRejectedLocationEmpty:
+			return SetUserStatus.Error_ModifyRejectedLocationEmpty;
+		default:
+			return SetUserStatus.Error_Unknown;
+	}
+}
+
+function u3cCredentialSetResultToStatus(
+	result: UserCredentialCCCredentialSetResult | undefined,
+): SetCredentialStatus {
+	if (!result) return SetCredentialStatus.Error_Unknown;
+	switch (result.reportType) {
+		case UserCredentialCredentialReportType.CredentialAdded:
+		case UserCredentialCredentialReportType.CredentialModified:
+		case UserCredentialCredentialReportType.CredentialDeleted:
+		case UserCredentialCredentialReportType.CredentialUnchanged:
+			return SetCredentialStatus.OK;
+		case UserCredentialCredentialReportType
+			.CredentialAddRejectedLocationOccupied:
+			return SetCredentialStatus.Error_AddRejectedLocationOccupied;
+		case UserCredentialCredentialReportType
+			.CredentialModifyRejectedLocationEmpty:
+			return SetCredentialStatus.Error_ModifyRejectedLocationEmpty;
+		case UserCredentialCredentialReportType.DuplicateCredential:
+			return SetCredentialStatus.Error_DuplicateCredential;
+		case UserCredentialCredentialReportType.ManufacturerSecurityRules:
+			return SetCredentialStatus.Error_ManufacturerSecurityRules;
+		case UserCredentialCredentialReportType.DuplicateAdminPINCode:
+			return SetCredentialStatus.Error_DuplicateAdminPINCode;
+		case UserCredentialCredentialReportType.WrongUserUniqueIdentifier:
+			return SetCredentialStatus.Error_WrongUserUniqueIdentifier;
+		default:
+			return SetCredentialStatus.Error_Unknown;
+	}
+}
+
+/**
+ * Dispatches event emission for a UserReport received as a response to a UserSet
+ * command. Normally the driver's handleCommand pipeline emits events for
+ * unsolicited reports, but responses matched to a pending transaction bypass that
+ * path. Re-invoke the handler here so applications observe the same events
+ * regardless of whether the report arrived as a response or unsolicited.
+ */
+function emitUserSetEvent(
+	endpoint: FeatureAPI["endpoint"],
+	result: UserCredentialCCUserSetResult,
+): void {
+	const node = endpoint.tryGetNode();
+	if (!node) return;
+	handleUserCredentialUserReport(
+		node,
+		result as unknown as UserCredentialCCUserReport,
+	);
+}
+
+function emitCredentialSetEvent(
+	endpoint: FeatureAPI["endpoint"],
+	result: UserCredentialCCCredentialSetResult,
+): void {
+	const node = endpoint.tryGetNode();
+	if (!node) return;
+	handleUserCredentialCredentialReport(
+		node,
+		result as unknown as UserCredentialCCCredentialReport,
+	);
 }
 
 const NON_PIN_CHARS = /[^0-9]/;
@@ -180,6 +292,12 @@ export class AccessControlAPI extends FeatureAPI {
 				) ?? false,
 			};
 		} else {
+			const maxUsers = this.getValue<number>(
+				UserCodeCCValues.supportedUsers.endpoint(
+					this.endpoint.index,
+				),
+			) ?? 0;
+
 			// User Code CC only supports a single credential per user
 			// with a length of 4-10 characters (CC:0063.01.01.11.006).
 			// Despite the spec calling them "PIN codes", v1 devices often
@@ -189,7 +307,8 @@ export class AccessControlAPI extends FeatureAPI {
 				UserCredentialCapability
 			>();
 			credentialTypes.set(this.#ucCredentialType, {
-				numberOfCredentialSlots: 1,
+				// For User Code CC, credential slots and users are identical
+				numberOfCredentialSlots: maxUsers,
 				minCredentialLength: 4,
 				maxCredentialLength: 10,
 				maxCredentialHashLength: 0,
@@ -360,7 +479,7 @@ export class AccessControlAPI extends FeatureAPI {
 	public async setUser(
 		userId: number,
 		options: SetUserOptions,
-	): Promise<SupervisionResult | undefined> {
+	): Promise<SetUserStatus> {
 		if (this.#usesUserCredentialCC) {
 			const api = this.#u3cAPI();
 			const existing = this.#getUserCached_U3C(userId);
@@ -372,8 +491,9 @@ export class AccessControlAPI extends FeatureAPI {
 				?? existing?.userType
 				?? UserCredentialUserType.General;
 
+			let result: UserCredentialCCUserSetResult | undefined;
 			if (userType === UserCredentialUserType.Expiring) {
-				return api.setUser({
+				result = await api.setUser({
 					operationType,
 					userId,
 					active: options.active ?? existing?.active ?? true,
@@ -385,17 +505,20 @@ export class AccessControlAPI extends FeatureAPI {
 						?? existing?.credentialRule,
 					userName: options.userName ?? existing?.userName,
 				});
+			} else {
+				result = await api.setUser({
+					operationType,
+					userId,
+					active: options.active ?? existing?.active ?? true,
+					userType,
+					credentialRule: options.credentialRule
+						?? existing?.credentialRule,
+					userName: options.userName ?? existing?.userName,
+				});
 			}
 
-			return api.setUser({
-				operationType,
-				userId,
-				active: options.active ?? existing?.active ?? true,
-				userType,
-				credentialRule: options.credentialRule
-					?? existing?.credentialRule,
-				userName: options.userName ?? existing?.userName,
-			});
+			if (result) emitUserSetEvent(this.endpoint, result);
+			return u3cUserSetResultToStatus(result);
 		} else {
 			const api = this.#ucAPI();
 			const existing = this.#getUserCached_UC(userId);
@@ -436,7 +559,7 @@ export class AccessControlAPI extends FeatureAPI {
 
 			const result = await api.set(
 				userId,
-				status as number,
+				status,
 				existingCode,
 			);
 			let succeeded: boolean;
@@ -461,7 +584,7 @@ export class AccessControlAPI extends FeatureAPI {
 					);
 				}
 			}
-			return result;
+			return succeeded ? SetUserStatus.OK : SetUserStatus.Error_Unknown;
 		}
 	}
 
@@ -471,17 +594,19 @@ export class AccessControlAPI extends FeatureAPI {
 	 */
 	public async deleteUser(
 		userId: number,
-	): Promise<SupervisionResult | undefined> {
+	): Promise<SetUserStatus> {
 		if (this.#usesUserCredentialCC) {
 			const api = this.#u3cAPI();
-			const result = await api.setUser({
+			const raw = await api.setUser({
 				operationType: UserCredentialOperationType.Delete,
 				userId,
 			});
-			if (isUnsupervisedOrSucceeded(result)) {
+			if (raw) emitUserSetEvent(this.endpoint, raw);
+			const status = u3cUserSetResultToStatus(raw);
+			if (status === SetUserStatus.OK) {
 				this.#purgeCachedCredentials(userId);
 			}
-			return result;
+			return status;
 		} else {
 			// User Code CC ties each user to their code, so clearing
 			// the code implicitly deletes the user and vice versa
@@ -504,11 +629,12 @@ export class AccessControlAPI extends FeatureAPI {
 					node.emit("credential deleted", this.endpoint as any, {
 						userId,
 						credentialType: this.#ucCredentialType,
-						credentialSlot: 1,
+						// For User Code CC, credential slots and users are identical
+						credentialSlot: userId,
 					});
 				}
 			}
-			return result;
+			return succeeded ? SetUserStatus.OK : SetUserStatus.Error_Unknown;
 		}
 	}
 
@@ -516,59 +642,50 @@ export class AccessControlAPI extends FeatureAPI {
 	 * Deletes all users and their credentials.
 	 * This communicates with the node.
 	 */
-	public async deleteAllUsers(): Promise<SupervisionResult | undefined> {
+	public async deleteAllUsers(): Promise<SetUserStatus> {
 		if (this.#usesUserCredentialCC) {
 			const api = this.#u3cAPI();
-			const result = await api.setUser({
+			const raw = await api.setUser({
 				operationType: UserCredentialOperationType.Delete,
 				userId: 0,
 			});
-			if (isUnsupervisedOrSucceeded(result)) {
+			if (raw) emitUserSetEvent(this.endpoint, raw);
+			const status = u3cUserSetResultToStatus(raw);
+			if (status === SetUserStatus.OK) {
 				this.#purgeAllCachedUsersAndCredentials();
 			}
-			return result;
+			return status;
 		} else {
 			const api = this.#ucAPI();
 			const result = await api.clear(0);
 			// Verifying all users being deleted is unrealistic
 			// since there can be up to 65535 users. So we just
 			// assume it worked when the command was not supervised.
-			if (isUnsupervisedOrSucceeded(result)) {
+			const succeeded = result == undefined
+				|| supervisedCommandSucceeded(result);
+			if (succeeded) {
 				this.#purgeAllCachedUserCodes();
 			}
-			return result;
+			return succeeded ? SetUserStatus.OK : SetUserStatus.Error_Unknown;
 		}
 	}
 
 	/**
-	 * Returns the data for a specific credential.
+	 * Returns the data for a specific credential type and slot.
 	 * This communicates with the node to retrieve fresh information.
 	 */
 	public async getCredential(
-		userId: number,
 		type: UserCredentialType,
 		slot: number,
 	): Promise<CredentialData | undefined> {
 		this.#assertValidSlot(type, slot);
 
 		if (this.#usesUserCredentialCC) {
-			const api = this.#u3cAPI();
-			const result = await api.getCredential(userId, type, slot);
-			if (!result?.credentialSlot) return undefined;
-			return {
-				userId: result.userId,
-				type: result.credentialType,
-				slot: result.credentialSlot,
-				data: result.credentialData != undefined
-					? normalizeCredentialData(
-						result.credentialType,
-						result.credentialData,
-					)
-					: undefined,
-			};
+			const result = await this.#u3cAPI().getCredential(0, type, slot);
+			return this.#mapCredentialData(result);
 		} else {
 			const api = this.#ucAPI();
-			const result = await api.get(userId);
+			const result = await api.get(slot);
 			if (!result) return undefined;
 			if (
 				result.userIdStatus === UserIDStatus.Available
@@ -576,117 +693,154 @@ export class AccessControlAPI extends FeatureAPI {
 			) {
 				return undefined;
 			}
-			return { userId, type, slot, data: result.userCode };
+			// For User Code CC, credential slots and users are identical
+			return { userId: slot, type, slot, data: result.userCode };
 		}
 	}
 
 	/**
-	 * Returns the data for a specific credential.
+	 * Returns the data for a specific credential type and slot.
 	 * This method uses cached information from the most recent interview.
 	 */
 	public getCredentialCached(
-		userId: number,
 		type: UserCredentialType,
 		slot: number,
 	): CredentialData | undefined {
 		this.#assertValidSlot(type, slot);
 
 		if (this.#usesUserCredentialCC) {
-			return this.#getCredentialCached_U3C(userId, type, slot);
+			return this.#getCredentialCached_U3C(type, slot);
 		} else {
-			return this.#getCredentialCached_UC(userId, type, slot);
+			return this.#getCredentialCached_UC(type, slot);
 		}
 	}
 
 	/**
-	 * Returns all credentials for the given user.
+	 * Returns all credentials for the given user and optional type.
 	 * This communicates with the node to retrieve fresh information.
 	 */
-	public async getCredentials(userId: number): Promise<CredentialData[]> {
+	public async getCredentialsForUser(
+		userId: number,
+		type?: UserCredentialType,
+	): Promise<CredentialData[]> {
 		if (this.#usesUserCredentialCC) {
-			const api = this.#u3cAPI();
-			const credentials: CredentialData[] = [];
-			// Starting from type 0 / slot 0 gives us the first credential for the user
-			let nextCredType: UserCredentialType = UserCredentialType.None;
-			let nextCredSlot = 0;
-			do {
-				const result = await api.getCredential(
-					userId,
-					nextCredType,
-					nextCredSlot,
-				);
-				if (!result?.credentialSlot) break;
-				credentials.push({
-					userId: result.userId,
-					type: result.credentialType,
-					slot: result.credentialSlot,
-					data: result.credentialData != undefined
-						? normalizeCredentialData(
-							result.credentialType,
-							result.credentialData,
-						)
-						: undefined,
-				});
-				nextCredType = result.nextCredentialType
-					?? UserCredentialType.None;
-				nextCredSlot = result.nextCredentialSlot ?? 0;
-			} while (
-				nextCredType !== UserCredentialType.None
-				|| nextCredSlot !== 0
-			);
-			return credentials;
-		} else {
-			const cred = await this.getCredential(
+			if (type != undefined && !this.#supportsCredentialType(type)) {
+				return [];
+			}
+			return this.#queryCredentials_U3C(
 				userId,
-				this.#ucCredentialType,
-				1,
+				type ?? UserCredentialType.None,
+				0,
+				type,
 			);
+		} else {
+			if (type != undefined && type !== this.#ucCredentialType) {
+				return [];
+			}
+			const cred = await this.getCredential(
+				this.#ucCredentialType,
+				// For User Code CC, credential slots and users are identical
+				userId,
+			);
+			// ...and there is at most one credential per user.
 			return cred ? [cred] : [];
 		}
 	}
 
 	/**
-	 * Returns all credentials for the given user.
+	 * Returns all credentials for the given user and optional type.
 	 * This method uses cached information from the most recent interview.
 	 */
-	public getCredentialsCached(userId: number): CredentialData[] {
+	public getCredentialsForUserCached(
+		userId: number,
+		type?: UserCredentialType,
+	): CredentialData[] {
 		if (this.#usesUserCredentialCC) {
-			const credentials: CredentialData[] = [];
-			const supportedTypes = this.getValue<UserCredentialType[]>(
-				UserCredentialCCValues.supportedCredentialTypes.endpoint(
-					this.endpoint.index,
-				),
-			) ?? [];
-
-			for (const type of supportedTypes) {
-				const cap = this.getValue<UserCredentialCapability>(
-					UserCredentialCCValues.credentialCapabilities(type)
-						.endpoint(
-							this.endpoint.index,
-						),
-				);
-				if (!cap) continue;
-				for (
-					let slot = 1;
-					slot <= cap.numberOfCredentialSlots;
-					slot++
-				) {
-					const cred = this.#getCredentialCached_U3C(
-						userId,
-						type,
-						slot,
-					);
-					if (cred) credentials.push(cred);
-				}
+			if (type != undefined && !this.#supportsCredentialType(type)) {
+				return [];
 			}
-			return credentials;
-		} else {
-			const cred = this.#getCredentialCached_UC(
-				userId,
-				this.#ucCredentialType,
-				1,
+			return this.#getAllCredentialsCached_U3C().filter(
+				(credential) =>
+					credential.userId === userId
+					&& (type == undefined || credential.type === type),
 			);
+		} else {
+			if (type != undefined && type !== this.#ucCredentialType) {
+				return [];
+			}
+			const cred = this.#getCredentialCached_UC(
+				this.#ucCredentialType,
+				// For User Code CC, credential slots and users are identical
+				userId,
+			);
+			// ...and there is at most one credential per user.
 			return cred ? [cred] : [];
+		}
+	}
+
+	/**
+	 * Returns all credentials of the given type, regardless of ownership.
+	 * This communicates with the node to retrieve fresh information.
+	 */
+	public async getCredentialsByType(
+		type: UserCredentialType,
+	): Promise<CredentialData[]> {
+		if (!this.#supportsCredentialType(type)) {
+			return [];
+		}
+
+		if (this.#usesUserCredentialCC) {
+			return this.#queryCredentials_U3C(0, type, 0, type);
+		} else {
+			return this.#getAllCredentials_UC();
+		}
+	}
+
+	/**
+	 * Returns all credentials of the given type, regardless of ownership.
+	 * This method uses cached information from the most recent interview.
+	 */
+	public getCredentialsByTypeCached(
+		type: UserCredentialType,
+	): CredentialData[] {
+		if (!this.#supportsCredentialType(type)) {
+			return [];
+		}
+
+		if (this.#usesUserCredentialCC) {
+			return this.#getAllCredentialsCached_U3C().filter(
+				(credential) => credential.type === type,
+			);
+		} else {
+			return this.#getAllCredentialsCached_UC();
+		}
+	}
+
+	/**
+	 * Returns all credentials, regardless of ownership or type.
+	 * This communicates with the node to retrieve fresh information.
+	 */
+	public async getAllCredentials(): Promise<CredentialData[]> {
+		if (this.#usesUserCredentialCC) {
+			return this.#queryCredentials_U3C(
+				0,
+				UserCredentialType.None,
+				0,
+			);
+		} else {
+			return this.#getAllCredentials_UC();
+		}
+	}
+
+	/**
+	 * Returns all credentials, regardless of ownership or type.
+	 * This method uses cached information from the most recent interview.
+	 */
+	public getAllCredentialsCached(): CredentialData[] {
+		if (this.#usesUserCredentialCC) {
+			return this.#getAllCredentialsCached_U3C();
+		} else {
+			return this.#getAllCredentialsCached_UC();
 		}
 	}
 
@@ -699,16 +853,20 @@ export class AccessControlAPI extends FeatureAPI {
 		type: UserCredentialType,
 		slot: number,
 		data: string | Uint8Array,
-	): Promise<SupervisionResult | undefined> {
-		this.#assertValidSlot(type, slot);
-
+	): Promise<SetCredentialStatus> {
 		if (this.#usesUserCredentialCC) {
+			this.#assertValidSlot(type, slot);
+
 			const api = this.#u3cAPI();
-			const existing = this.#getCredentialCached_U3C(userId, type, slot);
+			const existing = this.#getCredentialCachedForUser_U3C(
+				userId,
+				type,
+				slot,
+			);
 			const credentialData = typeof data === "string"
 				? Bytes.from(data, "utf-8")
 				: Bytes.from(data);
-			return api.setCredential({
+			const raw = await api.setCredential({
 				operationType: existing
 					? UserCredentialOperationType.Modify
 					: UserCredentialOperationType.Add,
@@ -717,7 +875,13 @@ export class AccessControlAPI extends FeatureAPI {
 				credentialSlot: slot,
 				credentialData,
 			});
+			if (raw) emitCredentialSetEvent(this.endpoint, raw);
+			return u3cCredentialSetResultToStatus(raw);
 		} else {
+			// User Code CC stores exactly one credential per user slot. Ignore the
+			// caller-provided unified slot and write back to the owning user's slot
+			// so events and cached state stay internally consistent.
+			this.#assertValidSlot(type, userId);
 			const api = this.#ucAPI();
 
 			// Determine the current status; default to Enabled for new users
@@ -734,9 +898,8 @@ export class AccessControlAPI extends FeatureAPI {
 				: existingStatus;
 
 			const existingCred = this.#getCredentialCached_UC(
-				userId,
 				type,
-				slot,
+				userId,
 			);
 
 			const codeData = typeof data === "string"
@@ -765,13 +928,15 @@ export class AccessControlAPI extends FeatureAPI {
 						{
 							userId,
 							credentialType: type,
-							credentialSlot: slot,
+							credentialSlot: userId,
 							data,
 						},
 					);
 				}
 			}
-			return result;
+			return succeeded
+				? SetCredentialStatus.OK
+				: SetCredentialStatus.Error_Unknown;
 		}
 	}
 
@@ -783,22 +948,28 @@ export class AccessControlAPI extends FeatureAPI {
 		userId: number,
 		type: UserCredentialType,
 		slot: number,
-	): Promise<SupervisionResult | undefined> {
-		this.#assertValidSlot(type, slot);
-
+	): Promise<SetCredentialStatus> {
 		if (this.#usesUserCredentialCC) {
+			this.#assertValidSlot(type, slot);
+
 			const api = this.#u3cAPI();
-			return api.setCredential({
+			const raw = await api.setCredential({
 				operationType: UserCredentialOperationType.Delete,
 				userId,
 				credentialType: type,
 				credentialSlot: slot,
 			});
+			if (raw) emitCredentialSetEvent(this.endpoint, raw);
+			return u3cCredentialSetResultToStatus(raw);
 		} else {
-			// User Code CC ties each user to their code, so clearing
-			// the credential also deletes the user
-			const existed = this.#getCredentialCached_UC(userId, type, slot)
-				!= undefined;
+			// User Code CC stores exactly one credential per user slot. Ignore the
+			// caller-provided unified slot and write back to the owning user's slot
+			// so events and cached state stay internally consistent.
+			this.#assertValidSlot(type, userId);
+			const existed = this.#getCredentialCached_UC(
+				type,
+				userId,
+			) != undefined;
 			const api = this.#ucAPI();
 			const result = await api.clear(userId);
 			let succeeded: boolean;
@@ -815,12 +986,14 @@ export class AccessControlAPI extends FeatureAPI {
 					node.emit("credential deleted", this.endpoint as any, {
 						userId,
 						credentialType: type,
-						credentialSlot: slot,
+						credentialSlot: userId,
 					});
 					node.emit("user deleted", this.endpoint as any, { userId });
 				}
 			}
-			return result;
+			return succeeded
+				? SetCredentialStatus.OK
+				: SetCredentialStatus.Error_Unknown;
 		}
 	}
 
@@ -845,7 +1018,11 @@ export class AccessControlAPI extends FeatureAPI {
 
 		this.#assertValidSlot(type, slot);
 
-		const existing = this.#getCredentialCached_U3C(userId, type, slot);
+		const existing = this.#getCredentialCachedForUser_U3C(
+			userId,
+			type,
+			slot,
+		);
 		const operationType = existing
 			? UserCredentialOperationType.Modify
 			: UserCredentialOperationType.Add;
@@ -932,6 +1109,12 @@ export class AccessControlAPI extends FeatureAPI {
 		] as unknown as UserCredentialCCAPI;
 	}
 
+	#supportsCredentialType(type: UserCredentialType): boolean {
+		return this.getCredentialCapabilitiesCached()
+			.supportedCredentialTypes
+			.has(type);
+	}
+
 	/** Returns the credential type to use for User Code CC based on supported characters */
 	get #ucCredentialType(): UserCredentialType {
 		const supportedASCIIChars = this.getValue<string>(
@@ -985,15 +1168,28 @@ export class AccessControlAPI extends FeatureAPI {
 	#purgeCachedCredentials(userId: number): void {
 		const valueDB = this.endpoint.tryGetNode()?.valueDB;
 		if (!valueDB) return;
-		const credentialValues = valueDB.findValues(
+		const credentialOwners = valueDB.findValues(
 			(vid) =>
-				(UserCredentialCCValues.credential.is(vid)
-					|| UserCredentialCCValues.credentialModifierType.is(vid)
-					|| UserCredentialCCValues.credentialModifierNodeId.is(vid))
-				&& (vid.propertyKey as number >> 24) === userId,
+				UserCredentialCCValues.credentialOwner.is(vid)
+				&& vid.endpoint === this.endpoint.index,
 		);
-		for (const vid of credentialValues) {
-			valueDB.removeValue(vid);
+		for (const { endpoint, propertyKey, value } of credentialOwners) {
+			if (value !== userId) continue;
+
+			const key = propertyKey as number;
+			const type = key >>> 16;
+			const slot = key & 0xffff;
+
+			for (
+				const valueId of [
+					UserCredentialCCValues.credential(type, slot),
+					UserCredentialCCValues.credentialOwner(type, slot),
+					UserCredentialCCValues.credentialModifierType(type, slot),
+					UserCredentialCCValues.credentialModifierNodeId(type, slot),
+				]
+			) {
+				valueDB.removeValue(valueId.endpoint(endpoint));
+			}
 		}
 	}
 
@@ -1028,6 +1224,7 @@ export class AccessControlAPI extends FeatureAPI {
 		const credentialValues = valueDB.findValues(
 			(vid) =>
 				UserCredentialCCValues.credential.is(vid)
+				|| UserCredentialCCValues.credentialOwner.is(vid)
 				|| UserCredentialCCValues.credentialModifierType.is(vid)
 				|| UserCredentialCCValues.credentialModifierNodeId.is(vid),
 		);
@@ -1049,6 +1246,178 @@ export class AccessControlAPI extends FeatureAPI {
 		for (const vid of values) {
 			valueDB.removeValue(vid);
 		}
+	}
+
+	#mapCredentialData(
+		result: UserCredentialGetResult,
+	): CredentialData | undefined {
+		if (!result?.credentialSlot) return undefined;
+		return {
+			userId: result.userId,
+			type: result.credentialType,
+			slot: result.credentialSlot,
+			data: result.credentialData != undefined
+				? normalizeCredentialData(
+					result.credentialType,
+					result.credentialData,
+				)
+				: undefined,
+		};
+	}
+
+	async #queryCredentials_U3C(
+		userId: number,
+		startType: UserCredentialType,
+		startSlot: number,
+		filterType?: UserCredentialType,
+	): Promise<CredentialData[]> {
+		const api = this.#u3cAPI();
+		const credentials: CredentialData[] = [];
+		let queryType = startType;
+		let querySlot = startSlot;
+
+		// U3C credential enumeration behaves like a cursor walk.
+		// The initial (userId, type, slot) triple may be exact or wildcarded,
+		// and each report returns both the matching credential and a pointer to
+		// the next credential that should be requested.
+		while (true) {
+			const result = await api.getCredential(
+				userId,
+				queryType,
+				querySlot,
+			);
+			const credential = this.#mapCredentialData(result);
+			// No credential means the walk is exhausted or the current selector did
+			// not resolve to a valid entry on this node.
+			if (!result || !credential) break;
+			// When iterating a single type, stop as soon as the node answers with a
+			// credential of another type instead of leaking unrelated results.
+			if (filterType != undefined && credential.type !== filterType) {
+				break;
+			}
+
+			credentials.push(credential);
+
+			const nextType = result.nextCredentialType
+				?? UserCredentialType.None;
+			const nextSlot = result.nextCredentialSlot ?? 0;
+			// A zero next pointer marks the end of the node's credential sequence.
+			if (
+				nextType === UserCredentialType.None
+				&& nextSlot === 0
+			) {
+				break;
+			}
+			// Per CC:0083.01.0C.11.024/.025, the next pointer advances to the next
+			// existing credential for the user, across credential types. For
+			// type-filtered walks, stop before following that pointer into a
+			// different type.
+			if (filterType != undefined && nextType !== filterType) {
+				break;
+			}
+			// Guard against buggy nodes that repeat the same cursor forever.
+			if (nextType === queryType && nextSlot === querySlot) {
+				break;
+			}
+
+			queryType = nextType;
+			querySlot = nextSlot;
+		}
+
+		return credentials;
+	}
+
+	async #getAllCredentials_UC(): Promise<CredentialData[]> {
+		const api = this.#ucAPI();
+		const maxUsers = await api.getUsersCount();
+		if (!maxUsers) return [];
+
+		const credentials: CredentialData[] = [];
+		const supportsBulk = !!this.getValue<boolean>(
+			UserCodeCCValues.supportsMultipleUserCodeReport.endpoint(
+				this.endpoint.index,
+			),
+		);
+
+		if (supportsBulk) {
+			let nextUserId = 1;
+			while (nextUserId > 0 && nextUserId <= maxUsers) {
+				const response = await api.get(nextUserId, true);
+				if (!response) break;
+
+				for (const entry of response.userCodes) {
+					if (
+						entry.userIdStatus === UserIDStatus.Available
+						|| entry.userIdStatus
+							=== UserIDStatus.StatusNotAvailable
+					) {
+						continue;
+					}
+					// Bulk User Code reports enumerate user slots, which become the
+					// unified credential slots for the returned credentials.
+					credentials.push({
+						userId: entry.userId,
+						type: this.#ucCredentialType,
+						slot: entry.userId,
+						data: entry.userCode,
+					});
+				}
+
+				nextUserId = response.nextUserId;
+			}
+		} else {
+			for (let userId = 1; userId <= maxUsers; userId++) {
+				const credential = await this.getCredential(
+					this.#ucCredentialType,
+					userId,
+				);
+				if (credential) credentials.push(credential);
+			}
+		}
+
+		return credentials;
+	}
+
+	#getAllCredentialsCached_U3C(): CredentialData[] {
+		const valueDB = this.endpoint.tryGetNode()?.valueDB;
+		if (!valueDB) return [];
+
+		return valueDB
+			.findValues(
+				(vid) =>
+					UserCredentialCCValues.credentialOwner.is(vid)
+					&& vid.endpoint === this.endpoint.index,
+			)
+			.filter(
+				({ propertyKey }) => typeof propertyKey === "number",
+			)
+			.toSorted(
+				(a, b) => (a.propertyKey as number) - (b.propertyKey as number),
+			)
+			.flatMap(({ propertyKey }) => {
+				const key = propertyKey as number;
+				const type = key >>> 16;
+				const slot = key & 0xffff;
+				const credential = this.#getCredentialCached_U3C(type, slot);
+				return credential ? [credential] : [];
+			});
+	}
+
+	#getAllCredentialsCached_UC(): CredentialData[] {
+		const maxUsers = this.getValue<number>(
+			UserCodeCCValues.supportedUsers.endpoint(this.endpoint.index),
+		) ?? 0;
+		const credentials: CredentialData[] = [];
+		// Cached User Code values are keyed by user slot, and the unified
+		// abstraction reuses that slot number as the credential slot.
+		for (let userId = 1; userId <= maxUsers; userId++) {
+			const credential = this.#getCredentialCached_UC(
+				this.#ucCredentialType,
+				userId,
+			);
+			if (credential) credentials.push(credential);
+		}
+		return credentials;
 	}
 
 	#assertValidSlot(type: UserCredentialType, slot: number): void {
@@ -1098,18 +1467,41 @@ export class AccessControlAPI extends FeatureAPI {
 		};
 	}
 
+	#getCredentialOwner_U3C(
+		type: UserCredentialType,
+		slot: number,
+	): number | undefined {
+		return this.getValue<number>(
+			UserCredentialCCValues.credentialOwner(type, slot).endpoint(
+				this.endpoint.index,
+			),
+		);
+	}
+
 	#getCredentialCached_U3C(
-		userId: number,
 		type: UserCredentialType,
 		slot: number,
 	): CredentialData | undefined {
+		const owner = this.#getCredentialOwner_U3C(type, slot);
+		if (owner == undefined) return undefined;
+
 		const data = this.getValue<string | Uint8Array>(
-			UserCredentialCCValues.credential(userId, type, slot).endpoint(
+			UserCredentialCCValues.credential(type, slot).endpoint(
 				this.endpoint.index,
 			),
 		);
 		if (data == undefined) return undefined;
-		return { userId, type, slot, data };
+		return { userId: owner, type, slot, data };
+	}
+
+	#getCredentialCachedForUser_U3C(
+		userId: number,
+		type: UserCredentialType,
+		slot: number,
+	): CredentialData | undefined {
+		const credential = this.#getCredentialCached_U3C(type, slot);
+		if (credential?.userId !== userId) return undefined;
+		return credential;
 	}
 
 	#getUserCached_UC(userId: number): UserData | undefined {
@@ -1123,13 +1515,13 @@ export class AccessControlAPI extends FeatureAPI {
 	}
 
 	#getCredentialCached_UC(
-		userId: number,
 		type: UserCredentialType,
 		slot: number,
 	): CredentialData | undefined {
-		if (slot !== 1) return undefined;
+		if (type !== this.#ucCredentialType) return undefined;
+		// For User Code CC, credential slots and users are identical
 		const status = this.getValue<UserIDStatus>(
-			UserCodeCCValues.userIdStatus(userId).endpoint(
+			UserCodeCCValues.userIdStatus(slot).endpoint(
 				this.endpoint.index,
 			),
 		);
@@ -1141,9 +1533,9 @@ export class AccessControlAPI extends FeatureAPI {
 			return undefined;
 		}
 		const data = this.getValue<string>(
-			UserCodeCCValues.userCode(userId).endpoint(this.endpoint.index),
+			UserCodeCCValues.userCode(slot).endpoint(this.endpoint.index),
 		);
 		if (data == undefined) return undefined;
-		return { userId, type, slot, data };
+		return { userId: slot, type, slot, data };
 	}
 }

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -343,6 +343,7 @@ export class AccessControlAPI extends FeatureAPI {
 		if (this.#usesUserCredentialCC) {
 			const api = this.#u3cAPI();
 			const result = await api.getUser(userId);
+			if (result) await this.endpoint.tryGetNode()?.handleCommand(result);
 			if (!result?.userId) return undefined;
 			return {
 				userId: result.userId,
@@ -388,6 +389,9 @@ export class AccessControlAPI extends FeatureAPI {
 			let nextUserId = 0;
 			do {
 				const result = await api.getUser(nextUserId);
+				if (result) {
+					await this.endpoint.tryGetNode()?.handleCommand(result);
+				}
 				if (!result?.userId) break;
 				users.push({
 					userId: result.userId,
@@ -686,6 +690,7 @@ export class AccessControlAPI extends FeatureAPI {
 
 		if (this.#usesUserCredentialCC) {
 			const result = await this.#u3cAPI().getCredential(0, type, slot);
+			if (result) await this.endpoint.tryGetNode()?.handleCommand(result);
 			return this.#mapCredentialData(result);
 		} else {
 			const api = this.#ucAPI();
@@ -1328,6 +1333,7 @@ export class AccessControlAPI extends FeatureAPI {
 				queryType,
 				querySlot,
 			);
+			if (result) await this.endpoint.tryGetNode()?.handleCommand(result);
 			const credential = this.#mapCredentialData(result);
 			// No credential means the walk is exhausted or the current selector did
 			// not resolve to a valid entry on this node.
@@ -1527,12 +1533,14 @@ export class AccessControlAPI extends FeatureAPI {
 		const owner = this.#getCredentialOwner_U3C(type, slot);
 		if (owner == undefined) return undefined;
 
+		// When credentialReadBack is false, the node never returns credential
+		// data. In that case, we still know the slot is occupied and to which
+		// user it belongs, and return the credential without data.
 		const data = this.getValue<string | Uint8Array>(
 			UserCredentialCCValues.credential(type, slot).endpoint(
 				this.endpoint.index,
 			),
 		);
-		if (data == undefined) return undefined;
 		return { userId: owner, type, slot, data };
 	}
 

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -276,7 +276,7 @@ export class AccessControlAPI extends FeatureAPI {
 					expiringTimeoutMinutes: result.expiringTimeoutMinutes
 						|| undefined,
 				});
-				nextUserId = result.nextUserId;
+				nextUserId = result.nextUserId ?? 0;
 			} while (nextUserId > 0);
 			return users;
 		} else {
@@ -559,10 +559,12 @@ export class AccessControlAPI extends FeatureAPI {
 				userId: result.userId,
 				type: result.credentialType,
 				slot: result.credentialSlot,
-				data: normalizeCredentialData(
-					result.credentialType,
-					result.credentialData,
-				),
+				data: result.credentialData != undefined
+					? normalizeCredentialData(
+						result.credentialType,
+						result.credentialData,
+					)
+					: undefined,
 			};
 		} else {
 			const api = this.#ucAPI();
@@ -618,13 +620,16 @@ export class AccessControlAPI extends FeatureAPI {
 					userId: result.userId,
 					type: result.credentialType,
 					slot: result.credentialSlot,
-					data: normalizeCredentialData(
-						result.credentialType,
-						result.credentialData,
-					),
+					data: result.credentialData != undefined
+						? normalizeCredentialData(
+							result.credentialType,
+							result.credentialData,
+						)
+						: undefined,
 				});
-				nextCredType = result.nextCredentialType;
-				nextCredSlot = result.nextCredentialSlot;
+				nextCredType = result.nextCredentialType
+					?? UserCredentialType.None;
+				nextCredSlot = result.nextCredentialSlot ?? 0;
 			} while (
 				nextCredType !== UserCredentialType.None
 				|| nextCredSlot !== 0

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -10,6 +10,7 @@ import { type UserCodeCCAPI, UserCodeCCValues } from "@zwave-js/cc/UserCodeCC";
 import {
 	type UserCredentialCCAPI,
 	UserCredentialCCValues,
+	normalizeCredentialData,
 } from "@zwave-js/cc/UserCredentialCC";
 import {
 	CommandClasses,
@@ -558,7 +559,10 @@ export class AccessControlAPI extends FeatureAPI {
 				userId: result.userId,
 				type: result.credentialType,
 				slot: result.credentialSlot,
-				data: result.credentialData,
+				data: normalizeCredentialData(
+					result.credentialType,
+					result.credentialData,
+				),
 			};
 		} else {
 			const api = this.#ucAPI();
@@ -614,7 +618,10 @@ export class AccessControlAPI extends FeatureAPI {
 					userId: result.userId,
 					type: result.credentialType,
 					slot: result.credentialSlot,
-					data: result.credentialData,
+					data: normalizeCredentialData(
+						result.credentialType,
+						result.credentialData,
+					),
 				});
 				nextCredType = result.nextCredentialType;
 				nextCredSlot = result.nextCredentialSlot;
@@ -1091,7 +1098,7 @@ export class AccessControlAPI extends FeatureAPI {
 		type: UserCredentialType,
 		slot: number,
 	): CredentialData | undefined {
-		const data = this.getValue<Uint8Array>(
+		const data = this.getValue<string | Uint8Array>(
 			UserCredentialCCValues.credential(userId, type, slot).endpoint(
 				this.endpoint.index,
 			),

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -1,5 +1,6 @@
 import {
 	type UserCredentialCapability,
+	UserCredentialCommand,
 	UserCredentialCredentialReportType,
 	UserCredentialOperationType,
 	UserCredentialRule,
@@ -11,10 +12,9 @@ import {
 import { type UserCodeCCAPI, UserCodeCCValues } from "@zwave-js/cc/UserCodeCC";
 import {
 	type UserCredentialCCAPI,
+	type UserCredentialCCAssociationReport,
 	type UserCredentialCCCredentialReport,
-	type UserCredentialCCCredentialSetResult,
 	type UserCredentialCCUserReport,
-	type UserCredentialCCUserSetResult,
 	UserCredentialCCValues,
 	normalizeCredentialData,
 } from "@zwave-js/cc/UserCredentialCC";
@@ -26,10 +26,6 @@ import {
 	supervisedCommandSucceeded,
 } from "@zwave-js/core";
 import { Bytes, getEnumMemberName } from "@zwave-js/shared";
-import {
-	handleUserCredentialCredentialReport,
-	handleUserCredentialUserReport,
-} from "../CCHandlers/UserCredentialCC.js";
 import { FeatureAPI } from "./FeatureAPI.js";
 
 export interface UserCapabilities {
@@ -46,6 +42,11 @@ export interface CredentialCapabilities {
 	>;
 	supportsAdminCode: boolean;
 	supportsAdminCodeDeactivation: boolean;
+	/**
+	 * Whether existing credentials can be reassigned between users via
+	 * {@link AccessControlAPI.assignCredential} without re-enrolling them.
+	 */
+	supportsCredentialAssignment: boolean;
 }
 
 export interface UserData {
@@ -96,11 +97,21 @@ export enum SetCredentialStatus {
 	Error_Unknown = 0xff,
 }
 
+/** Result status of an assignCredential call */
+export enum AssignCredentialStatus {
+	OK = 0,
+	/** Spec statuses 0x01 / 0x02 / 0x03 — credential type / slot invalid or empty */
+	Error_InvalidCredential = 1,
+	/** Spec statuses 0x04 / 0x05 — destination user invalid or nonexistent */
+	Error_InvalidUser = 2,
+	Error_Unknown = 0xff,
+}
+
 function u3cUserSetResultToStatus(
-	result: UserCredentialCCUserSetResult | undefined,
+	report: UserCredentialCCUserReport | undefined,
 ): SetUserStatus {
-	if (!result) return SetUserStatus.Error_Unknown;
-	switch (result.reportType) {
+	if (!report) return SetUserStatus.Error_Unknown;
+	switch (report.reportType) {
 		case UserCredentialUserReportType.UserAdded:
 		case UserCredentialUserReportType.UserModified:
 		case UserCredentialUserReportType.UserDeleted:
@@ -116,10 +127,10 @@ function u3cUserSetResultToStatus(
 }
 
 function u3cCredentialSetResultToStatus(
-	result: UserCredentialCCCredentialSetResult | undefined,
+	report: UserCredentialCCCredentialReport | undefined,
 ): SetCredentialStatus {
-	if (!result) return SetCredentialStatus.Error_Unknown;
-	switch (result.reportType) {
+	if (!report) return SetCredentialStatus.Error_Unknown;
+	switch (report.reportType) {
 		case UserCredentialCredentialReportType.CredentialAdded:
 		case UserCredentialCredentialReportType.CredentialModified:
 		case UserCredentialCredentialReportType.CredentialDeleted:
@@ -144,35 +155,23 @@ function u3cCredentialSetResultToStatus(
 	}
 }
 
-/**
- * Dispatches event emission for a UserReport received as a response to a UserSet
- * command. Normally the driver's handleCommand pipeline emits events for
- * unsolicited reports, but responses matched to a pending transaction bypass that
- * path. Re-invoke the handler here so applications observe the same events
- * regardless of whether the report arrived as a response or unsolicited.
- */
-function emitUserSetEvent(
-	endpoint: FeatureAPI["endpoint"],
-	result: UserCredentialCCUserSetResult,
-): void {
-	const node = endpoint.tryGetNode();
-	if (!node) return;
-	handleUserCredentialUserReport(
-		node,
-		result as unknown as UserCredentialCCUserReport,
-	);
-}
-
-function emitCredentialSetEvent(
-	endpoint: FeatureAPI["endpoint"],
-	result: UserCredentialCCCredentialSetResult,
-): void {
-	const node = endpoint.tryGetNode();
-	if (!node) return;
-	handleUserCredentialCredentialReport(
-		node,
-		result as unknown as UserCredentialCCCredentialReport,
-	);
+function u3cAssociationResultToStatus(
+	report: UserCredentialCCAssociationReport | undefined,
+): AssignCredentialStatus {
+	if (!report) return AssignCredentialStatus.Error_Unknown;
+	switch (report.status) {
+		case 0x00:
+			return AssignCredentialStatus.OK;
+		case 0x01:
+		case 0x02:
+		case 0x03:
+			return AssignCredentialStatus.Error_InvalidCredential;
+		case 0x04:
+		case 0x05:
+			return AssignCredentialStatus.Error_InvalidUser;
+		default:
+			return AssignCredentialStatus.Error_Unknown;
+	}
 }
 
 const NON_PIN_CHARS = /[^0-9]/;
@@ -290,6 +289,9 @@ export class AccessControlAPI extends FeatureAPI {
 					UserCredentialCCValues.supportsAdminCodeDeactivation
 						.endpoint(this.endpoint.index),
 				) ?? false,
+				supportsCredentialAssignment: this.#u3cAPI().supportsCommand(
+					UserCredentialCommand.UserCredentialAssociationSet,
+				) === true,
 			};
 		} else {
 			const maxUsers = this.getValue<number>(
@@ -327,6 +329,8 @@ export class AccessControlAPI extends FeatureAPI {
 						this.endpoint.index,
 					),
 				) ?? false,
+				// User Code CC has no equivalent to credential reassignment
+				supportsCredentialAssignment: false,
 			};
 		}
 	}
@@ -491,7 +495,7 @@ export class AccessControlAPI extends FeatureAPI {
 				?? existing?.userType
 				?? UserCredentialUserType.General;
 
-			let result: UserCredentialCCUserSetResult | undefined;
+			let result: UserCredentialCCUserReport | undefined;
 			if (userType === UserCredentialUserType.Expiring) {
 				result = await api.setUser({
 					operationType,
@@ -517,7 +521,7 @@ export class AccessControlAPI extends FeatureAPI {
 				});
 			}
 
-			if (result) emitUserSetEvent(this.endpoint, result);
+			if (result) await this.endpoint.tryGetNode()?.handleCommand(result);
 			return u3cUserSetResultToStatus(result);
 		} else {
 			const api = this.#ucAPI();
@@ -601,7 +605,7 @@ export class AccessControlAPI extends FeatureAPI {
 				operationType: UserCredentialOperationType.Delete,
 				userId,
 			});
-			if (raw) emitUserSetEvent(this.endpoint, raw);
+			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
 			const status = u3cUserSetResultToStatus(raw);
 			if (status === SetUserStatus.OK) {
 				this.#purgeCachedCredentials(userId);
@@ -649,7 +653,7 @@ export class AccessControlAPI extends FeatureAPI {
 				operationType: UserCredentialOperationType.Delete,
 				userId: 0,
 			});
-			if (raw) emitUserSetEvent(this.endpoint, raw);
+			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
 			const status = u3cUserSetResultToStatus(raw);
 			if (status === SetUserStatus.OK) {
 				this.#purgeAllCachedUsersAndCredentials();
@@ -875,7 +879,7 @@ export class AccessControlAPI extends FeatureAPI {
 				credentialSlot: slot,
 				credentialData,
 			});
-			if (raw) emitCredentialSetEvent(this.endpoint, raw);
+			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
 			return u3cCredentialSetResultToStatus(raw);
 		} else {
 			// User Code CC stores exactly one credential per user slot. Ignore the
@@ -959,7 +963,7 @@ export class AccessControlAPI extends FeatureAPI {
 				credentialType: type,
 				credentialSlot: slot,
 			});
-			if (raw) emitCredentialSetEvent(this.endpoint, raw);
+			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
 			return u3cCredentialSetResultToStatus(raw);
 		} else {
 			// User Code CC stores exactly one credential per user slot. Ignore the
@@ -995,6 +999,44 @@ export class AccessControlAPI extends FeatureAPI {
 				? SetCredentialStatus.OK
 				: SetCredentialStatus.Error_Unknown;
 		}
+	}
+
+	/**
+	 * Assigns an existing credential to a different user, without re-enrolling
+	 * it. Useful for credentials that were added locally on the device (e.g. a
+	 * biometric auto-assigned to a fresh user) that need to be attached to an
+	 * existing user which already has other credentials.
+	 *
+	 * Only supported on nodes using the User Credential CC. Use
+	 * {@link getCredentialCapabilitiesCached} to check for support via the
+	 * `supportsCredentialAssignment` property.
+	 *
+	 * This communicates with the node.
+	 */
+	public async assignCredential(
+		type: UserCredentialType,
+		slot: number,
+		destinationUserId: number,
+	): Promise<AssignCredentialStatus> {
+		if (!this.#usesUserCredentialCC) {
+			throw new ZWaveError(
+				"This node does not support assigning a credential to a different user",
+				ZWaveErrorCodes.CC_NotSupported,
+			);
+		}
+
+		this.#assertValidSlot(type, slot);
+
+		const api = this.#u3cAPI();
+		const response = await api.setUserCredentialAssociation({
+			credentialType: type,
+			credentialSlot: slot,
+			destinationUserId,
+		});
+		if (response) {
+			await this.endpoint.tryGetNode()?.handleCommand(response);
+		}
+		return u3cAssociationResultToStatus(response);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/UserCredential.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/UserCredential.ts
@@ -94,10 +94,9 @@ const STATE_KEY_PREFIX = "UserCredential_";
 const StateKeys = {
 	user: (userId: number) => `${STATE_KEY_PREFIX}user_${userId}`,
 	credential: (
-		userId: number,
 		credentialType: UserCredentialType,
 		credentialSlot: number,
-	) => `${STATE_KEY_PREFIX}cred_${userId}_${credentialType}_${credentialSlot}`,
+	) => `${STATE_KEY_PREFIX}cred_${credentialType}_${credentialSlot}`,
 	adminPinCode: `${STATE_KEY_PREFIX}adminPinCode`,
 	keyLockerEntry: (
 		entryType: UserCredentialKeyLockerEntryType,
@@ -121,6 +120,7 @@ interface UserState {
 }
 
 interface CredentialState {
+	userId: number;
 	credentialData: Bytes;
 	modifierType: UserCredentialModifierType;
 	modifierNodeId: number;
@@ -176,8 +176,22 @@ function getCredential(
 	credentialType: UserCredentialType,
 	credentialSlot: number,
 ): CredentialState | undefined {
+	const credential = getCredentialByTypeAndSlot(
+		self,
+		credentialType,
+		credentialSlot,
+	);
+	if (credential?.userId !== userId) return undefined;
+	return credential;
+}
+
+function getCredentialByTypeAndSlot(
+	self: MockNode,
+	credentialType: UserCredentialType,
+	credentialSlot: number,
+): CredentialState | undefined {
 	return self.state.get(
-		StateKeys.credential(userId, credentialType, credentialSlot),
+		StateKeys.credential(credentialType, credentialSlot),
 	) as CredentialState | undefined;
 }
 
@@ -186,11 +200,14 @@ function setCredential(
 	userId: number,
 	credentialType: UserCredentialType,
 	credentialSlot: number,
-	data: CredentialState,
+	data: Omit<CredentialState, "userId">,
 ): void {
 	self.state.set(
-		StateKeys.credential(userId, credentialType, credentialSlot),
-		data,
+		StateKeys.credential(credentialType, credentialSlot),
+		{
+			userId,
+			...data,
+		},
 	);
 }
 
@@ -200,9 +217,13 @@ function deleteCredential(
 	credentialType: UserCredentialType,
 	credentialSlot: number,
 ): void {
-	self.state.delete(
-		StateKeys.credential(userId, credentialType, credentialSlot),
-	);
+	if (
+		getCredential(self, userId, credentialType, credentialSlot)
+			== undefined
+	) {
+		return;
+	}
+	self.state.delete(StateKeys.credential(credentialType, credentialSlot));
 }
 
 /** Get sorted list of all occupied user IDs. */
@@ -245,34 +266,33 @@ interface CredentialRef {
 	credentialSlot: number;
 }
 
-/** Get all credentials, sorted ascending by userId, credentialType, credentialSlot. */
+/** Get all credentials, sorted ascending by credentialType and credentialSlot. */
 function getAllCredentials(
 	self: MockNode,
 	capabilities: UserCredentialCCCapabilities,
 ): CredentialRef[] {
 	const result: CredentialRef[] = [];
-	const allUserIds = getAllUserIds(self, capabilities);
-	for (const userId of allUserIds) {
+	for (
+		const [credentialType, typeCapabilities] of capabilities
+			.supportedCredentialTypes
+	) {
 		for (
-			const [credentialType, typeCapabilities] of capabilities
-				.supportedCredentialTypes
+			let slot = 1;
+			slot <= typeCapabilities.numberOfCredentialSlots;
+			slot++
 		) {
-			for (
-				let slot = 1;
-				slot <= typeCapabilities.numberOfCredentialSlots;
-				slot++
-			) {
-				if (
-					getCredential(self, userId, credentialType, slot)
-						!== undefined
-				) {
-					result.push({
-						userId,
-						credentialType,
-						credentialSlot: slot,
-					});
-				}
-			}
+			const credential = getCredentialByTypeAndSlot(
+				self,
+				credentialType,
+				slot,
+			);
+			if (credential == undefined) continue;
+
+			result.push({
+				userId: credential.userId,
+				credentialType,
+				credentialSlot: slot,
+			});
 		}
 	}
 	return result;
@@ -465,9 +485,7 @@ function buildCredentialChecksumData(
 	capabilities: UserCredentialCCCapabilities,
 ): Bytes {
 	const allCreds = getAllCredentials(self, capabilities)
-		.filter((c) => c.credentialType === credentialType)
-		// Sort by slot ascending (getAllCredentials already sorts by slot within type)
-		.toSorted((a, b) => a.credentialSlot - b.credentialSlot);
+		.filter((c) => c.credentialType === credentialType);
 
 	const parts: Bytes[] = [];
 	for (const ref of allCreds) {
@@ -1587,6 +1605,11 @@ const respondToCredentialSet: MockNodeBehavior = {
 			credentialType,
 			credentialSlot,
 		);
+		const occupiedCred = getCredentialByTypeAndSlot(
+			self,
+			credentialType,
+			credentialSlot,
+		);
 
 		// Verify the user exists for Add/Modify
 		const user = getUser(self, userId);
@@ -1611,17 +1634,17 @@ const respondToCredentialSet: MockNodeBehavior = {
 		}
 
 		if (operationType === UserCredentialOperationType.Add) {
-			if (existingCred) {
+			if (occupiedCred) {
 				// Slot occupied — reject
 				const report = makeReport(
 					UserCredentialCredentialReportType
 						.CredentialAddRejectedLocationOccupied,
-					userId,
+					occupiedCred.userId,
 					credentialType,
 					credentialSlot,
-					existingCred.credentialData,
-					existingCred.modifierType,
-					existingCred.modifierNodeId,
+					occupiedCred.credentialData,
+					occupiedCred.modifierType,
+					occupiedCred.modifierNodeId,
 				);
 				await self.sendToController(
 					createMockZWaveRequestFrame(report, {
@@ -1631,7 +1654,7 @@ const respondToCredentialSet: MockNodeBehavior = {
 				return { action: "fail" };
 			}
 		} else if (operationType === UserCredentialOperationType.Modify) {
-			if (!existingCred) {
+			if (!occupiedCred) {
 				// Slot empty — reject
 				const report = makeReport(
 					UserCredentialCredentialReportType
@@ -1642,6 +1665,24 @@ const respondToCredentialSet: MockNodeBehavior = {
 					new Bytes(),
 					UserCredentialModifierType.DoesNotExist,
 					0,
+				);
+				await self.sendToController(
+					createMockZWaveRequestFrame(report, {
+						ackRequested: false,
+					}),
+				);
+				return { action: "fail" };
+			}
+			if (occupiedCred.userId !== userId) {
+				const report = makeReport(
+					UserCredentialCredentialReportType
+						.WrongUserUniqueIdentifier,
+					occupiedCred.userId,
+					credentialType,
+					credentialSlot,
+					occupiedCred.credentialData,
+					occupiedCred.modifierType,
+					occupiedCred.modifierNodeId,
 				);
 				await self.sendToController(
 					createMockZWaveRequestFrame(report, {
@@ -2194,18 +2235,11 @@ const respondToUserCredentialAssociationSet: MockNodeBehavior = {
 		}
 
 		// Move: delete from source user, add to destination user
-		const credState = getCredential(
+		const credState = getCredentialByTypeAndSlot(
 			self,
-			credRef.userId,
 			credentialType,
 			credentialSlot,
 		)!;
-		deleteCredential(
-			self,
-			credRef.userId,
-			credentialType,
-			credentialSlot,
-		);
 		setCredential(self, destinationUserId, credentialType, credentialSlot, {
 			credentialData: credState.credentialData,
 			modifierType: UserCredentialModifierType.ZWave,

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/UserCredential.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/UserCredential.ts
@@ -762,7 +762,6 @@ const respondToUserSet: MockNodeBehavior = {
 				const report = new UserCredentialCCUserReport({
 					nodeId: controller.ownNodeId,
 					reportType: UserCredentialUserReportType.UserDeleted,
-					nextUserId: 0,
 					userId: 0,
 					modifierType: UserCredentialModifierType.ZWave,
 					modifierNodeId: controller.ownNodeId,
@@ -796,7 +795,6 @@ const respondToUserSet: MockNodeBehavior = {
 			const report = new UserCredentialCCUserReport({
 				nodeId: controller.ownNodeId,
 				reportType: UserCredentialUserReportType.UserDeleted,
-				nextUserId: findNextUserId(self, userId, capabilities),
 				userId,
 				modifierType: UserCredentialModifierType.ZWave,
 				modifierNodeId: controller.ownNodeId,
@@ -865,7 +863,6 @@ const respondToUserSet: MockNodeBehavior = {
 					nodeId: controller.ownNodeId,
 					reportType: UserCredentialUserReportType
 						.UserAddRejectedLocationOccupied,
-					nextUserId: findNextUserId(self, userId, capabilities),
 					userId,
 					modifierType: existingUser.modifierType,
 					modifierNodeId: existingUser.modifierNodeId,
@@ -890,7 +887,6 @@ const respondToUserSet: MockNodeBehavior = {
 					nodeId: controller.ownNodeId,
 					reportType: UserCredentialUserReportType
 						.UserModifyRejectedLocationEmpty,
-					nextUserId: findNextUserId(self, userId, capabilities),
 					userId,
 					modifierType: UserCredentialModifierType.DoesNotExist,
 					modifierNodeId: 0,
@@ -923,7 +919,6 @@ const respondToUserSet: MockNodeBehavior = {
 				nodeId: controller.ownNodeId,
 				reportType: UserCredentialUserReportType
 					.ZeroExpiringMinutesInvalid,
-				nextUserId: findNextUserId(self, userId, capabilities),
 				userId,
 				modifierType: existingUser?.modifierType
 					?? UserCredentialModifierType.DoesNotExist,
@@ -994,11 +989,6 @@ const respondToUserSet: MockNodeBehavior = {
 				const report = new UserCredentialCCUserReport({
 					nodeId: controller.ownNodeId,
 					reportType: UserCredentialUserReportType.UserUnchanged,
-					nextUserId: findNextUserId(
-						self,
-						userId,
-						capabilities,
-					),
 					userId,
 					modifierType: existingUser.modifierType,
 					modifierNodeId: existingUser.modifierNodeId,
@@ -1031,7 +1021,6 @@ const respondToUserSet: MockNodeBehavior = {
 		const report = new UserCredentialCCUserReport({
 			nodeId: controller.ownNodeId,
 			reportType,
-			nextUserId: findNextUserId(self, userId, capabilities),
 			userId,
 			modifierType: newUser.modifierType,
 			modifierNodeId: newUser.modifierNodeId,
@@ -1086,20 +1075,27 @@ const respondToCredentialGet: MockNodeBehavior = {
 				credentialSlot: number,
 				nextType: UserCredentialType,
 				nextSlot: number,
-			) => new UserCredentialCCCredentialReport({
-				nodeId: controller.ownNodeId,
-				reportType: UserCredentialCredentialReportType.ResponseToGet,
-				userId,
-				credentialType,
-				credentialSlot,
-				credentialReadBack: getCRB(credentialType),
-				credentialLength: 0,
-				credentialData: new Bytes(),
-				modifierType: UserCredentialModifierType.DoesNotExist,
-				modifierNodeId: 0,
-				nextCredentialType: nextType,
-				nextCredentialSlot: nextSlot,
-			});
+			) => {
+				const credentialReadBack = getCRB(credentialType);
+				return new UserCredentialCCCredentialReport({
+					nodeId: controller.ownNodeId,
+					reportType:
+						UserCredentialCredentialReportType.ResponseToGet,
+					userId,
+					credentialType,
+					credentialSlot,
+					...(credentialReadBack
+						? {
+							credentialReadBack: true,
+							credentialData: new Bytes(),
+						}
+						: { credentialReadBack: false }),
+					modifierType: UserCredentialModifierType.DoesNotExist,
+					modifierNodeId: 0,
+					nextCredentialType: nextType,
+					nextCredentialSlot: nextSlot,
+				});
+			};
 
 			// Helper to create a populated credential report
 			const populatedReport = (
@@ -1107,22 +1103,29 @@ const respondToCredentialGet: MockNodeBehavior = {
 				credState: CredentialState,
 				nextType: UserCredentialType,
 				nextSlot: number,
-			) => new UserCredentialCCCredentialReport({
-				nodeId: controller.ownNodeId,
-				reportType: UserCredentialCredentialReportType.ResponseToGet,
-				// CC:0083.01.0C.11.010: UUID MUST be set to the User
-				// associated with this credential.
-				userId: ref.userId,
-				credentialType: ref.credentialType,
-				credentialSlot: ref.credentialSlot,
-				credentialReadBack: getCRB(ref.credentialType),
-				credentialLength: credState.credentialData.length,
-				credentialData: credState.credentialData,
-				modifierType: credState.modifierType,
-				modifierNodeId: credState.modifierNodeId,
-				nextCredentialType: nextType,
-				nextCredentialSlot: nextSlot,
-			});
+			) => {
+				const credentialReadBack = getCRB(ref.credentialType);
+				return new UserCredentialCCCredentialReport({
+					nodeId: controller.ownNodeId,
+					reportType:
+						UserCredentialCredentialReportType.ResponseToGet,
+					// CC:0083.01.0C.11.010: UUID MUST be set to the User
+					// associated with this credential.
+					userId: ref.userId,
+					credentialType: ref.credentialType,
+					credentialSlot: ref.credentialSlot,
+					...(credentialReadBack
+						? {
+							credentialReadBack: true,
+							credentialData: credState.credentialData,
+						}
+						: { credentialReadBack: false }),
+					modifierType: credState.modifierType,
+					modifierNodeId: credState.modifierNodeId,
+					nextCredentialType: nextType,
+					nextCredentialSlot: nextSlot,
+				});
+			};
 
 			// Find the first credential matching a filter predicate
 			const findFirst = (
@@ -1451,27 +1454,31 @@ const respondToCredentialSet: MockNodeBehavior = {
 
 		// Helper to build a credential report for Set responses
 		const makeReport = (
-			reportType: UserCredentialCredentialReportType,
+			reportType: Exclude<
+				UserCredentialCredentialReportType,
+				UserCredentialCredentialReportType.ResponseToGet
+			>,
 			rUserId: number,
 			rType: UserCredentialType,
 			rSlot: number,
 			rData: Bytes,
 			rModType: UserCredentialModifierType,
 			rModNode: number,
-		) => new UserCredentialCCCredentialReport({
-			nodeId: controller.ownNodeId,
-			reportType,
-			userId: rUserId,
-			credentialType: rType,
-			credentialSlot: rSlot,
-			credentialReadBack: getCRB(rType),
-			credentialLength: rData.length,
-			credentialData: rData,
-			modifierType: rModType,
-			modifierNodeId: rModNode,
-			nextCredentialType: UserCredentialType.None,
-			nextCredentialSlot: 0,
-		});
+		) => {
+			const credentialReadBack = getCRB(rType);
+			return new UserCredentialCCCredentialReport({
+				nodeId: controller.ownNodeId,
+				reportType,
+				userId: rUserId,
+				credentialType: rType,
+				credentialSlot: rSlot,
+				...(credentialReadBack
+					? { credentialReadBack: true, credentialData: rData }
+					: { credentialReadBack: false }),
+				modifierType: rModType,
+				modifierNodeId: rModNode,
+			});
+		};
 
 		// --- Delete operations ---
 		if (operationType === UserCredentialOperationType.Delete) {

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/UserCredential.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/UserCredential.ts
@@ -16,6 +16,8 @@ import {
 	UserCredentialCCAdminPinCodeSet,
 	UserCredentialCCAllUsersChecksumGet,
 	UserCredentialCCAllUsersChecksumReport,
+	UserCredentialCCAssociationReport,
+	UserCredentialCCAssociationSet,
 	UserCredentialCCCredentialCapabilitiesGet,
 	UserCredentialCCCredentialCapabilitiesReport,
 	UserCredentialCCCredentialChecksumGet,
@@ -35,8 +37,6 @@ import {
 	UserCredentialCCUserCapabilitiesReport,
 	UserCredentialCCUserChecksumGet,
 	UserCredentialCCUserChecksumReport,
-	UserCredentialCCUserCredentialAssociationReport,
-	UserCredentialCCUserCredentialAssociationSet,
 	UserCredentialCCUserGet,
 	UserCredentialCCUserReport,
 	UserCredentialCCUserSet,
@@ -1778,6 +1778,7 @@ const respondToCredentialSet: MockNodeBehavior = {
 
 		// Store the credential
 		const newCred: CredentialState = {
+			userId,
 			credentialData,
 			// CC:0083.01.0C.11.030: When Modifier Type is Z-Wave, Node ID
 			// MUST be the sending node's ID.
@@ -2117,7 +2118,7 @@ const respondToUserCredentialAssociationSet: MockNodeBehavior = {
 	async handleCC(controller, self, receivedCC) {
 		if (
 			!(receivedCC
-				instanceof UserCredentialCCUserCredentialAssociationSet)
+				instanceof UserCredentialCCAssociationSet)
 		) return;
 
 		const setCC = receivedCC;
@@ -2129,7 +2130,7 @@ const respondToUserCredentialAssociationSet: MockNodeBehavior = {
 		// Validate credential type
 		if (!capabilities.supportedCredentialTypes.has(credentialType)) {
 			// CC:0083.01.13.11.000: Status 0x01 = Type Invalid
-			const report = new UserCredentialCCUserCredentialAssociationReport({
+			const report = new UserCredentialCCAssociationReport({
 				nodeId: controller.ownNodeId,
 				credentialType,
 				credentialSlot,
@@ -2153,7 +2154,7 @@ const respondToUserCredentialAssociationSet: MockNodeBehavior = {
 			|| credentialSlot > typeCaps.numberOfCredentialSlots
 		) {
 			// Status 0x02 = Slot Invalid
-			const report = new UserCredentialCCUserCredentialAssociationReport({
+			const report = new UserCredentialCCAssociationReport({
 				nodeId: controller.ownNodeId,
 				credentialType,
 				credentialSlot,
@@ -2178,7 +2179,7 @@ const respondToUserCredentialAssociationSet: MockNodeBehavior = {
 
 		if (!credRef) {
 			// Status 0x03 = Slot Empty
-			const report = new UserCredentialCCUserCredentialAssociationReport({
+			const report = new UserCredentialCCAssociationReport({
 				nodeId: controller.ownNodeId,
 				credentialType,
 				credentialSlot,
@@ -2199,7 +2200,7 @@ const respondToUserCredentialAssociationSet: MockNodeBehavior = {
 			|| destinationUserId > capabilities.numberOfSupportedUsers
 		) {
 			// Status 0x04 = Destination UUID Invalid
-			const report = new UserCredentialCCUserCredentialAssociationReport({
+			const report = new UserCredentialCCAssociationReport({
 				nodeId: controller.ownNodeId,
 				credentialType,
 				credentialSlot,
@@ -2219,7 +2220,7 @@ const respondToUserCredentialAssociationSet: MockNodeBehavior = {
 		const destUser = getUser(self, destinationUserId);
 		if (!destUser) {
 			// Status 0x05 = Destination UUID Nonexistent
-			const report = new UserCredentialCCUserCredentialAssociationReport({
+			const report = new UserCredentialCCAssociationReport({
 				nodeId: controller.ownNodeId,
 				credentialType,
 				credentialSlot,
@@ -2248,7 +2249,7 @@ const respondToUserCredentialAssociationSet: MockNodeBehavior = {
 
 		// CC:0083.01.13.11.000: Status 0x00 = Success
 		// CC:0083.01.13.11.002: MUST also be sent to Lifeline
-		const report = new UserCredentialCCUserCredentialAssociationReport({
+		const report = new UserCredentialCCAssociationReport({
 			nodeId: controller.ownNodeId,
 			credentialType,
 			credentialSlot,

--- a/packages/zwave-js/src/lib/test/cc-specific/userCredentialInterview.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/userCredentialInterview.test.ts
@@ -263,7 +263,8 @@ integrationTest(
 				modifierNodeId: 0,
 			});
 
-			mockNode.state.set("UserCredential_cred_1_1_1", {
+			mockNode.state.set("UserCredential_cred_1_1", {
+				userId: 1,
 				credentialData: Bytes.from("1234", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
@@ -280,7 +281,8 @@ integrationTest(
 				modifierNodeId: 0,
 			});
 
-			mockNode.state.set("UserCredential_cred_3_1_2", {
+			mockNode.state.set("UserCredential_cred_1_2", {
+				userId: 3,
 				credentialData: Bytes.from("5678", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
@@ -305,12 +307,19 @@ integrationTest(
 			t.expect(
 				node.getValue(
 					UserCredentialCCValues.credential(
-						1,
 						UserCredentialType.PINCode,
 						1,
 					).endpoint(0),
 				),
 			).toBeDefined();
+			t.expect(
+				node.getValue(
+					UserCredentialCCValues.credentialOwner(
+						UserCredentialType.PINCode,
+						1,
+					).endpoint(0),
+				),
+			).toBe(1);
 
 			// User 3 should be discovered (gap at user 2)
 			t.expect(
@@ -329,12 +338,19 @@ integrationTest(
 			t.expect(
 				node.getValue(
 					UserCredentialCCValues.credential(
-						3,
 						UserCredentialType.PINCode,
 						2,
 					).endpoint(0),
 				),
 			).toBeDefined();
+			t.expect(
+				node.getValue(
+					UserCredentialCCValues.credentialOwner(
+						UserCredentialType.PINCode,
+						2,
+					).endpoint(0),
+				),
+			).toBe(3);
 		},
 	},
 );
@@ -500,7 +516,8 @@ integrationTest(
 				modifierNodeId: 0,
 			});
 
-			mockNode.state.set("UserCredential_cred_1_1_1", {
+			mockNode.state.set("UserCredential_cred_1_1", {
+				userId: 1,
 				credentialData: Bytes.from("1234", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
@@ -583,7 +600,8 @@ integrationTest(
 				modifierNodeId: 0,
 			});
 
-			mockNode.state.set("UserCredential_cred_1_1_1", {
+			mockNode.state.set("UserCredential_cred_1_1", {
+				userId: 1,
 				credentialData: Bytes.from("1234", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
@@ -712,14 +730,16 @@ integrationTest(
 			});
 
 			// PIN code credential
-			mockNode.state.set("UserCredential_cred_1_1_1", {
+			mockNode.state.set("UserCredential_cred_1_1", {
+				userId: 1,
 				credentialData: Bytes.from("1234", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
 			});
 
 			// Password credential
-			mockNode.state.set("UserCredential_cred_1_2_1", {
+			mockNode.state.set("UserCredential_cred_2_1", {
+				userId: 1,
 				credentialData: Bytes.from("password", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
@@ -731,7 +751,6 @@ integrationTest(
 			t.expect(
 				node.getValue(
 					UserCredentialCCValues.credential(
-						1,
 						UserCredentialType.PINCode,
 						1,
 					).endpoint(0),
@@ -742,7 +761,6 @@ integrationTest(
 			t.expect(
 				node.getValue(
 					UserCredentialCCValues.credential(
-						1,
 						UserCredentialType.Password,
 						1,
 					).endpoint(0),
@@ -918,13 +936,15 @@ integrationTest(
 			});
 
 			// Two PIN code credentials in slots 1 and 3 (gap at 2)
-			mockNode.state.set("UserCredential_cred_1_1_1", {
+			mockNode.state.set("UserCredential_cred_1_1", {
+				userId: 1,
 				credentialData: Bytes.from("1234", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
 			});
 
-			mockNode.state.set("UserCredential_cred_1_1_3", {
+			mockNode.state.set("UserCredential_cred_1_3", {
+				userId: 1,
 				credentialData: Bytes.from("5678", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
@@ -936,7 +956,6 @@ integrationTest(
 			t.expect(
 				node.getValue(
 					UserCredentialCCValues.credential(
-						1,
 						UserCredentialType.PINCode,
 						1,
 					).endpoint(0),
@@ -946,7 +965,6 @@ integrationTest(
 			t.expect(
 				node.getValue(
 					UserCredentialCCValues.credential(
-						1,
 						UserCredentialType.PINCode,
 						3,
 					).endpoint(0),
@@ -957,7 +975,6 @@ integrationTest(
 			t.expect(
 				node.getValue(
 					UserCredentialCCValues.credential(
-						1,
 						UserCredentialType.PINCode,
 						2,
 					).endpoint(0),
@@ -1017,7 +1034,8 @@ integrationTest(
 				modifierNodeId: 0,
 			});
 
-			mockNode.state.set("UserCredential_cred_2_1_1", {
+			mockNode.state.set("UserCredential_cred_1_1", {
+				userId: 2,
 				credentialData: Bytes.from("1111", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
@@ -1035,7 +1053,8 @@ integrationTest(
 				modifierNodeId: 0,
 			});
 
-			mockNode.state.set("UserCredential_cred_5_1_1", {
+			mockNode.state.set("UserCredential_cred_1_2", {
+				userId: 5,
 				credentialData: Bytes.from("5555", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
@@ -1060,22 +1079,36 @@ integrationTest(
 			t.expect(
 				node.getValue(
 					UserCredentialCCValues.credential(
-						2,
 						UserCredentialType.PINCode,
 						1,
 					).endpoint(0),
 				),
 			).toBeDefined();
+			t.expect(
+				node.getValue(
+					UserCredentialCCValues.credentialOwner(
+						UserCredentialType.PINCode,
+						1,
+					).endpoint(0),
+				),
+			).toBe(2);
 
 			t.expect(
 				node.getValue(
 					UserCredentialCCValues.credential(
-						5,
 						UserCredentialType.PINCode,
-						1,
+						2,
 					).endpoint(0),
 				),
 			).toBeDefined();
+			t.expect(
+				node.getValue(
+					UserCredentialCCValues.credentialOwner(
+						UserCredentialType.PINCode,
+						2,
+					).endpoint(0),
+				),
+			).toBe(5);
 
 			// User Get commands should have been sent during the interview
 			mockNode.assertReceivedControllerFrame(

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -69,7 +69,7 @@ integrationTest(
 				UserCredentialType.PINCode,
 			);
 			t.expect(pinCap).toBeDefined();
-			t.expect(pinCap!.numberOfCredentialSlots).toBe(1);
+			t.expect(pinCap!.numberOfCredentialSlots).toBe(10);
 			t.expect(pinCap!.minCredentialLength).toBe(4);
 			t.expect(pinCap!.maxCredentialLength).toBe(10);
 			t.expect(pinCap!.supportsCredentialLearn).toBe(false);
@@ -178,7 +178,7 @@ integrationTest(
 );
 
 integrationTest(
-	"getCredentialsCached maps each User Code CC user to a single PINCode credential",
+	"getCredentialsForUserCached maps each User Code CC user to a single PINCode credential",
 	{
 		nodeCapabilities: {
 			commandClasses: [
@@ -203,15 +203,44 @@ integrationTest(
 				UserIDStatus.Enabled,
 			);
 			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(2).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "5678");
 
-			const creds = node.accessControl.getCredentialsCached(1);
+			const creds = node.accessControl.getCredentialsForUserCached(1);
 			t.expect(creds.length).toBe(1);
 			t.expect(creds[0].type).toBe(UserCredentialType.PINCode);
 			t.expect(creds[0].slot).toBe(1);
 			t.expect(creds[0].data).toBe("1234");
 
+			t.expect(
+				node.accessControl.getCredentialCached(
+					UserCredentialType.PINCode,
+					2,
+				),
+			).toMatchObject({
+				userId: 2,
+				type: UserCredentialType.PINCode,
+				slot: 2,
+				data: "5678",
+			});
+			t.expect(
+				node.accessControl.getCredentialsForUserCached(2)[0].slot,
+			).toBe(2);
+			t.expect(
+				node.accessControl.getCredentialsByTypeCached(
+					UserCredentialType.PINCode,
+				).length,
+			).toBe(2);
+			t.expect(node.accessControl.getAllCredentialsCached().length).toBe(
+				2,
+			);
+
 			// Non-existent user has no credentials
-			t.expect(node.accessControl.getCredentialsCached(2).length).toBe(0);
+			t.expect(node.accessControl.getCredentialsForUserCached(3).length)
+				.toBe(0);
 		},
 	},
 );
@@ -247,16 +276,16 @@ integrationTest(
 			);
 
 			await node.accessControl.setCredential(
-				1,
+				2,
 				UserCredentialType.PINCode,
-				1,
+				2,
 				"1234",
 			);
 
 			t.expect(await credEvent).toMatchObject({
-				userId: 1,
+				userId: 2,
 				credentialType: UserCredentialType.PINCode,
-				credentialSlot: 1,
+				credentialSlot: 2,
 				data: "1234",
 			});
 		},
@@ -283,12 +312,12 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			// Pre-populate user 1
+			// Pre-populate user 2
 			node.valueDB.setValue(
-				UserCodeCCValues.userIdStatus(1).id,
+				UserCodeCCValues.userIdStatus(2).id,
 				UserIDStatus.Enabled,
 			);
-			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
+			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "1234");
 
 			const credEvent = createDeferredPromise<unknown>();
 			node.on(
@@ -297,16 +326,16 @@ integrationTest(
 			);
 
 			await node.accessControl.setCredential(
-				1,
+				2,
 				UserCredentialType.PINCode,
-				1,
+				2,
 				"5678",
 			);
 
 			t.expect(await credEvent).toMatchObject({
-				userId: 1,
+				userId: 2,
 				credentialType: UserCredentialType.PINCode,
-				credentialSlot: 1,
+				credentialSlot: 2,
 				data: "5678",
 			});
 		},
@@ -419,9 +448,9 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			await node.accessControl.setCredential(
-				1,
+				2,
 				UserCredentialType.PINCode,
-				1,
+				2,
 				"1234",
 			);
 
@@ -429,12 +458,12 @@ integrationTest(
 				(frame) =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof UserCodeCCExtendedUserCodeSet
-					&& frame.payload.userCodes[0].userId === 1
+					&& frame.payload.userCodes[0].userId === 2
 					&& frame.payload.userCodes[0].userIdStatus
 						=== UserIDStatus.Enabled,
 				{
 					errorMessage:
-						"Should have sent ExtendedUserCodeSet for userId 1 with Enabled status",
+						"Should have sent ExtendedUserCodeSet for userId 2 with Enabled status",
 				},
 			);
 		},
@@ -462,9 +491,9 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			await node.accessControl.setCredential(
-				1,
+				2,
 				UserCredentialType.PINCode,
-				1,
+				2,
 				"5678",
 			);
 
@@ -541,12 +570,12 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			// Pre-populate user 1
+			// Pre-populate user 2
 			node.valueDB.setValue(
-				UserCodeCCValues.userIdStatus(1).id,
+				UserCodeCCValues.userIdStatus(2).id,
 				UserIDStatus.Enabled,
 			);
-			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
+			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "1234");
 
 			const credEvent = createDeferredPromise<unknown>();
 			node.on(
@@ -555,15 +584,15 @@ integrationTest(
 			);
 
 			await node.accessControl.deleteCredential(
-				1,
+				2,
 				UserCredentialType.PINCode,
-				1,
+				2,
 			);
 
 			t.expect(await credEvent).toMatchObject({
-				userId: 1,
+				userId: 2,
 				credentialType: UserCredentialType.PINCode,
-				credentialSlot: 1,
+				credentialSlot: 2,
 			});
 		},
 	},
@@ -833,6 +862,100 @@ integrationTest(
 						"Should have sent ExtendedUserCodeSet for userId 1 with Available status",
 				},
 			);
+		},
+	},
+);
+
+// =============================================================================
+// Credential slot values other than the user ID are ignored
+// =============================================================================
+
+integrationTest(
+	"setCredential ignores slot !== userId and emits event with slot = userId",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const credEvent = createDeferredPromise<unknown>();
+			node.on(
+				"credential added",
+				(_node, args) => credEvent.resolve(args),
+			);
+
+			await node.accessControl.setCredential(
+				2,
+				UserCredentialType.PINCode,
+				99,
+				"1234",
+			);
+
+			t.expect(await credEvent).toMatchObject({
+				userId: 2,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 2,
+				data: "1234",
+			});
+		},
+	},
+);
+
+integrationTest(
+	"deleteCredential ignores slot !== userId and deletes the user's credential",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(2).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "1234");
+
+			const credEvent = createDeferredPromise<unknown>();
+			node.on(
+				"credential deleted",
+				(_node, args) => credEvent.resolve(args),
+			);
+
+			await node.accessControl.deleteCredential(
+				2,
+				UserCredentialType.PINCode,
+				99,
+			);
+
+			t.expect(await credEvent).toMatchObject({
+				userId: 2,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 2,
+			});
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -235,7 +235,6 @@ integrationTest(
 			const cc = new UserCredentialCCUserReport({
 				nodeId: mockController.ownNodeId,
 				reportType: UserCredentialUserReportType.UserAdded,
-				nextUserId: 0,
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
 				userId: 5,
@@ -290,7 +289,6 @@ integrationTest(
 			const cc = new UserCredentialCCUserReport({
 				nodeId: mockController.ownNodeId,
 				reportType: UserCredentialUserReportType.UserModified,
-				nextUserId: 0,
 				modifierType: UserCredentialModifierType.ZWave,
 				modifierNodeId: 1,
 				userId: 2,
@@ -345,7 +343,6 @@ integrationTest(
 			const cc = new UserCredentialCCUserReport({
 				nodeId: mockController.ownNodeId,
 				reportType: UserCredentialUserReportType.UserDeleted,
-				nextUserId: 0,
 				modifierType: UserCredentialModifierType.ZWave,
 				modifierNodeId: 1,
 				userId: 3,
@@ -404,12 +401,9 @@ integrationTest(
 				credentialType: UserCredentialType.PINCode,
 				credentialSlot: 1,
 				credentialReadBack: true,
-				credentialLength: 4,
 				credentialData: Bytes.from("9876", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
-				nextCredentialType: UserCredentialType.None,
-				nextCredentialSlot: 0,
 			});
 			await mockNode.sendToController(
 				createMockZWaveRequestFrame(cc, { ackRequested: false }),
@@ -462,12 +456,9 @@ integrationTest(
 				credentialType: UserCredentialType.PINCode,
 				credentialSlot: 1,
 				credentialReadBack: true,
-				credentialLength: 4,
 				credentialData: Bytes.from("5555", "ascii"),
 				modifierType: UserCredentialModifierType.Locally,
 				modifierNodeId: 0,
-				nextCredentialType: UserCredentialType.None,
-				nextCredentialSlot: 0,
 			});
 			await mockNode.sendToController(
 				createMockZWaveRequestFrame(cc, { ackRequested: false }),
@@ -520,12 +511,8 @@ integrationTest(
 				credentialType: UserCredentialType.PINCode,
 				credentialSlot: 1,
 				credentialReadBack: false,
-				credentialLength: 0,
-				credentialData: new Bytes(),
 				modifierType: UserCredentialModifierType.ZWave,
 				modifierNodeId: 1,
-				nextCredentialType: UserCredentialType.None,
-				nextCredentialSlot: 0,
 			});
 			await mockNode.sendToController(
 				createMockZWaveRequestFrame(cc, { ackRequested: false }),
@@ -577,7 +564,6 @@ integrationTest(
 							nodeId: controller.ownNodeId,
 							reportType: UserCredentialUserReportType
 								.UserAddRejectedLocationOccupied,
-							nextUserId: 0,
 							modifierType: UserCredentialModifierType.ZWave,
 							modifierNodeId: 1,
 							userId: receivedCC.userId,
@@ -658,7 +644,6 @@ integrationTest(
 					new UserCredentialCCUserReport({
 						nodeId: mockController.ownNodeId,
 						reportType: UserCredentialUserReportType.UserAdded,
-						nextUserId: 0,
 						modifierType: UserCredentialModifierType.Locally,
 						modifierNodeId: 0,
 						userId: 4,
@@ -727,12 +712,9 @@ integrationTest(
 							credentialType: receivedCC.credentialType,
 							credentialSlot: receivedCC.credentialSlot,
 							credentialReadBack: true,
-							credentialLength: 4,
 							credentialData: Bytes.from("4242", "ascii"),
 							modifierType: UserCredentialModifierType.ZWave,
 							modifierNodeId: 1,
-							nextCredentialType: UserCredentialType.None,
-							nextCredentialSlot: 0,
 						});
 						await self.sendToController(
 							createMockZWaveRequestFrame(report, {
@@ -817,12 +799,8 @@ integrationTest(
 							credentialType: receivedCC.credentialType,
 							credentialSlot: receivedCC.credentialSlot,
 							credentialReadBack: false,
-							credentialLength: 0,
-							credentialData: new Bytes(),
 							modifierType: UserCredentialModifierType.ZWave,
 							modifierNodeId: 1,
-							nextCredentialType: UserCredentialType.None,
-							nextCredentialSlot: 0,
 						});
 						await self.sendToController(
 							createMockZWaveRequestFrame(report, {
@@ -905,13 +883,9 @@ integrationTest(
 							credentialType: receivedCC.credentialType,
 							credentialSlot: receivedCC.credentialSlot,
 							credentialReadBack: false,
-							credentialLength: 0,
-							credentialData: new Bytes(),
 							modifierType:
 								UserCredentialModifierType.DoesNotExist,
 							modifierNodeId: 0,
-							nextCredentialType: UserCredentialType.None,
-							nextCredentialSlot: 0,
 						});
 						await self.sendToController(
 							createMockZWaveRequestFrame(report, {
@@ -940,12 +914,9 @@ integrationTest(
 						credentialType: UserCredentialType.PINCode,
 						credentialSlot: 1,
 						credentialReadBack: true,
-						credentialLength: 4,
 						credentialData: Bytes.from("1111", "ascii"),
 						modifierType: UserCredentialModifierType.Locally,
 						modifierNodeId: 0,
-						nextCredentialType: UserCredentialType.None,
-						nextCredentialSlot: 0,
 					}),
 					{ ackRequested: false },
 				),

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -1,5 +1,4 @@
 import {
-	SupervisionCommand,
 	type UserCredentialCapability,
 	UserCredentialCredentialReportType,
 	UserCredentialModifierType,
@@ -27,6 +26,10 @@ import {
 	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
 import { createDeferredPromise } from "alcalzone-shared/deferred-promise";
+import {
+	SetCredentialStatus,
+	SetUserStatus,
+} from "../../node/feature-apis/AccessControl.js";
 import { integrationTest } from "../integrationTestSuite.js";
 
 const defaultPINCapability: UserCredentialCapability = {
@@ -90,7 +93,7 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			// User capabilities
-			const userCaps = node.accessControl.getUserCapabilitiesCached();
+			const userCaps = node.accessControl!.getUserCapabilitiesCached();
 			t.expect(userCaps).toBeDefined();
 			t.expect(userCaps.maxUsers).toBe(20);
 			t.expect(userCaps.maxUserNameLength).toBe(64);
@@ -105,7 +108,7 @@ integrationTest(
 			]);
 
 			// Credential capabilities
-			const credCaps = node.accessControl
+			const credCaps = node.accessControl!
 				.getCredentialCapabilitiesCached();
 			t.expect(credCaps).toBeDefined();
 			t.expect(credCaps.supportsAdminCode).toBe(true);
@@ -136,7 +139,7 @@ integrationTest(
 // =============================================================================
 
 integrationTest(
-	"getUserCached and getCredentialsCached return data set via the unified API",
+	"getUserCached and getCredentialsForUserCached return data set via the unified API",
 	{
 		nodeCapabilities: {
 			commandClasses: [
@@ -164,7 +167,7 @@ integrationTest(
 			// the mock's response has been processed and cached.
 			const userCreated = createDeferredPromise<void>();
 			node.once("user added", () => userCreated.resolve());
-			await node.accessControl.setUser(1, {
+			await node.accessControl!.setUser(1, {
 				active: true,
 				userType: UserCredentialUserType.General,
 				userName: "Alice",
@@ -173,7 +176,7 @@ integrationTest(
 
 			const credCreated = createDeferredPromise<void>();
 			node.once("credential added", () => credCreated.resolve());
-			await node.accessControl.setCredential(
+			await node.accessControl!.setCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -182,21 +185,185 @@ integrationTest(
 			await credCreated;
 
 			// Now verify reads return the correct data
-			const user = node.accessControl.getUserCached(1);
+			const user = node.accessControl!.getUserCached(1);
 			t.expect(user).toBeDefined();
 			t.expect(user!.active).toBe(true);
 			t.expect(user!.userType).toBe(UserCredentialUserType.General);
 			t.expect(user!.userName).toBe("Alice");
 
-			t.expect(node.accessControl.getUserCached(2)).toBeUndefined();
+			t.expect(node.accessControl!.getUserCached(2)).toBeUndefined();
 
-			const users = node.accessControl.getUsersCached();
+			const users = node.accessControl!.getUsersCached();
 			t.expect(users.length).toBe(1);
 
-			const creds = node.accessControl.getCredentialsCached(1);
+			const creds = node.accessControl!.getCredentialsForUserCached(1);
 			t.expect(creds.length).toBe(1);
 			t.expect(creds[0].type).toBe(UserCredentialType.PINCode);
 			t.expect(creds[0].slot).toBe(1);
+
+			const credsByType = node.accessControl!.getCredentialsByTypeCached(
+				UserCredentialType.PINCode,
+			);
+			t.expect(credsByType.length).toBe(1);
+			t.expect(node.accessControl!.getAllCredentialsCached().length).toBe(
+				1,
+			);
+		},
+	},
+);
+
+integrationTest(
+	"getCredentialCached resolves by type and slot while getCredentialsForUserCached filters by owner",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const firstUserCreated = createDeferredPromise<void>();
+			node.once("user added", () => firstUserCreated.resolve());
+			await node.accessControl!.setUser(1, {
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Alice",
+			});
+			await firstUserCreated;
+
+			const secondUserCreated = createDeferredPromise<void>();
+			node.once("user added", () => secondUserCreated.resolve());
+			await node.accessControl!.setUser(2, {
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Bob",
+			});
+			await secondUserCreated;
+
+			const credentialCreated = createDeferredPromise<void>();
+			node.once("credential added", () => credentialCreated.resolve());
+			await node.accessControl!.setCredential(
+				1,
+				UserCredentialType.PINCode,
+				1,
+				"1234",
+			);
+			await credentialCreated;
+
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.PINCode,
+					1,
+				),
+			).toMatchObject({
+				userId: 1,
+				type: UserCredentialType.PINCode,
+				slot: 1,
+				data: "1234",
+			});
+
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(2),
+			).toStrictEqual(
+				[],
+			);
+		},
+	},
+);
+
+integrationTest(
+	"setCredential rejects reusing the same credential slot for a different user",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const firstUserCreated = createDeferredPromise<void>();
+			node.once("user added", () => firstUserCreated.resolve());
+			await node.accessControl!.setUser(1, {
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Alice",
+			});
+			await firstUserCreated;
+
+			const secondUserCreated = createDeferredPromise<void>();
+			node.once("user added", () => secondUserCreated.resolve());
+			await node.accessControl!.setUser(2, {
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Bob",
+			});
+			await secondUserCreated;
+
+			const firstCredentialCreated = createDeferredPromise<void>();
+			node.once(
+				"credential added",
+				() => firstCredentialCreated.resolve(),
+			);
+			await node.accessControl!.setCredential(
+				1,
+				UserCredentialType.PINCode,
+				1,
+				"1234",
+			);
+			await firstCredentialCreated;
+
+			const result = await node.accessControl!.setCredential(
+				2,
+				UserCredentialType.PINCode,
+				1,
+				"5678",
+			);
+
+			t.expect(result).toBe(
+				SetCredentialStatus.Error_AddRejectedLocationOccupied,
+			);
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.PINCode,
+					1,
+				),
+			).toMatchObject({
+				userId: 1,
+				type: UserCredentialType.PINCode,
+				slot: 1,
+				data: "1234",
+			});
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(2),
+			).toStrictEqual([]);
 		},
 	},
 );
@@ -750,7 +917,6 @@ integrationTest(
 			});
 
 			const cached = node.accessControl!.getCredentialCached(
-				2,
 				UserCredentialType.PINCode,
 				1,
 			);
@@ -833,7 +999,6 @@ integrationTest(
 			t.expect(emitted).toBe(false);
 			t.expect(
 				node.accessControl!.getCredentialCached(
-					2,
 					UserCredentialType.PINCode,
 					1,
 				),
@@ -924,7 +1089,6 @@ integrationTest(
 			await priming;
 			t.expect(
 				node.accessControl!.getCredentialCached(
-					1,
 					UserCredentialType.PINCode,
 					1,
 				),
@@ -950,7 +1114,6 @@ integrationTest(
 			});
 			t.expect(
 				node.accessControl!.getCredentialCached(
-					1,
 					UserCredentialType.PINCode,
 					1,
 				),
@@ -987,7 +1150,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.setUser(1, {
+			await node.accessControl!.setUser(1, {
 				active: true,
 				userType: UserCredentialUserType.General,
 				userName: "Charlie",
@@ -1032,7 +1195,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.setCredential(
+			await node.accessControl!.setCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -1082,7 +1245,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.deleteUser(5);
+			await node.accessControl!.deleteUser(5);
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -1124,7 +1287,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.deleteAllUsers();
+			await node.accessControl!.deleteAllUsers();
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -1166,7 +1329,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.deleteCredential(
+			await node.accessControl!.deleteCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -1214,7 +1377,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.setAdminCode("9876");
+			await node.accessControl!.setAdminCode("9876");
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -1253,7 +1416,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.getAdminCode();
+			await node.accessControl!.getAdminCode();
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -1289,7 +1452,7 @@ async function populateUserAndCredential(
 ) {
 	const userCreated = createDeferredPromise<void>();
 	node.once("user added", () => userCreated.resolve());
-	await node.accessControl.setUser(1, {
+	await node.accessControl!.setUser(1, {
 		active: true,
 		userType: UserCredentialUserType.General,
 		userName: "Test",
@@ -1298,7 +1461,7 @@ async function populateUserAndCredential(
 
 	const credCreated = createDeferredPromise<void>();
 	node.once("credential added", () => credCreated.resolve());
-	await node.accessControl.setCredential(
+	await node.accessControl!.setCredential(
 		1,
 		UserCredentialType.PINCode,
 		1,
@@ -1321,64 +1484,78 @@ integrationTest(
 			await populateUserAndCredential(node);
 
 			// Verify data is cached
-			t.expect(node.accessControl.getUserCached(1)).toBeDefined();
-			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl!.getUserCached(1)).toBeDefined();
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(1).length,
+			).toBe(
+				1,
+			);
 
 			const deleted = createDeferredPromise<void>();
 			node.once("user deleted", () => deleted.resolve());
-			await node.accessControl.deleteUser(1);
+			await node.accessControl!.deleteUser(1);
 			await deleted;
 
 			// User values are purged by the CC report handler,
 			// credentials must be purged by the AccessControl mixin
-			t.expect(node.accessControl.getUserCached(1)).toBeUndefined();
-			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(0);
+			t.expect(node.accessControl!.getUserCached(1)).toBeUndefined();
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(1).length,
+			).toBe(
+				0,
+			);
 		},
 	},
 );
 
 integrationTest(
-	"deleteUser does not purge cached credentials on supervised failure",
+	"deleteUser does not purge cached credentials when the node does not respond",
 	{
 		nodeCapabilities: {
 			commandClasses: [
 				CommandClasses.Version,
-				CommandClasses.Supervision,
 				ccCaps(defaultDeleteTestCaps),
 			],
 		},
 
 		customSetup: async (driver, controller, mockNode) => {
-			// Only reject supervised Delete operations
-			const rejectSupervisedUserDelete: MockNodeBehavior = {
+			// Stop any default response to UserSet Delete. Without a UserReport,
+			// the setUser API call resolves with an undefined result, which the
+			// feature API must treat as a failure (do not purge the cache).
+			const dropUserDelete: MockNodeBehavior = {
 				handleCC(controller, self, receivedCC) {
 					if (
 						receivedCC instanceof UserCredentialCCUserSet
 						&& receivedCC.operationType
 							=== UserCredentialOperationType.Delete
-						&& receivedCC.isEncapsulatedWith(
-							CommandClasses.Supervision,
-							SupervisionCommand.Get,
-						)
 					) {
-						return { action: "fail" };
+						return { action: "stop" };
 					}
 				},
 			};
-			mockNode.defineBehavior(rejectSupervisedUserDelete);
+			mockNode.defineBehavior(dropUserDelete);
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			await populateUserAndCredential(node);
 
-			t.expect(node.accessControl.getUserCached(1)).toBeDefined();
-			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl!.getUserCached(1)).toBeDefined();
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(1).length,
+			).toBe(
+				1,
+			);
 
-			await node.accessControl.deleteUser(1);
+			const result = await node.accessControl!.deleteUser(1);
+			t.expect(result).toBe(SetUserStatus.Error_Unknown);
 
-			// Supervised command failed — cache must remain intact
-			t.expect(node.accessControl.getUserCached(1)).toBeDefined();
-			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
+			// Command had no response — cache must remain intact
+			t.expect(node.accessControl!.getUserCached(1)).toBeDefined();
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(1).length,
+			).toBe(
+				1,
+			);
 		},
 	},
 );
@@ -1396,60 +1573,72 @@ integrationTest(
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			await populateUserAndCredential(node);
 
-			t.expect(node.accessControl.getUsersCached().length).toBe(1);
-			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl!.getUsersCached().length).toBe(1);
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(1).length,
+			).toBe(
+				1,
+			);
 
 			// deleteAllUsers returns after the API call completes;
 			// the purge happens synchronously before returning
-			await node.accessControl.deleteAllUsers();
+			await node.accessControl!.deleteAllUsers();
 
-			t.expect(node.accessControl.getUsersCached().length).toBe(0);
-			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(0);
+			t.expect(node.accessControl!.getUsersCached().length).toBe(0);
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(1).length,
+			).toBe(
+				0,
+			);
 		},
 	},
 );
 
 integrationTest(
-	"deleteAllUsers does not purge on supervised failure",
+	"deleteAllUsers does not purge when the node does not respond",
 	{
 		nodeCapabilities: {
 			commandClasses: [
 				CommandClasses.Version,
-				CommandClasses.Supervision,
 				ccCaps(defaultDeleteTestCaps),
 			],
 		},
 
 		customSetup: async (driver, controller, mockNode) => {
-			const rejectSupervisedUserDelete: MockNodeBehavior = {
+			const dropUserDelete: MockNodeBehavior = {
 				handleCC(controller, self, receivedCC) {
 					if (
 						receivedCC instanceof UserCredentialCCUserSet
 						&& receivedCC.operationType
 							=== UserCredentialOperationType.Delete
-						&& receivedCC.isEncapsulatedWith(
-							CommandClasses.Supervision,
-							SupervisionCommand.Get,
-						)
 					) {
-						return { action: "fail" };
+						return { action: "stop" };
 					}
 				},
 			};
-			mockNode.defineBehavior(rejectSupervisedUserDelete);
+			mockNode.defineBehavior(dropUserDelete);
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			await populateUserAndCredential(node);
 
-			t.expect(node.accessControl.getUsersCached().length).toBe(1);
-			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl!.getUsersCached().length).toBe(1);
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(1).length,
+			).toBe(
+				1,
+			);
 
-			await node.accessControl.deleteAllUsers();
+			const result = await node.accessControl!.deleteAllUsers();
+			t.expect(result).toBe(SetUserStatus.Error_Unknown);
 
-			// Supervised command failed — cache must remain intact
-			t.expect(node.accessControl.getUsersCached().length).toBe(1);
-			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
+			// Command had no response — cache must remain intact
+			t.expect(node.accessControl!.getUsersCached().length).toBe(1);
+			t.expect(
+				node.accessControl!.getCredentialsForUserCached(1).length,
+			).toBe(
+				1,
+			);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -540,6 +540,454 @@ integrationTest(
 	},
 );
 
+integrationTest(
+	"setUser(Add) rejected with UserAddRejectedLocationOccupied emits user added event and caches the existing user",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Simulate a device that already has user 2 before the driver
+			// knows about it: reply to any Add with the existing user's data.
+			const rejectAddOccupied: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC instanceof UserCredentialCCUserSet
+						&& receivedCC.operationType
+							=== UserCredentialOperationType.Add
+					) {
+						const report = new UserCredentialCCUserReport({
+							nodeId: controller.ownNodeId,
+							reportType: UserCredentialUserReportType
+								.UserAddRejectedLocationOccupied,
+							nextUserId: 0,
+							modifierType: UserCredentialModifierType.ZWave,
+							modifierNodeId: 1,
+							userId: receivedCC.userId,
+							userType: UserCredentialUserType.General,
+							active: true,
+							credentialRule: UserCredentialRule.Single,
+							expiringTimeoutMinutes: 0,
+							nameEncoding: UserCredentialNameEncoding.ASCII,
+							userName: "Existing",
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(report, {
+								ackRequested: false,
+							}),
+						);
+						return { action: "fail" };
+					}
+				},
+			};
+			mockNode.defineBehavior(rejectAddOccupied);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const userEvent = createDeferredPromise<unknown>();
+			node.on("user added", (_node, args) => userEvent.resolve(args));
+
+			// Driver cache is empty, so this sends Add
+			await node.accessControl!.setUser(2, {
+				userType: UserCredentialUserType.General,
+				userName: "Attempted",
+			});
+
+			t.expect(await userEvent).toMatchObject({
+				userId: 2,
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Existing",
+			});
+
+			const cached = node.accessControl!.getUserCached(2);
+			t.expect(cached).toBeDefined();
+			t.expect(cached!.userName).toBe("Existing");
+		},
+	},
+);
+
+integrationTest(
+	"setUser(Modify) rejected with UserModifyRejectedLocationEmpty emits user deleted event and clears the cache",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Prime the driver cache with a user that doesn't exist on the
+			// mock device (the unsolicited UserReport caches without
+			// populating mock state). A subsequent setUser will use Modify.
+			const priming = createDeferredPromise<void>();
+			node.once("user added", () => priming.resolve());
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(
+					new UserCredentialCCUserReport({
+						nodeId: mockController.ownNodeId,
+						reportType: UserCredentialUserReportType.UserAdded,
+						nextUserId: 0,
+						modifierType: UserCredentialModifierType.Locally,
+						modifierNodeId: 0,
+						userId: 4,
+						userType: UserCredentialUserType.General,
+						active: true,
+						credentialRule: UserCredentialRule.Single,
+						expiringTimeoutMinutes: 0,
+						nameEncoding: UserCredentialNameEncoding.ASCII,
+						userName: "Stale",
+					}),
+					{ ackRequested: false },
+				),
+			);
+			await priming;
+			t.expect(node.accessControl!.getUserCached(4)).toBeDefined();
+
+			const userEvent = createDeferredPromise<unknown>();
+			node.on("user deleted", (_node, args) => userEvent.resolve(args));
+
+			// Driver cache has user 4 → this sends Modify. Mock has no user 4
+			// in state → replies with UserModifyRejectedLocationEmpty.
+			await node.accessControl!.setUser(4, { userName: "Updated" });
+
+			t.expect(await userEvent).toMatchObject({ userId: 4 });
+			t.expect(node.accessControl!.getUserCached(4)).toBeUndefined();
+		},
+	},
+);
+
+integrationTest(
+	"setCredential(Add) rejected with CredentialAddRejectedLocationOccupied emits credential added event and caches the read-back data",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 0,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			const rejectAddOccupied: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC instanceof UserCredentialCCCredentialSet
+						&& receivedCC.operationType
+							=== UserCredentialOperationType.Add
+					) {
+						const report = new UserCredentialCCCredentialReport({
+							nodeId: controller.ownNodeId,
+							reportType: UserCredentialCredentialReportType
+								.CredentialAddRejectedLocationOccupied,
+							userId: receivedCC.userId,
+							credentialType: receivedCC.credentialType,
+							credentialSlot: receivedCC.credentialSlot,
+							credentialReadBack: true,
+							credentialLength: 4,
+							credentialData: Bytes.from("4242", "ascii"),
+							modifierType: UserCredentialModifierType.ZWave,
+							modifierNodeId: 1,
+							nextCredentialType: UserCredentialType.None,
+							nextCredentialSlot: 0,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(report, {
+								ackRequested: false,
+							}),
+						);
+						return { action: "fail" };
+					}
+				},
+			};
+			mockNode.defineBehavior(rejectAddOccupied);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const credEvent = createDeferredPromise<unknown>();
+			node.on(
+				"credential added",
+				(_node, args) => credEvent.resolve(args),
+			);
+
+			// Driver cache is empty, so this sends Add
+			await node.accessControl!.setCredential(
+				2,
+				UserCredentialType.PINCode,
+				1,
+				"1111",
+			);
+
+			t.expect(await credEvent).toMatchObject({
+				userId: 2,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 1,
+			});
+
+			const cached = node.accessControl!.getCredentialCached(
+				2,
+				UserCredentialType.PINCode,
+				1,
+			);
+			t.expect(cached).toBeDefined();
+			t.expect(cached!.data).toBe("4242");
+		},
+	},
+);
+
+integrationTest(
+	"CredentialAddRejectedLocationOccupied without read-back does not emit or cache",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 0,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			const rejectWithoutReadback: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC instanceof UserCredentialCCCredentialSet
+						&& receivedCC.operationType
+							=== UserCredentialOperationType.Add
+					) {
+						const report = new UserCredentialCCCredentialReport({
+							nodeId: controller.ownNodeId,
+							reportType: UserCredentialCredentialReportType
+								.CredentialAddRejectedLocationOccupied,
+							userId: receivedCC.userId,
+							credentialType: receivedCC.credentialType,
+							credentialSlot: receivedCC.credentialSlot,
+							credentialReadBack: false,
+							credentialLength: 0,
+							credentialData: new Bytes(),
+							modifierType: UserCredentialModifierType.ZWave,
+							modifierNodeId: 1,
+							nextCredentialType: UserCredentialType.None,
+							nextCredentialSlot: 0,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(report, {
+								ackRequested: false,
+							}),
+						);
+						return { action: "fail" };
+					}
+				},
+			};
+			mockNode.defineBehavior(rejectWithoutReadback);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			let emitted = false;
+			node.on("credential added", () => {
+				emitted = true;
+			});
+
+			await node.accessControl!.setCredential(
+				2,
+				UserCredentialType.PINCode,
+				1,
+				"1111",
+			);
+
+			// Give any (unwanted) event a chance to fire
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			t.expect(emitted).toBe(false);
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					2,
+					UserCredentialType.PINCode,
+					1,
+				),
+			).toBeUndefined();
+		},
+	},
+);
+
+integrationTest(
+	"setCredential(Modify) rejected with CredentialModifyRejectedLocationEmpty emits credential deleted event and clears the cache",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 0,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Reject Modify operations with LocationEmpty, regardless of
+			// whether the credential actually exists in mock state.
+			const rejectModifyEmpty: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC instanceof UserCredentialCCCredentialSet
+						&& receivedCC.operationType
+							=== UserCredentialOperationType.Modify
+					) {
+						const report = new UserCredentialCCCredentialReport({
+							nodeId: controller.ownNodeId,
+							reportType: UserCredentialCredentialReportType
+								.CredentialModifyRejectedLocationEmpty,
+							userId: receivedCC.userId,
+							credentialType: receivedCC.credentialType,
+							credentialSlot: receivedCC.credentialSlot,
+							credentialReadBack: false,
+							credentialLength: 0,
+							credentialData: new Bytes(),
+							modifierType:
+								UserCredentialModifierType.DoesNotExist,
+							modifierNodeId: 0,
+							nextCredentialType: UserCredentialType.None,
+							nextCredentialSlot: 0,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(report, {
+								ackRequested: false,
+							}),
+						);
+						return { action: "fail" };
+					}
+				},
+			};
+			mockNode.defineBehavior(rejectModifyEmpty);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Prime the driver cache with a credential that doesn't exist
+			// on the mock device. A subsequent setCredential will use Modify.
+			const priming = createDeferredPromise<void>();
+			node.once("credential added", () => priming.resolve());
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(
+					new UserCredentialCCCredentialReport({
+						nodeId: mockController.ownNodeId,
+						reportType:
+							UserCredentialCredentialReportType.CredentialAdded,
+						userId: 1,
+						credentialType: UserCredentialType.PINCode,
+						credentialSlot: 1,
+						credentialReadBack: true,
+						credentialLength: 4,
+						credentialData: Bytes.from("1111", "ascii"),
+						modifierType: UserCredentialModifierType.Locally,
+						modifierNodeId: 0,
+						nextCredentialType: UserCredentialType.None,
+						nextCredentialSlot: 0,
+					}),
+					{ ackRequested: false },
+				),
+			);
+			await priming;
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					1,
+					UserCredentialType.PINCode,
+					1,
+				),
+			).toBeDefined();
+
+			const credEvent = createDeferredPromise<unknown>();
+			node.on(
+				"credential deleted",
+				(_node, args) => credEvent.resolve(args),
+			);
+
+			await node.accessControl!.setCredential(
+				1,
+				UserCredentialType.PINCode,
+				1,
+				"9999",
+			);
+
+			t.expect(await credEvent).toMatchObject({
+				userId: 1,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 1,
+			});
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					1,
+					UserCredentialType.PINCode,
+					1,
+				),
+			).toBeUndefined();
+		},
+	},
+);
+
 // =============================================================================
 // Set-type commands use correct CC commands
 // =============================================================================


### PR DESCRIPTION
The previous iterations of this feature were misunderstanding that credential slots were not counted per user, but globally on the lock. This PR corrects that, improves how errors are exposed to applications, and adds a high-level API for associating credentials with different users.