### PR TITLE
fix: handle failed serial port reopen during controller recovery

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3561,7 +3561,11 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 		// Make sure we're able to communicate with the controller again
 		if (!(await this.ensureSerialAPI())) {
 			if (destroyOnError) {
-				await this.destroy();
+				// Notify applications that the driver failed, so they can
+				// clean up and restart, instead of just disappearing
+				await this.destroyWithMessage(
+					"The Serial API did not respond after soft-reset",
+				);
 			} else {
 				throw new ZWaveError(
 					"The Serial API did not respond after soft-reset",
@@ -4711,12 +4715,10 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 			try {
 				await this.openSerialport();
 			} catch (e) {
-				// If we can't reopen the serial port (e.g. a TCP-backed port
-				// whose remote endpoint went away), there is no path back to
-				// a working driver from here. Destroy the driver so consumers
-				// see a `Driver_Failed` error event and can restart, instead
-				// of leaving the driver wedged. Matches the pattern in
-				// handleSerialPortClosedUnexpectedly. See zwave-js-ui#4451.
+				// The serial port cannot be reopened, e.g. because a TCP-based
+				// connection to the controller is gone. The driver cannot
+				// recover from this, so notify applications that it failed,
+				// allowing them to clean up and restart.
 				void this.destroyWithMessage(getErrorMessage(e));
 				return;
 			}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4708,7 +4708,18 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 			);
 			if (this.serial.isOpen) await this.serial.close();
 			await wait(1000);
-			await this.openSerialport();
+			try {
+				await this.openSerialport();
+			} catch (e) {
+				// If we can't reopen the serial port (e.g. a TCP-backed port
+				// whose remote endpoint went away), there is no path back to
+				// a working driver from here. Destroy the driver so consumers
+				// see a `Driver_Failed` error event and can restart, instead
+				// of leaving the driver wedged. Matches the pattern in
+				// handleSerialPortClosedUnexpectedly. See zwave-js-ui#4451.
+				void this.destroyWithMessage(getErrorMessage(e));
+				return;
+			}
 
 			this.driverLog.print(
 				"Serial port reopened. Returning to normal operation and hoping for the best...",

--- a/packages/zwave-js/src/lib/test/driver/controllerUnresponsive.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/controllerUnresponsive.test.ts
@@ -149,6 +149,94 @@ integrationTest(
 );
 
 integrationTest(
+	"When the serial port cannot be reopened during unresponsive controller recovery, the driver emits an error and destroys itself",
+	{
+		// debug: true,
+
+		connectViaTCP: true,
+
+		additionalDriverOptions: {
+			testingHooks: {
+				skipNodeInterview: true,
+			},
+			timeouts: {
+				// Shorten the timeouts to speed up the test
+				ack: 400,
+			},
+			attempts: {
+				// Spend less time waiting, but make sure
+				// we excercise the loops at least
+				controller: 2,
+				openSerialPort: 2,
+			},
+		},
+
+		async customSetup(driver, mockController, mockNode) {
+			const doNotRespond: MockControllerBehavior = {
+				onHostMessage(controller, msg) {
+					if (!shouldRespond) return true;
+
+					return false;
+				},
+			};
+			mockController.defineBehavior(doNotRespond);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode, context) {
+			shouldRespond = false;
+			mockController.autoAckHostMessages = false;
+			// Restore the shared flag, so the following tests in this file
+			// start with a responsive controller
+			t.onTestFinished(() => {
+				shouldRespond = true;
+			});
+
+			// Simulate a remote endpoint that lost power: the established
+			// connection stays half-open without traffic, but reconnection
+			// attempts are refused
+			context.tcpServer!.close();
+
+			const errorPromise = new Promise<Error>((resolve) => {
+				driver.on("error", resolve);
+			});
+
+			// The command fails since the controller is unresponsive
+			await assertZWaveError(
+				t.expect,
+				() =>
+					driver.sendMessage<GetControllerIdResponse>(
+						new GetControllerIdRequest(),
+						{ supportCheck: false },
+					),
+				{
+					errorCode: ZWaveErrorCodes.Controller_Timeout,
+					context: "ACK",
+				},
+			);
+
+			// The recovery via soft reset and reopening the serial port fails.
+			// Instead of emitting an unhandled exception, this should be surfaced
+			// as a Driver_Failed error.
+			const error = await Promise.race([
+				errorPromise,
+				wait(10000).then(() => {
+					throw new Error(
+						"The driver did not emit an error event",
+					);
+				}),
+			]);
+			assertZWaveError(t.expect, error, {
+				errorCode: ZWaveErrorCodes.Driver_Failed,
+			});
+
+			// And the driver should be destroyed
+			await wait(100);
+			t.expect(driver["wasDestroyed"]).toBe(true);
+		},
+	},
+);
+
+integrationTest(
 	"The unresponsive controller recovery does not kick in when it was enabled via config",
 	{
 		// debug: true,


### PR DESCRIPTION
When recovering an unresponsive controller by reopening the serial port, `openSerialport()` could throw (e.g. a TCP-backed port whose remote endpoint became unreachable) and the rejection went unhandled. The driver was left wedged: the serial port was closed, the controller status was never restored, and no `error` event was emitted, so applications never learned they needed to restart the driver.

Wrap the reopen call in a try/catch and route failures through `destroyWithMessage()`, matching the pattern already used in `handleSerialPortClosedUnexpectedly()`. Consumers now receive a `Driver_Failed` error event and can trigger their normal restart logic.

Fixes: https://github.com/zwave-js/zwave-js-ui/issues/4451
fixes: https://github.com/zwave-js/zwave-js/issues/8178
closes: https://github.com/zwave-js/zwave-js/pull/8635