### PR TITLE
fix(config): add lifeline association and remove Binary Switch CC for iBlinds v2 (IB2.0)

### DIFF
--- a/packages/config/config/devices/0x0287/ib2_0.json
+++ b/packages/config/config/devices/0x0287/ib2_0.json
@@ -20,15 +20,6 @@
 			"isLifeline": true
 		}
 	},
-	"compat": {
-		"commandClasses": {
-			"remove": {
-				"Binary Switch": {
-					"endpoints": "*"
-				}
-			}
-		}
-	},
 	"paramInformation": [
 		{
 			"#": "1",
@@ -60,5 +51,17 @@
 				}
 			]
 		}
-	]
+	],
+	"compat": {
+		// https://github.com/zwave-js/zwave-js/issues/5686
+		// The device supports Binary Switch CC to control the tilt, but it is not linked
+		// to the Window Covering CC values. Remove the Binary Switch CC to avoid confusion.
+		"commandClasses": {
+			"remove": {
+				"Binary Switch": {
+					"endpoints": "*"
+				}
+			}
+		}
+	}
 }

--- a/packages/config/config/devices/0x0287/ib2_0.json
+++ b/packages/config/config/devices/0x0287/ib2_0.json
@@ -13,6 +13,22 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 1,
+			"isLifeline": true
+		}
+	},
+	"compat": {
+		"commandClasses": {
+			"remove": {
+				"Binary Switch": {
+					"endpoints": "*"
+				}
+			}
+		}
+	},
 	"paramInformation": [
 		{
 			"#": "1",


### PR DESCRIPTION
## Problem

Two issues affect the iBlinds v2 (IB2.0) blind motor under zwave-js:

### 1 — Position always "unknown"

The v2 config was missing an Association Group 1 (Lifeline) definition. Without it, zwave-js does not assign the controller to the lifeline during inclusion, so the device never sends unsolicited Multilevel Switch Reports after movement. The controller must poll manually, and the position remains "unknown" between polls.

**Fix:** Add the standard Lifeline association block (identical to `iblindsv3.json`).

### 2 — Binary Switch CC confusion

v2 firmware 1.65 exposes Binary Switch CC, but like v3, it is not linked to Window Covering CC values. This causes incorrect state in controllers that surface Binary Switch as a separate entity.

**Fix:** Remove Binary Switch CC via compat flag, consistent with v3 config and the documented reasoning in #5686.

## Changes

`packages/config/config/devices/0x0287/ib2_0.json`:
- Added `associations` block with Group 1 Lifeline (1 node, `isLifeline: true`)
- Added `compat.commandClasses.remove` for Binary Switch across all endpoints

## Notes

- Parameters 2–10 (including Parameter 4 "Default ON Value") are v3 firmware additions and are **not** supported by v2 firmware (1.65). Only Parameter 1 is retained.
- The fix mirrors the existing `iblindsv3.json` pattern for both associations and compat.

## Testing

Verified on 6× IB2.0 nodes at firmware 1.65 with zwave-js-ui. After re-interview, all nodes self-assigned the controller to Group 1 and began sending position reports without manual polling.