### PR TITLE
feat: implement bulk-delete APIs for credentials

### DIFF
--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -309,7 +309,7 @@ if (endpoint.accessControl) {
 >
 > - Adding a credential implicitly creates a user.
 > - Deleting one or more credentials implicitly deletes the owning users (and vice versa). Methods that delete users or credentials therefore emit both a `"credential deleted"` and a `"user deleted"` event.
-> - `deleteAllCredentialsForUser` rejects when called with a `credentialType` the node does not support.
+> - `deleteCredentials` rejects when called with a `credentialType` the node does not support.
 > - When `deleteCredential` is called without a `userId`, the `slot` is interpreted as the user identifier.
 
 ### Querying capabilities
@@ -366,24 +366,23 @@ Each entry in `supportedCredentialTypes` maps a `UserCredentialType` to its capa
 <!-- #import UserCredentialCapability from "@zwave-js/cc" -->
 
 ```ts
-type UserCredentialCapability =
-	& {
-		numberOfCredentialSlots: number;
-		minCredentialLength: number;
-		maxCredentialLength: number;
-		maxCredentialHashLength: number;
-	}
-	& (
-		{
+type UserCredentialCapability = {
+	numberOfCredentialSlots: number;
+	minCredentialLength: number;
+	maxCredentialLength: number;
+	maxCredentialHashLength: number;
+} & (
+	| {
 			supportsCredentialLearn: true;
 			credentialLearnRecommendedTimeout: number;
 			credentialLearnNumberOfSteps: number;
-		} | {
+	  }
+	| {
 			supportsCredentialLearn: false;
 			credentialLearnRecommendedTimeout?: undefined;
 			credentialLearnNumberOfSteps?: undefined;
-		}
-	);
+	  }
+);
 ```
 
 ### Managing users
@@ -611,28 +610,21 @@ deleteCredential(
 
 Deletes the given credential. Throws if the credential slot is out of range. When a `userId` is given, the credential is only deleted if it belongs to that user.
 
-#### `deleteAllCredentialsForUser`
+#### `deleteCredentials`
 
 ```ts
-deleteAllCredentialsForUser(
-	userId: number,
-	credentialType?: UserCredentialType,
-): Promise<SetCredentialResult>
+deleteCredentials(options?: DeleteCredentialsOptions): Promise<SetCredentialResult>
 ```
 
-Deletes all credentials owned by the given user. When `credentialType` is provided, only credentials of that type are deleted. On nodes using the **User Credential CC**, the user record itself is preserved.
+Deletes credentials matching the given filters:
 
-A single [`"credential deleted"`](#quotcredential-deletedquot) event is emitted whose payload echoes the request: `credentialSlot` is always `0`, and `credentialType` is `0` when no type filter was given. Treat zeros in this payload as wildcards and refresh the affected scope rather than a single credential. This avoids flooding listeners with up to N×M events on fully provisioned locks.
+<!-- #import DeleteCredentialsOptions from "zwave-js" -->
 
-#### `deleteAllCredentials`
+- When `userId` is omitted or `0`, credentials for all users are deleted.
+- When `credentialType` is omitted or `UserCredentialType.None`, credentials of all types are deleted.
+- Calling without any filters deletes every credential on the node.
 
-```ts
-deleteAllCredentials(): Promise<SetCredentialResult>
-```
-
-Deletes all credentials on the node. On nodes using the **User Credential CC**, user records are preserved — use [`deleteAllUsers`](#deleteallusers) to delete those as well.
-
-A single [`"credential deleted"`](#quotcredential-deletedquot) event with all zeros is emitted (and on User Code CC, a [`"user deleted"`](#quotuser-deletedquot) event with `userId: 0`). Treat zeros as wildcards.
+A single [`"credential deleted"`](#quotcredential-deletedquot) event is emitted whose payload echoes the request: omitted filters are reported as `0`.
 
 #### `assignCredential`
 

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -366,23 +366,24 @@ Each entry in `supportedCredentialTypes` maps a `UserCredentialType` to its capa
 <!-- #import UserCredentialCapability from "@zwave-js/cc" -->
 
 ```ts
-type UserCredentialCapability = {
-	numberOfCredentialSlots: number;
-	minCredentialLength: number;
-	maxCredentialLength: number;
-	maxCredentialHashLength: number;
-} & (
-	| {
+type UserCredentialCapability =
+	& {
+		numberOfCredentialSlots: number;
+		minCredentialLength: number;
+		maxCredentialLength: number;
+		maxCredentialHashLength: number;
+	}
+	& (
+		{
 			supportsCredentialLearn: true;
 			credentialLearnRecommendedTimeout: number;
 			credentialLearnNumberOfSteps: number;
-	  }
-	| {
+		} | {
 			supportsCredentialLearn: false;
 			credentialLearnRecommendedTimeout?: undefined;
 			credentialLearnNumberOfSteps?: undefined;
-	  }
-);
+		}
+	);
 ```
 
 ### Managing users
@@ -618,7 +619,24 @@ deleteCredentials(options?: DeleteCredentialsOptions): Promise<SetCredentialResu
 
 Deletes credentials matching the given filters:
 
-<!-- #import DeleteCredentialsOptions from "zwave-js" -->
+<!-- #import DeleteCredentialsOptions from "zwave-js" without comments -->
+
+```ts
+interface DeleteCredentialsOptions {
+	/**
+	 * Only delete credentials owned by this user. When omitted or `0`, the
+	 * filter is treated as a wildcard and credentials for all users are
+	 * deleted.
+	 */
+	userId?: number;
+	/**
+	 * Only delete credentials of this type. When omitted or
+	 * {@link UserCredentialType.None}, the filter is treated as a wildcard and
+	 * credentials of all types are deleted.
+	 */
+	credentialType?: UserCredentialType;
+}
+```
 
 - When `userId` is omitted or `0`, credentials for all users are deleted.
 - When `credentialType` is omitted or `UserCredentialType.None`, credentials of all types are deleted.

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -304,6 +304,13 @@ if (endpoint.accessControl) {
 ```
 
 > [!NOTE] For nodes using the **User Code CC**, only a subset of the functionality is available. Each user maps to a single credential of the device's unified credential type, and the unified credential slot matches the user slot. User names and credential rules are not supported, and credential learning is unavailable.
+>
+> As a result, several of the below APIs have side effects on these devices:
+>
+> - Adding a credential implicitly creates a user.
+> - Deleting one or more credentials implicitly deletes the owning users (and vice versa). Methods that delete users or credentials therefore emit both a `"credential deleted"` and a `"user deleted"` event.
+> - `deleteAllCredentialsForUser` rejects when called with a `credentialType` the node does not support.
+> - When `deleteCredential` is called without a `userId`, the `slot` is interpreted as the user identifier.
 
 ### Querying capabilities
 
@@ -592,15 +599,40 @@ Creates or updates a credential for the given user. Whether a credential is crea
 
 ```ts
 deleteCredential(
-	userId: number,
 	type: UserCredentialType,
 	slot: number,
-): Promise<SupervisionResult | undefined>
+): Promise<SetCredentialResult>;
+deleteCredential(
+	userId: number | undefined,
+	type: UserCredentialType,
+	slot: number,
+): Promise<SetCredentialResult>;
 ```
 
-Deletes the given credential. Throws if the credential slot is out of range.
+Deletes the given credential. Throws if the credential slot is out of range. When a `userId` is given, the credential is only deleted if it belongs to that user.
 
-> [!NOTE] For nodes using the **User Code CC**, deleting a credential also deletes the associated user, because User Code CC does not distinguish between users and their credentials.
+#### `deleteAllCredentialsForUser`
+
+```ts
+deleteAllCredentialsForUser(
+	userId: number,
+	credentialType?: UserCredentialType,
+): Promise<SetCredentialResult>
+```
+
+Deletes all credentials owned by the given user. When `credentialType` is provided, only credentials of that type are deleted. On nodes using the **User Credential CC**, the user record itself is preserved.
+
+A single [`"credential deleted"`](#quotcredential-deletedquot) event is emitted whose payload echoes the request: `credentialSlot` is always `0`, and `credentialType` is `0` when no type filter was given. Treat zeros in this payload as wildcards and refresh the affected scope rather than a single credential. This avoids flooding listeners with up to N×M events on fully provisioned locks.
+
+#### `deleteAllCredentials`
+
+```ts
+deleteAllCredentials(): Promise<SetCredentialResult>
+```
+
+Deletes all credentials on the node. On nodes using the **User Credential CC**, user records are preserved — use [`deleteAllUsers`](#deleteallusers) to delete those as well.
+
+A single [`"credential deleted"`](#quotcredential-deletedquot) event with all zeros is emitted (and on User Code CC, a [`"user deleted"`](#quotuser-deletedquot) event with `userId: 0`). Treat zeros as wildcards.
 
 #### `assignCredential`
 

--- a/packages/cc/src/cc/UserCredentialCC.ts
+++ b/packages/cc/src/cc/UserCredentialCC.ts
@@ -2854,15 +2854,10 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;
 
-		if (
-			this.credentialType === UserCredentialType.None
-			|| this.credentialSlot === 0
-		) {
-			return true;
-		}
-
 		// A CredentialModifyRejectedLocationEmpty report means we have a stale
 		// cache entry for a credential that no longer exists on the device.
+		// CredentialDeleted reports may echo the request fields, including the
+		// wildcard zeros used to trigger bulk deletes per CC:0083.01.0A.
 		if (
 			this.reportType
 				=== UserCredentialCredentialReportType.CredentialDeleted
@@ -2870,34 +2865,99 @@ export class UserCredentialCCCredentialReport extends UserCredentialCC {
 				=== UserCredentialCredentialReportType
 					.CredentialModifyRejectedLocationEmpty
 		) {
-			this.removeValue(
-				ctx,
-				UserCredentialCCValues.credential(
-					this.credentialType,
-					this.credentialSlot,
-				),
-			);
-			this.removeValue(
-				ctx,
-				UserCredentialCCValues.credentialOwner(
-					this.credentialType,
-					this.credentialSlot,
-				),
-			);
-			this.removeValue(
-				ctx,
-				UserCredentialCCValues.credentialModifierType(
-					this.credentialType,
-					this.credentialSlot,
-				),
-			);
-			this.removeValue(
-				ctx,
-				UserCredentialCCValues.credentialModifierNodeId(
-					this.credentialType,
-					this.credentialSlot,
-				),
-			);
+			if (
+				this.credentialType !== UserCredentialType.None
+				&& this.credentialSlot !== 0
+			) {
+				// Single credential. The (type, slot) tuple uniquely identifies
+				// the entry in the value DB, so the userId is not needed.
+				this.removeValue(
+					ctx,
+					UserCredentialCCValues.credential(
+						this.credentialType,
+						this.credentialSlot,
+					),
+				);
+				this.removeValue(
+					ctx,
+					UserCredentialCCValues.credentialOwner(
+						this.credentialType,
+						this.credentialSlot,
+					),
+				);
+				this.removeValue(
+					ctx,
+					UserCredentialCCValues.credentialModifierType(
+						this.credentialType,
+						this.credentialSlot,
+					),
+				);
+				this.removeValue(
+					ctx,
+					UserCredentialCCValues.credentialModifierNodeId(
+						this.credentialType,
+						this.credentialSlot,
+					),
+				);
+			} else {
+				// Bulk delete. Walk all cached credentials and remove those
+				// matching the (userId, type) filter (zero means wildcard).
+				const valueDB = this.getValueDB(ctx);
+				const credentialOwners = valueDB.findValues(
+					(vid) =>
+						UserCredentialCCValues.credentialOwner.is(vid)
+						&& vid.endpoint === this.endpointIndex,
+				);
+				for (
+					const { endpoint, propertyKey, value } of credentialOwners
+				) {
+					// If a user ID is given, only delete credentials owned by that user
+					if (this.userId !== 0 && value !== this.userId) continue;
+
+					const key = propertyKey as number;
+					const cType = key >>> 16;
+					const cSlot = key & 0xffff;
+
+					// If a credential type is given, only delete credentials of that type
+					if (
+						this.credentialType !== UserCredentialType.None
+						&& cType !== this.credentialType
+					) {
+						continue;
+					}
+
+					valueDB.removeValue(
+						UserCredentialCCValues.credential(cType, cSlot)
+							.endpoint(endpoint),
+					);
+					valueDB.removeValue(
+						UserCredentialCCValues.credentialOwner(cType, cSlot)
+							.endpoint(endpoint),
+					);
+					valueDB.removeValue(
+						UserCredentialCCValues.credentialModifierType(
+							cType,
+							cSlot,
+						).endpoint(endpoint),
+					);
+					valueDB.removeValue(
+						UserCredentialCCValues.credentialModifierNodeId(
+							cType,
+							cSlot,
+						).endpoint(endpoint),
+					);
+				}
+			}
+			return true;
+		}
+
+		// Non-delete reports may carry (None, 0) as a sentinel for "no credential
+		// at this location" — e.g. the end-of-walk marker in nextCredential* of
+		// a ResponseToGet. Bail out so we don't write bogus cache entries.
+		if (
+			this.credentialType === UserCredentialType.None
+			|| this.credentialSlot === 0
+		) {
 			return true;
 		}
 

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -29,6 +29,7 @@ export type {
 	CredentialCapabilities,
 	CredentialData,
 	SetUserOptions,
+	DeleteCredentialsOptions,
 	UserCapabilities,
 	UserData,
 } from "./lib/node/feature-apis/AccessControl.js";

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -28,8 +28,8 @@ export {
 export type {
 	CredentialCapabilities,
 	CredentialData,
-	SetUserOptions,
 	DeleteCredentialsOptions,
+	SetUserOptions,
 	UserCapabilities,
 	UserData,
 } from "./lib/node/feature-apis/AccessControl.js";

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -72,6 +72,21 @@ export interface SetUserOptions {
 	expiringTimeoutMinutes?: number;
 }
 
+export interface DeleteCredentialsOptions {
+	/**
+	 * Only delete credentials owned by this user. When omitted or `0`, the
+	 * filter is treated as a wildcard and credentials for all users are
+	 * deleted.
+	 */
+	userId?: number;
+	/**
+	 * Only delete credentials of this type. When omitted or
+	 * {@link UserCredentialType.None}, the filter is treated as a wildcard and
+	 * credentials of all types are deleted.
+	 */
+	credentialType?: UserCredentialType;
+}
+
 type UserCredentialGetResult = Awaited<
 	ReturnType<UserCredentialCCAPI["getCredential"]>
 >;
@@ -1050,32 +1065,21 @@ export class AccessControlAPI extends FeatureAPI {
 	}
 
 	/**
-	 * Deletes all credentials of the given type for the given user.
-	 * When the credential type is omitted, all credentials of all types for
-	 * the user are deleted. The user itself is not deleted.
-	 *
-	 * For nodes using the User Code CC, this implicitly deletes the user as
-	 * well because User Code CC does not distinguish between users and their
-	 * credentials. Throws if a `credentialType` is provided that the node does
-	 * not support.
+	 * Deletes credentials matching the given filters.
 	 */
-	public async deleteAllCredentialsForUser(
-		userId: number,
-		credentialType?: UserCredentialType,
+	public async deleteCredentials(
+		options: DeleteCredentialsOptions = {},
 	): Promise<SetCredentialResult> {
-		if (userId === 0) {
-			throw new ZWaveError(
-				"User ID 0 is not valid. Use deleteAllCredentials to delete credentials for all users instead.",
-				ZWaveErrorCodes.Argument_Invalid,
-			);
-		}
+		const userId = options.userId ?? 0;
+		const credentialType = options.credentialType
+			?? UserCredentialType.None;
 
 		if (this.#usesUserCredentialCC) {
 			const api = this.#u3cAPI();
 			const raw = await api.setCredential({
 				operationType: UserCredentialOperationType.Delete,
 				userId,
-				credentialType: credentialType ?? UserCredentialType.None,
+				credentialType,
 				credentialSlot: 0,
 			});
 			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
@@ -1083,8 +1087,9 @@ export class AccessControlAPI extends FeatureAPI {
 				raw?.reportType,
 			);
 		} else {
+			// User Code CC
 			if (
-				credentialType != undefined
+				credentialType !== UserCredentialType.None
 				&& credentialType !== this.#ucCredentialType
 			) {
 				// Returning OK here would falsely imply the User Code CC user
@@ -1100,16 +1105,24 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 
 			// Only emit deleted events if we knew about the credential beforehand.
-			const existed = this.#getUserCached_UC(userId) != undefined;
+			// The wildcard branch (userId === 0) always emits, since verifying
+			// the prior state across all users is unrealistic.
+			const existed = userId !== 0
+				? this.#getUserCached_UC(userId) != undefined
+				: true;
 
 			const api = this.#ucAPI();
 			const result = await api.clear(userId);
 			let succeeded: boolean;
-			if (result == undefined) {
+			if (userId !== 0 && result == undefined) {
 				const verified = await api.get(userId);
 				succeeded = verified?.userIdStatus === UserIDStatus.Available;
 			} else {
-				succeeded = supervisedCommandSucceeded(result);
+				// Verifying all users being deleted is unrealistic
+				// since there can be up to 65535 users. So we just
+				// assume it worked when the command was not supervised.
+				succeeded = result == undefined
+					|| supervisedCommandSucceeded(result);
 			}
 			if (succeeded) {
 				this.#purgeCachedUserCodes(userId);
@@ -1123,55 +1136,6 @@ export class AccessControlAPI extends FeatureAPI {
 						credentialSlot: userId,
 					});
 					node.emit("user deleted", this.endpoint as any, { userId });
-				}
-			}
-			return succeeded
-				? SetCredentialResult.OK
-				: SetCredentialResult.Error_Unknown;
-		}
-	}
-
-	/**
-	 * Deletes all credentials on the node.
-	 *
-	 * For nodes using the User Credential CC, user records are preserved (use
-	 * {@link deleteAllUsers} to delete those). For nodes using the User Code
-	 * CC, all users are implicitly deleted as well because User Code CC does
-	 * not distinguish between users and their credentials.
-	 */
-	public async deleteAllCredentials(): Promise<SetCredentialResult> {
-		if (this.#usesUserCredentialCC) {
-			const api = this.#u3cAPI();
-			const raw = await api.setCredential({
-				operationType: UserCredentialOperationType.Delete,
-				userId: 0,
-				credentialType: UserCredentialType.None,
-				credentialSlot: 0,
-			});
-			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
-			return u3cCredentialReportTypeToSetCredentialResult(
-				raw?.reportType,
-			);
-		} else {
-			const api = this.#ucAPI();
-			const result = await api.clear(0);
-			// Verifying all users being deleted is unrealistic
-			// since there can be up to 65535 users. So we just
-			// assume it worked when the command was not supervised.
-			const succeeded = result == undefined
-				|| supervisedCommandSucceeded(result);
-			if (succeeded) {
-				this.#purgeCachedUserCodes();
-				const node = this.endpoint.tryGetNode();
-				if (node) {
-					node.emit("credential deleted", this.endpoint as any, {
-						userId: 0,
-						credentialType: this.#ucCredentialType,
-						credentialSlot: 0,
-					});
-					node.emit("user deleted", this.endpoint as any, {
-						userId: 0,
-					});
 				}
 			}
 			return succeeded

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -616,7 +616,10 @@ export class AccessControlAPI extends FeatureAPI {
 			return status;
 		} else {
 			// User Code CC ties each user to their code, so clearing
-			// the code implicitly deletes the user and vice versa
+			// the code implicitly deletes the user and vice versa.
+			// The cache entry only gates event emission - the node may have
+			// a user we never observed, so a missing entry must not gate the
+			// success of the API call itself.
 			const existed = this.#getUserCached_UC(userId) != undefined;
 			const api = this.#ucAPI();
 			const result = await api.clear(userId);
@@ -624,12 +627,14 @@ export class AccessControlAPI extends FeatureAPI {
 			if (result == undefined) {
 				// Unsupervised - verify the change
 				const verified = await api.get(userId);
-				succeeded = existed
-					&& verified?.userIdStatus === UserIDStatus.Available;
+				succeeded = verified?.userIdStatus === UserIDStatus.Available;
 			} else {
-				succeeded = supervisedCommandSucceeded(result) && existed;
+				succeeded = supervisedCommandSucceeded(result);
 			}
 			if (succeeded) {
+				this.#purgeCachedUserCodes(userId);
+			}
+			if (succeeded && existed) {
 				const node = this.endpoint.tryGetNode();
 				if (node) {
 					node.emit("user deleted", this.endpoint as any, { userId });
@@ -671,7 +676,7 @@ export class AccessControlAPI extends FeatureAPI {
 			const succeeded = result == undefined
 				|| supervisedCommandSucceeded(result);
 			if (succeeded) {
-				this.#purgeAllCachedUserCodes();
+				this.#purgeCachedUserCodes();
 			}
 			return succeeded ? SetUserResult.OK : SetUserResult.Error_Unknown;
 		}
@@ -955,10 +960,31 @@ export class AccessControlAPI extends FeatureAPI {
 	 * This communicates with the node.
 	 */
 	public async deleteCredential(
-		userId: number,
 		type: UserCredentialType,
 		slot: number,
+	): Promise<SetCredentialResult>;
+	public async deleteCredential(
+		userId: number | undefined,
+		type: UserCredentialType,
+		slot: number,
+	): Promise<SetCredentialResult>;
+
+	public async deleteCredential(
+		userIdOrType: number | undefined,
+		typeOrSlot: UserCredentialType | number,
+		slot?: number,
 	): Promise<SetCredentialResult> {
+		// 2-arg overload: (type, slot) — normalize to the 3-arg form
+		if (slot == undefined) {
+			return this.deleteCredential(
+				0,
+				userIdOrType as UserCredentialType,
+				typeOrSlot,
+			);
+		}
+		const userId = userIdOrType ?? 0;
+		const type = typeOrSlot as UserCredentialType;
+
 		if (this.#usesUserCredentialCC) {
 			this.#assertValidSlot(type, slot);
 
@@ -974,33 +1000,178 @@ export class AccessControlAPI extends FeatureAPI {
 				raw?.reportType,
 			);
 		} else {
-			// User Code CC stores exactly one credential per user slot. Ignore the
-			// caller-provided unified slot and write back to the owning user's slot
-			// so events and cached state stay internally consistent.
-			this.#assertValidSlot(type, userId);
+			// User Code CC stores exactly one credential per user slot, with the
+			// user identifier being the slot number. When the caller omits the
+			// user (2-arg form), fall back to the slot. When both are given but
+			// disagree, no credential can exist at that (user, slot) pair.
+			if (userId !== 0 && userId !== slot) {
+				return SetCredentialResult.Error_ModifyRejectedLocationEmpty;
+			}
+
+			// Make sure the addressed slot is valid
+			const targetUserId = userId === 0 ? slot : userId;
+			this.#assertValidSlot(type, targetUserId);
+
+			// Only emit deleted events if we knew about the credential beforehand.
 			const existed = this.#getCredentialCached_UC(
 				type,
-				userId,
+				targetUserId,
 			) != undefined;
+
+			const api = this.#ucAPI();
+			const result = await api.clear(targetUserId);
+			let succeeded: boolean;
+			if (result == undefined) {
+				const verified = await api.get(targetUserId);
+				succeeded = verified?.userIdStatus === UserIDStatus.Available;
+			} else {
+				succeeded = supervisedCommandSucceeded(result);
+			}
+			if (succeeded) {
+				this.#purgeCachedUserCodes(targetUserId);
+			}
+			if (succeeded && existed) {
+				const node = this.endpoint.tryGetNode();
+				if (node) {
+					node.emit("credential deleted", this.endpoint as any, {
+						userId: targetUserId,
+						credentialType: type,
+						credentialSlot: targetUserId,
+					});
+					node.emit("user deleted", this.endpoint as any, {
+						userId: targetUserId,
+					});
+				}
+			}
+			return succeeded
+				? SetCredentialResult.OK
+				: SetCredentialResult.Error_Unknown;
+		}
+	}
+
+	/**
+	 * Deletes all credentials of the given type for the given user.
+	 * When the credential type is omitted, all credentials of all types for
+	 * the user are deleted. The user itself is not deleted.
+	 *
+	 * For nodes using the User Code CC, this implicitly deletes the user as
+	 * well because User Code CC does not distinguish between users and their
+	 * credentials. Throws if a `credentialType` is provided that the node does
+	 * not support.
+	 */
+	public async deleteAllCredentialsForUser(
+		userId: number,
+		credentialType?: UserCredentialType,
+	): Promise<SetCredentialResult> {
+		if (userId === 0) {
+			throw new ZWaveError(
+				"User ID 0 is not valid. Use deleteAllCredentials to delete credentials for all users instead.",
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
+			const raw = await api.setCredential({
+				operationType: UserCredentialOperationType.Delete,
+				userId,
+				credentialType: credentialType ?? UserCredentialType.None,
+				credentialSlot: 0,
+			});
+			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
+			return u3cCredentialReportTypeToSetCredentialResult(
+				raw?.reportType,
+			);
+		} else {
+			if (
+				credentialType != undefined
+				&& credentialType !== this.#ucCredentialType
+			) {
+				// Returning OK here would falsely imply the User Code CC user
+				// was deleted (cascade), which only happens when the type
+				// matches. Reject loudly so callers do not act on a fictional
+				// success.
+				throw new ZWaveError(
+					`Credential type ${
+						getEnumMemberName(UserCredentialType, credentialType)
+					} is not supported by this node`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+
+			// Only emit deleted events if we knew about the credential beforehand.
+			const existed = this.#getUserCached_UC(userId) != undefined;
+
 			const api = this.#ucAPI();
 			const result = await api.clear(userId);
 			let succeeded: boolean;
 			if (result == undefined) {
 				const verified = await api.get(userId);
-				succeeded = existed
-					&& verified?.userIdStatus === UserIDStatus.Available;
+				succeeded = verified?.userIdStatus === UserIDStatus.Available;
 			} else {
-				succeeded = supervisedCommandSucceeded(result) && existed;
+				succeeded = supervisedCommandSucceeded(result);
 			}
 			if (succeeded) {
+				this.#purgeCachedUserCodes(userId);
+			}
+			if (succeeded && existed) {
 				const node = this.endpoint.tryGetNode();
 				if (node) {
 					node.emit("credential deleted", this.endpoint as any, {
 						userId,
-						credentialType: type,
+						credentialType: this.#ucCredentialType,
 						credentialSlot: userId,
 					});
 					node.emit("user deleted", this.endpoint as any, { userId });
+				}
+			}
+			return succeeded
+				? SetCredentialResult.OK
+				: SetCredentialResult.Error_Unknown;
+		}
+	}
+
+	/**
+	 * Deletes all credentials on the node.
+	 *
+	 * For nodes using the User Credential CC, user records are preserved (use
+	 * {@link deleteAllUsers} to delete those). For nodes using the User Code
+	 * CC, all users are implicitly deleted as well because User Code CC does
+	 * not distinguish between users and their credentials.
+	 */
+	public async deleteAllCredentials(): Promise<SetCredentialResult> {
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
+			const raw = await api.setCredential({
+				operationType: UserCredentialOperationType.Delete,
+				userId: 0,
+				credentialType: UserCredentialType.None,
+				credentialSlot: 0,
+			});
+			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
+			return u3cCredentialReportTypeToSetCredentialResult(
+				raw?.reportType,
+			);
+		} else {
+			const api = this.#ucAPI();
+			const result = await api.clear(0);
+			// Verifying all users being deleted is unrealistic
+			// since there can be up to 65535 users. So we just
+			// assume it worked when the command was not supervised.
+			const succeeded = result == undefined
+				|| supervisedCommandSucceeded(result);
+			if (succeeded) {
+				this.#purgeCachedUserCodes();
+				const node = this.endpoint.tryGetNode();
+				if (node) {
+					node.emit("credential deleted", this.endpoint as any, {
+						userId: 0,
+						credentialType: this.#ucCredentialType,
+						credentialSlot: 0,
+					});
+					node.emit("user deleted", this.endpoint as any, {
+						userId: 0,
+					});
 				}
 			}
 			return succeeded
@@ -1283,16 +1454,27 @@ export class AccessControlAPI extends FeatureAPI {
 		}
 	}
 
-	/** Removes all cached user code status and code values from the value DB */
-	#purgeAllCachedUserCodes(): void {
+	/**
+	 * Removes cached user code status and code values from the value DB.
+	 * If `userId` is given, only values for that user are removed. Otherwise, all
+	 * cached user codes are purged.
+	 */
+	#purgeCachedUserCodes(userId?: number): void {
 		const valueDB = this.endpoint.tryGetNode()?.valueDB;
 		if (!valueDB) return;
 
-		const values = valueDB.findValues(
+		let values = valueDB.findValues(
 			(vid) =>
-				UserCodeCCValues.userIdStatus.is(vid)
-				|| UserCodeCCValues.userCode.is(vid),
+				vid.endpoint === this.endpoint.index
+				&& (UserCodeCCValues.userIdStatus.is(vid)
+					|| UserCodeCCValues.userCode.is(vid)),
 		);
+		if (userId) {
+			values = values.filter(
+				(vid) => vid.propertyKey === userId,
+			);
+		}
+
 		for (const vid of values) {
 			valueDB.removeValue(vid);
 		}

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -14,6 +14,7 @@ import {
 import { CommandClasses } from "@zwave-js/core";
 import { MockZWaveFrameType, ccCaps } from "@zwave-js/testing";
 import { createDeferredPromise } from "alcalzone-shared/deferred-promise";
+import { SetCredentialResult } from "../../node/feature-apis/AccessControl.js";
 import { integrationTest } from "../integrationTestSuite.js";
 
 // =============================================================================
@@ -551,7 +552,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteCredential emits credential deleted event for existing credential",
+	"deleteCredential emits credential deleted + user deleted events on UC (cross-deletion cascade)",
 	{
 		nodeCapabilities: {
 			commandClasses: [
@@ -578,22 +579,218 @@ integrationTest(
 			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "1234");
 
 			const credEvent = createDeferredPromise<unknown>();
+			const userEvent = createDeferredPromise<unknown>();
 			node.on(
 				"credential deleted",
 				(_node, args) => credEvent.resolve(args),
 			);
+			node.on("user deleted", (_node, args) => userEvent.resolve(args));
 
 			await node.accessControl.deleteCredential(
 				2,
 				UserCredentialType.PINCode,
 				2,
 			);
+			t.expect(
+				node.accessControl.getCredentialCached(
+					UserCredentialType.PINCode,
+					2,
+				),
+			).toBeUndefined();
+			t.expect(node.accessControl.getUserCached(2)).toBeUndefined();
 
 			t.expect(await credEvent).toMatchObject({
 				userId: 2,
 				credentialType: UserCredentialType.PINCode,
 				credentialSlot: 2,
 			});
+			t.expect(await userEvent).toMatchObject({ userId: 2 });
+		},
+	},
+);
+
+integrationTest(
+	"deleteCredential(type, slot) overload on UC treats slot as the user identifier",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(3).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(3).id, "9999");
+
+			const credEvent = createDeferredPromise<unknown>();
+			const userEvent = createDeferredPromise<unknown>();
+			node.on(
+				"credential deleted",
+				(_node, args) => credEvent.resolve(args),
+			);
+			node.on("user deleted", (_node, args) => userEvent.resolve(args));
+
+			await node.accessControl.deleteCredential(
+				UserCredentialType.PINCode,
+				3,
+			);
+
+			t.expect(await credEvent).toMatchObject({
+				userId: 3,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 3,
+			});
+			t.expect(await userEvent).toMatchObject({ userId: 3 });
+		},
+	},
+);
+
+integrationTest(
+	"deleteAllCredentialsForUser emits credential deleted + user deleted events on UC",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(4).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(4).id, "1111");
+
+			const credEvent = createDeferredPromise<unknown>();
+			const userEvent = createDeferredPromise<unknown>();
+			node.on(
+				"credential deleted",
+				(_node, args) => credEvent.resolve(args),
+			);
+			node.on("user deleted", (_node, args) => userEvent.resolve(args));
+
+			await node.accessControl.deleteAllCredentialsForUser(4);
+			t.expect(
+				node.accessControl.getCredentialCached(
+					UserCredentialType.PINCode,
+					4,
+				),
+			).toBeUndefined();
+			t.expect(node.accessControl.getUserCached(4)).toBeUndefined();
+
+			t.expect(await credEvent).toMatchObject({
+				userId: 4,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 4,
+			});
+			t.expect(await userEvent).toMatchObject({ userId: 4 });
+		},
+	},
+);
+
+integrationTest(
+	"deleteAllCredentialsForUser throws on UC when credentialType is unsupported",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			await t.expect(
+				node.accessControl.deleteAllCredentialsForUser(
+					1,
+					UserCredentialType.Password,
+				),
+			).rejects.toThrow();
+		},
+	},
+);
+
+integrationTest(
+	"deleteAllCredentials emits wildcard credential deleted + user deleted events on UC",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const credEvent = createDeferredPromise<unknown>();
+			const userEvent = createDeferredPromise<unknown>();
+			node.on(
+				"credential deleted",
+				(_node, args) => credEvent.resolve(args),
+			);
+			node.on("user deleted", (_node, args) => userEvent.resolve(args));
+
+			await node.accessControl.deleteAllCredentials();
+
+			t.expect(await credEvent).toMatchObject({
+				userId: 0,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 0,
+			});
+			t.expect(await userEvent).toMatchObject({ userId: 0 });
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof UserCodeCCExtendedUserCodeSet
+					&& frame.payload.userCodes.length === 1
+					&& frame.payload.userCodes[0].userId === 0
+					&& frame.payload.userCodes[0].userIdStatus
+						=== UserIDStatus.Available,
+				{
+					errorMessage:
+						"Should have sent ExtendedUserCodeSet with userId 0 and Available status",
+				},
+			);
 		},
 	},
 );
@@ -914,7 +1111,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteCredential ignores slot !== userId and deletes the user's credential",
+	"deleteCredential rejects with ModifyRejectedLocationEmpty when slot !== userId on UC",
 	{
 		nodeCapabilities: {
 			commandClasses: [
@@ -939,23 +1136,21 @@ integrationTest(
 			);
 			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "1234");
 
-			const credEvent = createDeferredPromise<unknown>();
-			node.on(
-				"credential deleted",
-				(_node, args) => credEvent.resolve(args),
-			);
+			let emitted = false;
+			node.on("credential deleted", () => {
+				emitted = true;
+			});
 
-			await node.accessControl.deleteCredential(
+			const result = await node.accessControl.deleteCredential(
 				2,
 				UserCredentialType.PINCode,
 				99,
 			);
 
-			t.expect(await credEvent).toMatchObject({
-				userId: 2,
-				credentialType: UserCredentialType.PINCode,
-				credentialSlot: 2,
-			});
+			t.expect(result).toBe(
+				SetCredentialResult.Error_ModifyRejectedLocationEmpty,
+			);
+			t.expect(emitted).toBe(false);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -46,7 +46,7 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			// User capabilities
-			const userCaps = node.accessControl.getUserCapabilitiesCached();
+			const userCaps = node.accessControl!.getUserCapabilitiesCached();
 			t.expect(userCaps).toBeDefined();
 			t.expect(userCaps.maxUsers).toBe(10);
 			t.expect(userCaps.supportedUserTypes).toStrictEqual([
@@ -59,7 +59,7 @@ integrationTest(
 			]);
 
 			// Credential capabilities
-			const credCaps = node.accessControl
+			const credCaps = node.accessControl!
 				.getCredentialCapabilitiesCached();
 			t.expect(credCaps).toBeDefined();
 			t.expect(credCaps.supportsAdminCode).toBe(true);
@@ -99,7 +99,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			const caps = node.accessControl.getUserCapabilitiesCached();
+			const caps = node.accessControl!.getUserCapabilitiesCached();
 			t.expect(caps.supportedUserTypes).toStrictEqual([
 				UserCredentialUserType.General,
 			]);
@@ -151,28 +151,28 @@ integrationTest(
 			node.valueDB.setValue(UserCodeCCValues.userCode(3).id, "9999");
 
 			// User 1: Enabled -> active: true, userType: General
-			const user1 = node.accessControl.getUserCached(1);
+			const user1 = node.accessControl!.getUserCached(1);
 			t.expect(user1).toBeDefined();
 			t.expect(user1!.active).toBe(true);
 			t.expect(user1!.userType).toBe(UserCredentialUserType.General);
 
 			// User 2: Disabled -> active: false, userType: General
-			const user2 = node.accessControl.getUserCached(2);
+			const user2 = node.accessControl!.getUserCached(2);
 			t.expect(user2).toBeDefined();
 			t.expect(user2!.active).toBe(false);
 			t.expect(user2!.userType).toBe(UserCredentialUserType.General);
 
 			// User 3: Messaging -> active: true, userType: NonAccess
-			const user3 = node.accessControl.getUserCached(3);
+			const user3 = node.accessControl!.getUserCached(3);
 			t.expect(user3).toBeDefined();
 			t.expect(user3!.active).toBe(true);
 			t.expect(user3!.userType).toBe(UserCredentialUserType.NonAccess);
 
 			// User 4: not set -> undefined
-			t.expect(node.accessControl.getUserCached(4)).toBeUndefined();
+			t.expect(node.accessControl!.getUserCached(4)).toBeUndefined();
 
 			// getUsers should return 3 users
-			const users = node.accessControl.getUsersCached();
+			const users = node.accessControl!.getUsersCached();
 			t.expect(users.length).toBe(3);
 		},
 	},
@@ -210,14 +210,14 @@ integrationTest(
 			);
 			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "5678");
 
-			const creds = node.accessControl.getCredentialsForUserCached(1);
+			const creds = node.accessControl!.getCredentialsForUserCached(1);
 			t.expect(creds.length).toBe(1);
 			t.expect(creds[0].type).toBe(UserCredentialType.PINCode);
 			t.expect(creds[0].slot).toBe(1);
 			t.expect(creds[0].data).toBe("1234");
 
 			t.expect(
-				node.accessControl.getCredentialCached(
+				node.accessControl!.getCredentialCached(
 					UserCredentialType.PINCode,
 					2,
 				),
@@ -228,19 +228,19 @@ integrationTest(
 				data: "5678",
 			});
 			t.expect(
-				node.accessControl.getCredentialsForUserCached(2)[0].slot,
+				node.accessControl!.getCredentialsForUserCached(2)[0].slot,
 			).toBe(2);
 			t.expect(
-				node.accessControl.getCredentialsByTypeCached(
+				node.accessControl!.getCredentialsByTypeCached(
 					UserCredentialType.PINCode,
 				).length,
 			).toBe(2);
-			t.expect(node.accessControl.getAllCredentialsCached().length).toBe(
+			t.expect(node.accessControl!.getAllCredentialsCached().length).toBe(
 				2,
 			);
 
 			// Non-existent user has no credentials
-			t.expect(node.accessControl.getCredentialsForUserCached(3).length)
+			t.expect(node.accessControl!.getCredentialsForUserCached(3).length)
 				.toBe(0);
 		},
 	},
@@ -276,7 +276,7 @@ integrationTest(
 				(_node, args) => credEvent.resolve(args),
 			);
 
-			await node.accessControl.setCredential(
+			await node.accessControl!.setCredential(
 				2,
 				UserCredentialType.PINCode,
 				2,
@@ -326,7 +326,7 @@ integrationTest(
 				(_node, args) => credEvent.resolve(args),
 			);
 
-			await node.accessControl.setCredential(
+			await node.accessControl!.setCredential(
 				2,
 				UserCredentialType.PINCode,
 				2,
@@ -378,7 +378,7 @@ integrationTest(
 				(_node, args) => credEvent.resolve(args),
 			);
 
-			await node.accessControl.deleteUser(1);
+			await node.accessControl!.deleteUser(1);
 
 			t.expect(await userEvent).toMatchObject({ userId: 1 });
 			t.expect(await credEvent).toMatchObject({
@@ -415,7 +415,7 @@ integrationTest(
 			node.on("credential deleted", () => eventEmitted = true);
 
 			// User 5 is within range but was never set
-			await node.accessControl.deleteUser(5);
+			await node.accessControl!.deleteUser(5);
 
 			// Give the driver time to process
 			await new Promise((resolve) => setTimeout(resolve, 100));
@@ -448,7 +448,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.setCredential(
+			await node.accessControl!.setCredential(
 				2,
 				UserCredentialType.PINCode,
 				2,
@@ -491,7 +491,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.setCredential(
+			await node.accessControl!.setCredential(
 				2,
 				UserCredentialType.PINCode,
 				2,
@@ -537,7 +537,7 @@ integrationTest(
 			const userEvent = createDeferredPromise<unknown>();
 			node.on("user added", (_node, args) => userEvent.resolve(args));
 
-			await node.accessControl.setUser(1, {
+			await node.accessControl!.setUser(1, {
 				active: true,
 				userType: UserCredentialUserType.General,
 			});
@@ -586,18 +586,18 @@ integrationTest(
 			);
 			node.on("user deleted", (_node, args) => userEvent.resolve(args));
 
-			await node.accessControl.deleteCredential(
+			await node.accessControl!.deleteCredential(
 				2,
 				UserCredentialType.PINCode,
 				2,
 			);
 			t.expect(
-				node.accessControl.getCredentialCached(
+				node.accessControl!.getCredentialCached(
 					UserCredentialType.PINCode,
 					2,
 				),
 			).toBeUndefined();
-			t.expect(node.accessControl.getUserCached(2)).toBeUndefined();
+			t.expect(node.accessControl!.getUserCached(2)).toBeUndefined();
 
 			t.expect(await credEvent).toMatchObject({
 				userId: 2,
@@ -643,7 +643,7 @@ integrationTest(
 			);
 			node.on("user deleted", (_node, args) => userEvent.resolve(args));
 
-			await node.accessControl.deleteCredential(
+			await node.accessControl!.deleteCredential(
 				UserCredentialType.PINCode,
 				3,
 			);
@@ -659,7 +659,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteAllCredentialsForUser emits credential deleted + user deleted events on UC",
+	"deleteCredentials for a single user emits credential deleted + user deleted events on UC",
 	{
 		nodeCapabilities: {
 			commandClasses: [
@@ -692,14 +692,14 @@ integrationTest(
 			);
 			node.on("user deleted", (_node, args) => userEvent.resolve(args));
 
-			await node.accessControl.deleteAllCredentialsForUser(4);
+			await node.accessControl!.deleteCredentials({ userId: 4 });
 			t.expect(
-				node.accessControl.getCredentialCached(
+				node.accessControl!.getCredentialCached(
 					UserCredentialType.PINCode,
 					4,
 				),
 			).toBeUndefined();
-			t.expect(node.accessControl.getUserCached(4)).toBeUndefined();
+			t.expect(node.accessControl!.getUserCached(4)).toBeUndefined();
 
 			t.expect(await credEvent).toMatchObject({
 				userId: 4,
@@ -712,7 +712,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteAllCredentialsForUser throws on UC when credentialType is unsupported",
+	"deleteCredentials throws on UC when credentialType is unsupported",
 	{
 		nodeCapabilities: {
 			commandClasses: [
@@ -732,17 +732,17 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			await t.expect(
-				node.accessControl.deleteAllCredentialsForUser(
-					1,
-					UserCredentialType.Password,
-				),
+				node.accessControl!.deleteCredentials({
+					userId: 1,
+					credentialType: UserCredentialType.Password,
+				}),
 			).rejects.toThrow();
 		},
 	},
 );
 
 integrationTest(
-	"deleteAllCredentials emits wildcard credential deleted + user deleted events on UC",
+	"deleteCredentials without filters emits wildcard credential deleted + user deleted events on UC",
 	{
 		nodeCapabilities: {
 			commandClasses: [
@@ -769,7 +769,7 @@ integrationTest(
 			);
 			node.on("user deleted", (_node, args) => userEvent.resolve(args));
 
-			await node.accessControl.deleteAllCredentials();
+			await node.accessControl!.deleteCredentials();
 
 			t.expect(await credEvent).toMatchObject({
 				userId: 0,
@@ -815,7 +815,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.deleteAllUsers();
+			await node.accessControl!.deleteAllUsers();
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -856,8 +856,8 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			// Set admin code, then read it back
-			await node.accessControl.setAdminCode("9999");
-			const code = await node.accessControl.getAdminCode();
+			await node.accessControl!.setAdminCode("9999");
+			const code = await node.accessControl!.getAdminCode();
 			t.expect(code).toBe("9999");
 		},
 	},
@@ -886,7 +886,7 @@ integrationTest(
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
 
-			await node.accessControl.setUser(1, {
+			await node.accessControl!.setUser(1, {
 				active: false,
 				userType: UserCredentialUserType.General,
 			});
@@ -933,7 +933,7 @@ integrationTest(
 			);
 			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
 
-			await node.accessControl.deleteCredential(
+			await node.accessControl!.deleteCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -976,7 +976,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.setAdminCode("9999");
+			await node.accessControl!.setAdminCode("9999");
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -1011,7 +1011,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.getAdminCode();
+			await node.accessControl!.getAdminCode();
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -1045,7 +1045,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.accessControl.deleteUser(1);
+			await node.accessControl!.deleteUser(1);
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -1093,7 +1093,7 @@ integrationTest(
 				(_node, args) => credEvent.resolve(args),
 			);
 
-			await node.accessControl.setCredential(
+			await node.accessControl!.setCredential(
 				2,
 				UserCredentialType.PINCode,
 				99,
@@ -1141,7 +1141,7 @@ integrationTest(
 				emitted = true;
 			});
 
-			const result = await node.accessControl.deleteCredential(
+			const result = await node.accessControl!.deleteCredential(
 				2,
 				UserCredentialType.PINCode,
 				99,


### PR DESCRIPTION
This PR adds the missing APIs for bulk-deleting credentials to the `accessControl` API.
Fixes: https://github.com/zwave-js/zwave-js/issues/8768