### PR TITLE
feat(config): add fingerprint to Kwikset HC620

### DIFF
--- a/packages/config/config/devices/0x0090/hc620.json
+++ b/packages/config/config/devices/0x0090/hc620.json
@@ -20,6 +20,10 @@
 		},
 		{
 			"productType": "0x0811",
+			"productId": "0x13b9"
+		},
+		{
+			"productType": "0x0811",
 			"productId": "0x23a8",
 			"zwaveAllianceId": 4184
 		},


### PR DESCRIPTION
added fingerprint 0x13b9 as a variation for Home Connect 620
