### PR TITLE
feat(config): add Shenzhen Neo NAS-WS02Z Water Sensor

### DIFF
--- a/packages/config/config/devices/0x0258/nas-ws02z.json
+++ b/packages/config/config/devices/0x0258/nas-ws02z.json
@@ -1,0 +1,78 @@
+{
+	"manufacturer": "Shenzhen Neo Electronics Co., Ltd.",
+	"manufacturerId": "0x0258",
+	"label": "NAS-WS02Z",
+	"description": "Water Sensor",
+	"devices": [
+		{
+			"productType": "0x0100",
+			"productId": "0x1025"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Alarm Duration",
+			"valueSize": 1,
+			"unit": "minutes",
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 120,
+			"unsigned": true
+		},
+		{
+			"#": "2",
+			"label": "Alarm Interval",
+			"valueSize": 2,
+			"unit": "minutes",
+			"minValue": 1,
+			"maxValue": 255,
+			"defaultValue": 1
+		},
+		{
+			"#": "3",
+			"label": "First Alarm Activity Duration",
+			"valueSize": 1,
+			"unit": "seconds",
+			"minValue": 1,
+			"maxValue": 255,
+			"defaultValue": 60,
+			"unsigned": true
+		},
+		{
+			"#": "4",
+			"label": "Alarm Activity Duration",
+			"valueSize": 1,
+			"unit": "seconds",
+			"minValue": 5,
+			"maxValue": 255,
+			"defaultValue": 5,
+			"unsigned": true
+		},
+		{
+			"#": "5",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Alarm Beep",
+			"defaultValue": 1
+		},
+		{
+			"#": "6",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Water Detection",
+			"defaultValue": 1
+		},
+		{
+			"#": "7",
+			"label": "Basic Set Level",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
+		}
+	]
+}


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

Added the Shenzhen Neo Electronics NAS-WS02Z device, based on the user manual here:
https://fccid.io/Z52NAS-WS02Z/User-Manual/15-NAS-WS02Z-UserMan-US-r1-4384664.pdf

It closely matches the NAS-WS01Z which is already an available config.
