### PR TITLE
fix(config): update parameters for Zooz ZSE44 firmware 2.40

### DIFF
--- a/packages/config/config/devices/0x027a/zse44.json
+++ b/packages/config/config/devices/0x027a/zse44.json
@@ -366,6 +366,7 @@
 		},
 		{
 			"#": "15",
+			"$if": "firmwareVersion < 2.40.0",
 			"$purpose": "calibration.humidity",
 			"label": "Humidity Offset",
 			"description": "0=-10, 100=0, 200=+10",
@@ -375,6 +376,18 @@
 			"maxValue": 200,
 			"defaultValue": 100,
 			"unsigned": true
+		},
+		{
+			"#": "15",
+			"$if": "firmwareVersion >= 2.40.0",
+			"$purpose": "calibration.humidity",
+			"label": "Humidity Offset",
+			"description": "0=-20%, 200=0, 400=+20%",
+			"valueSize": 2,
+			"unit": "0.1 %",
+			"minValue": 0,
+			"maxValue": 400,
+			"defaultValue": 200
 		},
 		{
 			"#": "16",


### PR DESCRIPTION
I think this might be needed after https://github.com/zwave-js/firmware-updates/pull/310 (I thought I commented on a merge request, but can't figure where)

From public doc:

Humidity Reporting Offset
Parameter 15: Set the reporting offset on your humidity sensor in case you see any reporting discrepancies after 48 hours of using the sensor. Values: 0 - 400 (.1% step, where value 0 equals -20%, value 200 equals 0%, and value 400 equals +20%). Default: 200. Size: 2 byte dec

*Some hubs, like Hubitat and SmartThings, allow for a more intuitive display, and the values available will show as -20 to 20, and can accept non-whole values (9.6, 8.2, etc.) Default 0.

