### PR TITLE
fix: do not ignore controlled CCs in NIF

### DIFF
--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -469,6 +469,16 @@ export class VersionCC extends CommandClass {
 					// for which support is determined later.
 					if (cc === CommandClasses.Basic) {
 						endpoint.addCC(cc, { version: supportedVersion });
+					} else if (
+						endpoint.controlsCC(cc) && !endpoint.supportsCC(cc)
+					) {
+						// The node only advertised this CC as controlled (e.g. in the NIF).
+						// Remember the version so its values can be exposed, but do not
+						// promote it to a supported CC.
+						endpoint.addCC(cc, {
+							isControlled: true,
+							version: supportedVersion,
+						});
 					} else {
 						endpoint.addCC(cc, {
 							isSupported: true,

--- a/packages/cc/src/cc/ZWaveProtocolCC.ts
+++ b/packages/cc/src/cc/ZWaveProtocolCC.ts
@@ -92,6 +92,7 @@ export class ZWaveProtocolCCNodeInformationFrame extends ZWaveProtocolCC
 		this.supportsSecurity = options.supportsSecurity;
 		this.supportsBeaming = options.supportsBeaming;
 		this.supportedCCs = options.supportedCCs;
+		this.controlledCCs = options.controlledCCs ?? [];
 	}
 
 	public static from(
@@ -119,6 +120,7 @@ export class ZWaveProtocolCCNodeInformationFrame extends ZWaveProtocolCC
 	public supportsSecurity: boolean;
 	public supportsBeaming: boolean;
 	public supportedCCs: CommandClasses[];
+	public controlledCCs: CommandClasses[];
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		this.payload = encodeNodeInformationFrame(this);
@@ -679,6 +681,7 @@ export class ZWaveProtocolCCNewNodeRegistered extends ZWaveProtocolCC
 		this.supportsSecurity = options.supportsSecurity;
 		this.supportsBeaming = options.supportsBeaming;
 		this.supportedCCs = options.supportedCCs;
+		this.controlledCCs = options.controlledCCs ?? [];
 	}
 
 	public static from(
@@ -711,6 +714,7 @@ export class ZWaveProtocolCCNewNodeRegistered extends ZWaveProtocolCC
 	public supportsSecurity: boolean;
 	public supportsBeaming: boolean;
 	public supportedCCs: CommandClasses[];
+	public controlledCCs: CommandClasses[];
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		this.payload = Bytes.concat([

--- a/packages/core/src/definitions/NodeInfo.test.ts
+++ b/packages/core/src/definitions/NodeInfo.test.ts
@@ -14,8 +14,8 @@ test("parseApplicationNodeInformation() should parse correctly", (t) => {
 		CommandClasses["Multi Channel"],
 		CommandClasses["Multilevel Toggle Switch"],
 		0xef, // ======
-		// Controlled CCs (ignored in Application Node Info)
-		CommandClasses["Multilevel Toggle Switch"],
+		// Controlled CCs
+		CommandClasses["Scene Activation"],
 	]);
 	const eif = parseApplicationNodeInformation(payload);
 
@@ -24,6 +24,9 @@ test("parseApplicationNodeInformation() should parse correctly", (t) => {
 	t.expect(eif.supportedCCs).toStrictEqual([
 		CommandClasses["Multi Channel"],
 		CommandClasses["Multilevel Toggle Switch"],
+	]);
+	t.expect(eif.controlledCCs).toStrictEqual([
+		CommandClasses["Scene Activation"],
 	]);
 });
 

--- a/packages/core/src/definitions/NodeInfo.ts
+++ b/packages/core/src/definitions/NodeInfo.ts
@@ -9,23 +9,26 @@ export interface ApplicationNodeInformation {
 	genericDeviceClass: number;
 	specificDeviceClass: number;
 	supportedCCs: CommandClasses[];
+	controlledCCs?: CommandClasses[];
 }
 
 export function parseApplicationNodeInformation(
 	nif: BytesView,
 ): ApplicationNodeInformation {
 	validatePayload(nif.length >= 2);
+	const ccList = parseCCList(nif.subarray(2));
 	return {
 		genericDeviceClass: nif[0],
 		specificDeviceClass: nif[1],
-		supportedCCs: parseCCList(nif.subarray(2)).supportedCCs,
+		supportedCCs: ccList.supportedCCs,
+		controlledCCs: ccList.controlledCCs,
 	};
 }
 
 export function encodeApplicationNodeInformation(
 	nif: ApplicationNodeInformation,
 ): Bytes {
-	const ccList = encodeCCList(nif.supportedCCs, []);
+	const ccList = encodeCCList(nif.supportedCCs, nif.controlledCCs ?? []);
 	return Bytes.concat([
 		[nif.genericDeviceClass, nif.specificDeviceClass],
 		ccList,
@@ -63,7 +66,7 @@ export function encodeNodeUpdatePayload(
 	nif: NodeUpdatePayload,
 	nodeIdType: NodeIDType = NodeIDType.Short,
 ): Bytes {
-	const ccList = encodeCCList(nif.supportedCCs, []);
+	const ccList = encodeCCList(nif.supportedCCs, nif.controlledCCs ?? []);
 	const nodeId = encodeNodeID(nif.nodeId, nodeIdType);
 	return Bytes.concat([
 		nodeId,
@@ -395,11 +398,12 @@ export function parseNodeInformationFrame(
 		ccList = buffer.subarray(offset);
 	}
 
-	const supportedCCs = parseCCList(ccList).supportedCCs;
+	const { supportedCCs, controlledCCs } = parseCCList(ccList);
 
 	return {
 		...info,
 		supportedCCs,
+		controlledCCs,
 	};
 }
 
@@ -412,7 +416,7 @@ export function encodeNodeInformationFrame(
 		isLongRange,
 	);
 
-	let ccList = encodeCCList(info.supportedCCs, []);
+	let ccList = encodeCCList(info.supportedCCs, info.controlledCCs ?? []);
 	if (isLongRange) {
 		ccList = Bytes.concat([[ccList.length], ccList]);
 	}

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -72,6 +72,12 @@ const respondToRequestNodeInfo: MockNodeBehavior = {
 					.filter(([, info]) => info.isSupported)
 					// FIXME: Filter out secure CCs if the node isn't secure
 					.map(([ccId]) => ccId),
+				controlledCCs: [...self.implementedCCs]
+					// Basic CC must not be included in the NIF
+					.filter(([ccId]) => ccId !== CommandClasses.Basic)
+					// Only include controlled CCs
+					.filter(([, info]) => info.isControlled)
+					.map(([ccId]) => ccId),
 			});
 			return { action: "sendCC", cc };
 		}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2083,6 +2083,17 @@ protocol version:      ${this.protocolVersion}`;
 				}
 				this.addCC(cc, { isSupported: true });
 			}
+			// CC:0000.00.00.12.004: Nodes SHOULD NOT advertise controlled CCs, so we normally
+			// ignore them. However, some devices advertise CCs like Scene Activation ONLY as
+			// controlled, so we remember the controlled list as well. Whether values are exposed
+			// for a controlled CC is decided separately in getDefinedValueIDs().
+			for (const cc of nodeInfo.controlledCCs ?? []) {
+				if (cc === CommandClasses.Basic) {
+					// Basic CC MUST not be in the NIF and we have special rules to determine support
+					continue;
+				}
+				this.addCC(cc, { isControlled: true });
+			}
 		}
 
 		// As the NIF is sent on wakeup, treat this as a sign that the node is awake

--- a/packages/zwave-js/src/lib/test/cc-specific/sceneActivationControlledOnly.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/sceneActivationControlledOnly.test.ts
@@ -1,0 +1,41 @@
+import { SceneActivationCCValues } from "@zwave-js/cc/SceneActivationCC";
+import { CommandClasses } from "@zwave-js/core";
+import { integrationTest } from "../integrationTestSuite.js";
+
+// Regression test for https://github.com/zwave-js/zwave-js/issues/7546
+// Scene Activation CC is typically ONLY reported as controlled, never as supported.
+integrationTest(
+	"Scene Activation CC advertised only as controlled is not ignored",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				// A realistic device supports a few CCs and only controls Scene Activation
+				CommandClasses.Version,
+				{
+					ccId: CommandClasses["Scene Activation"],
+					isSupported: false,
+					isControlled: true,
+				},
+			],
+		},
+
+		testBody: async (t, _driver, node, _mockController, _mockNode) => {
+			// The CC must be remembered as controlled, even though it is neither
+			// supported nor in the supported part of the NIF
+			t.expect(node.controlsCC(CommandClasses["Scene Activation"]))
+				.toBe(true);
+			t.expect(node.supportsCC(CommandClasses["Scene Activation"]))
+				.toBe(false);
+
+			// ...and its value IDs must be exposed
+			const definedValueIDs = node.getDefinedValueIDs();
+			t.expect(
+				definedValueIDs.some((v) =>
+					SceneActivationCCValues.sceneId.is(v)
+				),
+			).toBe(true);
+		},
+	},
+);


### PR DESCRIPTION
We used to ignore controlled CCs in a device's NIF because of a requirement that _Nodes SHOULD NOT advertise controlled CCs_. However that does not mean we can not evaluate them.

For some devices this also caused an issue with missing Scene Activation CC functionality, since this CC is exclusively reported as controlled.

closes: https://github.com/zwave-js/zwave-js/discussions/7983
fixes: https://github.com/zwave-js/zwave-js/issues/7546

closes: https://github.com/zwave-js/zwave-js/pull/8102
closes: https://github.com/zwave-js/zwave-js/pull/7848