### PR TITLE
fix: clear User Code CC slots in value DB instead of deleting

### DIFF
--- a/packages/cc/tsconfig.build.json
+++ b/packages/cc/tsconfig.build.json
@@ -19,8 +19,13 @@
 		},
 		{
 			"path": "../maintenance/tsconfig.build.json"
+		},
+		{
+			"path": "../transformers/tsconfig.build.json"
 		}
 	],
-	"include": ["src_gen/**/*.ts"],
+	"include": [
+		"src_gen/**/*.ts"
+	],
 	"exclude": []
 }

--- a/packages/cc/tsconfig.build.json
+++ b/packages/cc/tsconfig.build.json
@@ -19,13 +19,8 @@
 		},
 		{
 			"path": "../maintenance/tsconfig.build.json"
-		},
-		{
-			"path": "../transformers/tsconfig.build.json"
 		}
 	],
-	"include": [
-		"src_gen/**/*.ts"
-	],
+	"include": ["src_gen/**/*.ts"],
 	"exclude": []
 }

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -799,7 +799,7 @@ export class AccessControlAPI extends FeatureAPI {
 				succeeded = supervisedCommandSucceeded(result);
 			}
 			if (succeeded) {
-				this.#purgeCachedUserCodes(userId);
+				this.#clearCachedUserCodes(userId);
 			}
 			if (succeeded && existed) {
 				const node = this.endpoint.tryGetNode();
@@ -843,7 +843,7 @@ export class AccessControlAPI extends FeatureAPI {
 			const succeeded = result == undefined
 				|| supervisedCommandSucceeded(result);
 			if (succeeded) {
-				this.#purgeCachedUserCodes();
+				this.#clearCachedUserCodes();
 			}
 			return succeeded ? SetUserResult.OK : SetUserResult.Error_Unknown;
 		}
@@ -1195,40 +1195,19 @@ export class AccessControlAPI extends FeatureAPI {
 				succeeded = supervisedCommandSucceeded(result);
 			}
 			if (succeeded) {
-				// User Code CC reserves a permanent slot per user, so a successful
-				// clear leaves the slot in the Available state with an empty code
-				// rather than removing the slot. Persist that explicitly so the
-				// value DB matches what a post-clear Get/Report would yield, and
-				// downstream consumers continue to render the (now empty) slot.
+				this.#clearCachedUserCodes(targetUserId);
+			}
+			if (succeeded && existed) {
 				const node = this.endpoint.tryGetNode();
 				if (node) {
-					const endpointIndex = this.endpoint.index;
-					node.valueDB.setValue(
-						UserCodeCCValues.userIdStatus(targetUserId).endpoint(
-							endpointIndex,
-						),
-						UserIDStatus.Available,
-					);
-					node.valueDB.setValue(
-						UserCodeCCValues.userCode(targetUserId).endpoint(
-							endpointIndex,
-						),
-						"",
-					);
-					if (existed) {
-						node.emit(
-							"credential deleted",
-							this.endpoint as any,
-							{
-								userId: targetUserId,
-								credentialType: type,
-								credentialSlot: targetUserId,
-							},
-						);
-						node.emit("user deleted", this.endpoint as any, {
-							userId: targetUserId,
-						});
-					}
+					node.emit("credential deleted", this.endpoint as any, {
+						userId: targetUserId,
+						credentialType: type,
+						credentialSlot: targetUserId,
+					});
+					node.emit("user deleted", this.endpoint as any, {
+						userId: targetUserId,
+					});
 				}
 			}
 			return succeeded
@@ -1302,7 +1281,7 @@ export class AccessControlAPI extends FeatureAPI {
 					|| supervisedCommandSucceeded(result);
 			}
 			if (succeeded) {
-				this.#purgeCachedUserCodes(userId);
+				this.#clearCachedUserCodes(userId);
 			}
 			if (succeeded && existed) {
 				const node = this.endpoint.tryGetNode();
@@ -1611,11 +1590,13 @@ export class AccessControlAPI extends FeatureAPI {
 	}
 
 	/**
-	 * Removes cached user code status and code values from the value DB.
-	 * If `userId` is given, only values for that user are removed. Otherwise, all
-	 * cached user codes are purged.
+	 * Resets cached User Code CC slots in the value DB to the cleared state
+	 * (`userIdStatus = Available`, `userCode = ""`). User Code CC reserves a
+	 * permanent slot per user identifier, so a cleared slot is still present —
+	 * just empty. If `userId` is given, only that slot is reset; otherwise all
+	 * cached slots are reset.
 	 */
-	#purgeCachedUserCodes(userId?: number): void {
+	#clearCachedUserCodes(userId?: number): void {
 		const valueDB = this.endpoint.tryGetNode()?.valueDB;
 		if (!valueDB) return;
 
@@ -1632,7 +1613,11 @@ export class AccessControlAPI extends FeatureAPI {
 		}
 
 		for (const vid of values) {
-			valueDB.removeValue(vid);
+			if (UserCodeCCValues.userIdStatus.is(vid)) {
+				valueDB.setValue(vid, UserIDStatus.Available);
+			} else {
+				valueDB.setValue(vid, "");
+			}
 		}
 	}
 

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -1195,19 +1195,40 @@ export class AccessControlAPI extends FeatureAPI {
 				succeeded = supervisedCommandSucceeded(result);
 			}
 			if (succeeded) {
-				this.#purgeCachedUserCodes(targetUserId);
-			}
-			if (succeeded && existed) {
+				// User Code CC reserves a permanent slot per user, so a successful
+				// clear leaves the slot in the Available state with an empty code
+				// rather than removing the slot. Persist that explicitly so the
+				// value DB matches what a post-clear Get/Report would yield, and
+				// downstream consumers continue to render the (now empty) slot.
 				const node = this.endpoint.tryGetNode();
 				if (node) {
-					node.emit("credential deleted", this.endpoint as any, {
-						userId: targetUserId,
-						credentialType: type,
-						credentialSlot: targetUserId,
-					});
-					node.emit("user deleted", this.endpoint as any, {
-						userId: targetUserId,
-					});
+					const endpointIndex = this.endpoint.index;
+					node.valueDB.setValue(
+						UserCodeCCValues.userIdStatus(targetUserId).endpoint(
+							endpointIndex,
+						),
+						UserIDStatus.Available,
+					);
+					node.valueDB.setValue(
+						UserCodeCCValues.userCode(targetUserId).endpoint(
+							endpointIndex,
+						),
+						"",
+					);
+					if (existed) {
+						node.emit(
+							"credential deleted",
+							this.endpoint as any,
+							{
+								userId: targetUserId,
+								credentialType: type,
+								credentialSlot: targetUserId,
+							},
+						);
+						node.emit("user deleted", this.endpoint as any, {
+							userId: targetUserId,
+						});
+					}
 				}
 			}
 			return succeeded

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -1591,10 +1591,8 @@ export class AccessControlAPI extends FeatureAPI {
 
 	/**
 	 * Resets cached User Code CC slots in the value DB to the cleared state
-	 * (`userIdStatus = Available`, `userCode = ""`). User Code CC reserves a
-	 * permanent slot per user identifier, so a cleared slot is still present —
-	 * just empty. If `userId` is given, only that slot is reset; otherwise all
-	 * cached slots are reset.
+	 * (`userIdStatus = Available`, `userCode = ""`).
+	 * If `userId` is given, only that slot is reset; otherwise all cached slots are reset.
 	 */
 	#clearCachedUserCodes(userId?: number): void {
 		const valueDB = this.endpoint.tryGetNode()?.valueDB;

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -1307,3 +1307,164 @@ integrationTest(
 		},
 	},
 );
+
+// =============================================================================
+// Post-clear value DB state
+//
+// User Code CC reserves a permanent slot per user identifier, so a cleared
+// slot must persist as `userIdStatus = Available` and `userCode = ""` rather
+// than being removed from the value DB. This mirrors what `persistUserCode`
+// would write after a Get → Report round-trip.
+// =============================================================================
+
+integrationTest(
+	"deleteCredential persists cleared slot as Available + empty code on UC",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const statusVid = UserCodeCCValues.userIdStatus(2).id;
+			const codeVid = UserCodeCCValues.userCode(2).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "1234");
+
+			await node.accessControl!.deleteCredential(
+				2,
+				UserCredentialType.PINCode,
+				2,
+			);
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("");
+		},
+	},
+);
+
+integrationTest(
+	"deleteUser persists cleared slot as Available + empty code on UC",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const statusVid = UserCodeCCValues.userIdStatus(1).id;
+			const codeVid = UserCodeCCValues.userCode(1).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "5678");
+
+			await node.accessControl!.deleteUser(1);
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("");
+		},
+	},
+);
+
+integrationTest(
+	"deleteCredentials persists cleared slot as Available + empty code on UC",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const statusVid = UserCodeCCValues.userIdStatus(4).id;
+			const codeVid = UserCodeCCValues.userCode(4).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "1111");
+
+			await node.accessControl!.deleteCredentials({ userId: 4 });
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("");
+		},
+	},
+);
+
+integrationTest(
+	"deleteAllUsers persists all cleared slots as Available + empty code on UC",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const status1Vid = UserCodeCCValues.userIdStatus(1).id;
+			const code1Vid = UserCodeCCValues.userCode(1).id;
+			const status2Vid = UserCodeCCValues.userIdStatus(2).id;
+			const code2Vid = UserCodeCCValues.userCode(2).id;
+			node.valueDB.setValue(status1Vid, UserIDStatus.Enabled);
+			node.valueDB.setValue(code1Vid, "1111");
+			node.valueDB.setValue(status2Vid, UserIDStatus.Enabled);
+			node.valueDB.setValue(code2Vid, "2222");
+
+			await node.accessControl!.deleteAllUsers();
+
+			t.expect(node.valueDB.getValue(status1Vid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(code1Vid)).toBe("");
+			t.expect(node.valueDB.getValue(status2Vid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(code2Vid)).toBe("");
+		},
+	},
+);


### PR DESCRIPTION
### What

On a successful clear via any of the User Code CC access control APIs (`deleteUser`, `deleteAllUsers`, `deleteCredential`, `deleteCredentials`), the UC branch routes through the shared `#purgeCachedUserCodes` helper, which calls `valueDB.removeValue(vid)` for the `userIdStatus` and `userCode` entries of the affected slots.

### Why this is wrong

User Code CC reserves a fixed number of slots (1..N), one per user identifier. Clearing a slot doesn't make the slot go away — it moves the slot to the `Available` state with an empty code. The slot is still there and can be filled again later.

The legacy property-set path (`UserCodeCCAPI[SET_VALUE]` for `userIdStatus = Available`) ultimately ends up with the slot persisted as `userIdStatus = Available` and `userCode = ""` in the value DB, because of the `verifyChanges` hook in `UserCodeCCAPI[SET_VALUE_HOOKS]` that schedules a poll → Get → Report → `persistUserCode` writes both values.

The `accessControl.*` delete paths skip that and actively *remove* the entries instead. The effect is observable to value-DB consumers: zwave-js-ui renders slots from value-DB entries, so after a delete via any of these APIs, the slot row disappears from its UI entirely (rather than showing as Available like every other cleared slot).

The neighboring `setCredential` UC branch does not purge or rewrite value-DB entries on success — it just emits an event. The asymmetry lives in `#purgeCachedUserCodes`.

### The fix

Rename `#purgeCachedUserCodes` → `#clearCachedUserCodes` and change its implementation to write the cleared state explicitly into the value DB for each existing slot:

* `userIdStatus(userId)` → `UserIDStatus.Available`
* `userCode(userId)` → `""`

This mirrors what `persistUserCode` would write if a Report came back via Get, without forcing an extra Get round-trip on supervised success. All four UC-CC delete paths benefit from the same fix.

### How this was found

Encountered while testing [`lock_code_manager`](https://github.com/raman325/lock_code_manager) 2.x against a 500-series UC lock + zwave-js-ui. LCM 2.x routes credential deletes through `accessControl.deleteCredential` (instead of the legacy property-set path used by LCM 1.x), and the affected slot disappears from zwave-js-ui after each delete. Other cleared slots remain visible.

### Verification

* `yarn test:ts -- accessControl.UserCode.test.ts` → 32/32 pass (28 prior + 4 new integration tests asserting the post-clear `Available` / `""` state for each delete path)
* `yarn test:ts -- accessControl.UserCredential.test.ts` → 30/30 pass (U3C path untouched)
* `oxlint --type-aware` clean
* `dprint check` clean

### Commits

The first and fourth commits are `tsconfig.build.json` noise (added then reverted per review). The actual fix is in commits 2 (initial inline fix) + 3 (refactor to shared helper + integration tests).