### PR TITLE
test: support connecting the driver to the mock port via TCP

### DIFF
--- a/packages/zwave-js/src/lib/driver/DriverMock.ts
+++ b/packages/zwave-js/src/lib/driver/DriverMock.ts
@@ -1,7 +1,14 @@
-import type { ZWaveSerialStream } from "@zwave-js/serial";
+import {
+	SerialAPIParser,
+	type ZWaveSerialBindingFactory,
+	ZWaveSerialFrameType,
+	type ZWaveSerialStream,
+} from "@zwave-js/serial";
 import { MockPort } from "@zwave-js/serial/mock";
+import { noop } from "@zwave-js/shared";
 import type { FileSystem } from "@zwave-js/shared/bindings";
 import { createDeferredPromise } from "alcalzone-shared/deferred-promise";
+import net from "node:net";
 import { tmpdir } from "node:os";
 import path from "pathe";
 import { Driver } from "./Driver.js";
@@ -12,46 +19,109 @@ export interface CreateAndStartDriverWithMockPortResult {
 	continueStartup: () => void;
 	mockPort: MockPort;
 	serial: ZWaveSerialStream;
+	/** The TCP server the driver is connected to. Only present when the `connectViaTCP` option is enabled. */
+	tcpServer?: net.Server;
 }
 
 export interface CreateAndStartDriverWithMockPortOptions {
-	// portAddress: string;
+	/**
+	 * Whether the driver should connect to the mock port through an actual TCP connection
+	 * instead of using its binding directly. This allows testing reconnection scenarios
+	 * with real network errors. Default: false.
+	 */
+	connectViaTCP?: boolean;
+}
+
+/** Exposes a {@link MockPort} via a local TCP server, so the driver can connect to it using a `tcp://` connection string */
+async function serveMockPortViaTCP(mockPort: MockPort): Promise<net.Server> {
+	// Take the role the driver would normally have in direct mode and
+	// bridge between the mock port binding and the TCP socket
+	const binding = await mockPort.factory()();
+
+	let socket: net.Socket | undefined;
+
+	// Forward data from the mock controller to the connected socket
+	void new ReadableStream(binding.source).pipeTo(
+		new WritableStream({
+			write(chunk) {
+				socket?.write(chunk);
+			},
+		}),
+	).catch(noop);
+
+	const sinkWriter = new WritableStream(binding.sink).getWriter();
+
+	const server = net.createServer((sock) => {
+		socket = sock;
+
+		// The mock controller expects one complete message per chunk, but TCP
+		// does not preserve write boundaries. Re-chunk the byte stream into
+		// Serial API frames before passing them on.
+		const parser = new SerialAPIParser();
+		const parserWriter = parser.writable.getWriter();
+		void parser.readable.pipeTo(
+			new WritableStream({
+				write(frame) {
+					if (frame.type !== ZWaveSerialFrameType.SerialAPI) return;
+					const data = typeof frame.data === "number"
+						? Uint8Array.from([frame.data])
+						: frame.data;
+					void sinkWriter.write(data).catch(noop);
+				},
+			}),
+		).catch(noop);
+
+		sock.on("data", (chunk) => {
+			void parserWriter.write(chunk).catch(noop);
+		});
+		sock.on("error", noop);
+		sock.on("close", () => {
+			if (socket === sock) socket = undefined;
+			void parserWriter.abort().catch(noop);
+		});
+	});
+
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", resolve);
+	});
+
+	return server;
 }
 
 /** Creates a real driver instance with a mocked serial port to enable end to end tests */
-export function createAndStartDriverWithMockPort(
+export async function createAndStartDriverWithMockPort(
 	options:
 		& Partial<CreateAndStartDriverWithMockPortOptions>
 		& PartialZWaveOptions = {},
 ): Promise<CreateAndStartDriverWithMockPortResult> {
-	const { ...driverOptions } = options;
+	const { connectViaTCP = false, ...driverOptions } = options;
+
+	const mockPort = new MockPort();
+	let port: string | ZWaveSerialBindingFactory;
+	let tcpServer: net.Server | undefined;
+	if (connectViaTCP) {
+		tcpServer = await serveMockPortViaTCP(mockPort);
+		const address = tcpServer.address() as net.AddressInfo;
+		port = `tcp://${address.address}:${address.port}`;
+	} else {
+		port = mockPort.factory();
+	}
+
 	return new Promise((resolve, reject) => {
 		let driver: Driver;
-		const mockPort = new MockPort();
-		const bindingFactory = mockPort.factory();
-		// let mockPort: MockPortBinding;
-
-		// MockBinding.reset();
-		// MockBinding.createPort(portAddress, {
-		// 	record: true,
-		// 	readyData: new Uint8Array(),
-		// });
 
 		// This will be called when the driver has opened the serial port
 		const onSerialPortOpen = (
 			serial: ZWaveSerialStream,
 		): Promise<void> => {
-			// // Extract the mock serial port
-			// mockPort = MockBinding.getInstance(portAddress)!;
-			// if (!mockPort) reject(new Error("Mock serial port is not open!"));
-
-			// And return the info to the calling code, giving it control over
+			// Return the info to the calling code, giving it control over
 			// continuing the driver startup.
 			const continuePromise = createDeferredPromise();
 			resolve({
 				driver,
 				mockPort,
 				serial,
+				tcpServer,
 				continueStartup: () => continuePromise.resolve(),
 			});
 
@@ -70,7 +140,7 @@ export function createAndStartDriverWithMockPort(
 			onSerialPortOpen,
 		};
 
-		driver = new Driver(bindingFactory, {
+		driver = new Driver(port, {
 			...driverOptions,
 			testingHooks,
 		});

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -11,6 +11,7 @@ import type {
 import { wait } from "alcalzone-shared/async";
 import crypto from "node:crypto";
 import fsp from "node:fs/promises";
+import type net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { type TestContext, test } from "vitest";
@@ -26,6 +27,8 @@ interface IntegrationTestOptions {
 	provisioningDirectory?: string;
 	/** Whether the recorded messages and frames should be cleared before executing the test body. Default: true. */
 	clearMessageStatsBeforeTest?: boolean;
+	/** Whether the driver should connect to the mock controller through an actual TCP connection. This allows testing reconnection scenarios with real network errors. Default: false */
+	connectViaTCP?: boolean;
 	controllerCapabilities?: MockControllerOptions["capabilities"];
 	nodeCapabilities?: MockNodeOptions["capabilities"];
 	customSetup?: (
@@ -39,8 +42,14 @@ interface IntegrationTestOptions {
 		node: ZWaveNode,
 		mockController: MockController,
 		mockNode: MockNode,
+		context: IntegrationTestContext,
 	) => Promise<void>;
 	additionalDriverOptions?: PartialZWaveOptions;
+}
+
+export interface IntegrationTestContext {
+	/** The TCP server the driver is connected to. Only present when the `connectViaTCP` option is enabled. */
+	tcpServer?: net.Server;
 }
 
 export interface IntegrationTestFn {
@@ -66,6 +75,7 @@ function suite(
 		debug = false,
 		provisioningDirectory,
 		clearMessageStatsBeforeTest = true,
+		connectViaTCP = false,
 		additionalDriverOptions,
 	} = options;
 
@@ -73,6 +83,7 @@ function suite(
 	let node: ZWaveNode;
 	let mockPort: MockPort;
 	let serial: ZWaveSerialStream;
+	let tcpServer: net.Server | undefined;
 	let continueStartup: () => void;
 	let mockController: MockController;
 	let mockNode: MockNode;
@@ -96,11 +107,13 @@ function suite(
 			await copyFilesRecursive(fs, provisioningDirectory, cacheDir);
 		}
 
-		({ driver, continueStartup, mockPort, serial } = await prepareDriver(
-			cacheDir,
-			debug,
-			additionalDriverOptions,
-		));
+		({ driver, continueStartup, mockPort, serial, tcpServer } =
+			await prepareDriver(
+				cacheDir,
+				debug,
+				additionalDriverOptions,
+				connectViaTCP,
+			));
 
 		({
 			mockController,
@@ -175,6 +188,7 @@ function suite(
 			await wait(100);
 
 			await driver.destroy();
+			tcpServer?.close(noop);
 			if (!debug) {
 				await fsp.rm(cacheDir, { recursive: true, force: true })
 					.catch(noop);
@@ -182,7 +196,9 @@ function suite(
 		});
 
 		await prepareTest();
-		await testBody(t, driver, node, mockController, mockNode);
+		await testBody(t, driver, node, mockController, mockNode, {
+			tcpServer,
+		});
 	}, 30000);
 }
 

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
@@ -25,6 +25,7 @@ export function prepareDriver(
 	cacheDir: string = path.join(__dirname, "cache"),
 	logToFile: boolean = false,
 	additionalOptions: PartialZWaveOptions = {},
+	connectViaTCP: boolean = false,
 ): Promise<CreateAndStartDriverWithMockPortResult> {
 	// Skipping the bootloader check speeds up tests a lot
 	additionalOptions.testingHooks ??= {};
@@ -46,6 +47,7 @@ export function prepareDriver(
 
 	return createAndStartDriverWithMockPort({
 		...additionalOptions,
+		connectViaTCP,
 		logConfig,
 		securityKeys: {
 			S0_Legacy: Bytes.from("0102030405060708090a0b0c0d0e0f10", "hex"),


### PR DESCRIPTION
Adds a `connectViaTCP` option to the integration test harness. When enabled, the `MockPort` is served through a local TCP server and the driver connects to it using a real `tcp://127.0.0.1:<port>` connection string, going through the production `NodeSocket` binding instead of using the mock port binding directly.

This makes it possible to test disconnection/reconnection scenarios with actual TCP traffic and real network errors (e.g. `ECONNREFUSED`), like the ones reported in #8178.

Tests can access the TCP server through a new `context` parameter of `testBody` to simulate connection failures.