### PR TITLE
fix(config): correct label of "Twist Assist" parameter on Danalock V3-BTZE, limit to FW < 0.22

### DIFF
--- a/packages/config/config/devices/0x010e/danalock_v3-btze.json
+++ b/packages/config/config/devices/0x010e/danalock_v3-btze.json
@@ -18,6 +18,7 @@
 		{
 			"#": "1",
 			"label": "Twist Assist",
+			"description": "Deprecated parameter - no longer supported",
 			"deprecated": true,
 			"valueSize": 1,
 			"defaultValue": 0,

--- a/packages/config/config/devices/0x010e/danalock_v3-btze.json
+++ b/packages/config/config/devices/0x010e/danalock_v3-btze.json
@@ -17,7 +17,8 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Twin Assist",
+			"label": "Twist Assist",
+			"deprecated": true,
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,

--- a/packages/config/config/devices/0x010e/danalock_v3-btze.json
+++ b/packages/config/config/devices/0x010e/danalock_v3-btze.json
@@ -17,9 +17,9 @@
 	"paramInformation": [
 		{
 			"#": "1",
+			// This parameter was removed in firmware version 0.22.0
+			"$if": "firmwareVersion < 0.22",
 			"label": "Twist Assist",
-			"description": "Deprecated parameter - no longer supported",
-			"deprecated": true,
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,


### PR DESCRIPTION
Corrects the label for parameter #1 from "Twin Assist" to "Twist Assist" and marks it as deprecated, as this parameter has not been supported for 2-3 years.
