### PR TITLE
feat(config): add Jasco 76592 (ZWN4016) In-Wall Smart Switch

### DIFF
--- a/packages/config/config/devices/0x0063/76592_zwn4016.json
+++ b/packages/config/config/devices/0x0063/76592_zwn4016.json
@@ -1,0 +1,79 @@
+{
+	"manufacturer": "Jasco",
+	"manufacturerId": "0x0063",
+	"label": "76592 / ZWN4016",
+	"description": "In-Wall Smart Switch, 800S",
+	"devices": [
+		{
+			"productType": "0x4952",
+			"productId": "0x3438"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Single Press",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Double Press",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "3",
+			"$import": "~/templates/master_template.json#led_indicator_four_options"
+		},
+		{
+			"#": "4",
+			"$import": "~/templates/master_template.json#orientation"
+		},
+		{
+			"#": "5",
+			"$import": "templates/jasco_template.json#three_way_setup"
+		},
+		{
+			"#": "19",
+			"$import": "templates/jasco_template.json#alternate_exclusion"
+		},
+		{
+			"#": "34",
+			"$import": "templates/jasco_template.json#led_indicator_color"
+		},
+		{
+			"#": "35",
+			"$import": "templates/jasco_template.json#led_indicator_intensity"
+		},
+		{
+			"#": "36",
+			"$import": "templates/jasco_template.json#led_indicator_intensity",
+			"label": "Guidelight Mode Intensity"
+		},
+		{
+			"#": "39",
+			"$import": "templates/jasco_template.json#control_groups"
+		},
+		{
+			"#": "84",
+			"$import": "templates/jasco_template.json#factory_default"
+		}
+	],
+	"compat": {
+		// Needed for double-tap support
+		"mapBasicSet": "event"
+	},
+	"metadata": {
+		"inclusion": "Press and release the top or bottom of the smart switch.",
+		"exclusion": "Press and release the top or bottom of the smart switch.",
+		"reset": "1. Pull the airgap switch.\n2. Press and hold the bottom button, push the airgap switch in and continue holding the bottom button for 10 seconds.\n3. The LED will flash once each of the 8 colors then stop."
+	}
+}

--- a/packages/config/config/devices/0x0063/76592_zwn4016.json
+++ b/packages/config/config/devices/0x0063/76592_zwn4016.json
@@ -43,7 +43,7 @@
 		},
 		{
 			"#": "19",
-			"$import": "templates/jasco_template.json#alternate_exclusion"
+			"$import": "templates/jasco_template.json#alternate_exclusion_menu"
 		},
 		{
 			"#": "34",
@@ -51,16 +51,17 @@
 		},
 		{
 			"#": "35",
-			"$import": "templates/jasco_template.json#led_indicator_intensity"
+			"$import": "templates/jasco_template.json#led_indicator_intensity_no_off"
 		},
 		{
 			"#": "36",
-			"$import": "templates/jasco_template.json#led_indicator_intensity",
+			"$import": "templates/jasco_template.json#led_indicator_intensity_no_off",
 			"label": "Guidelight Mode Intensity"
 		},
 		{
 			"#": "39",
-			"$import": "templates/jasco_template.json#control_groups"
+			"$import": "templates/jasco_template.json#smart_bulb_mode",
+			"label": "Relay Control"
 		},
 		{
 			"#": "84",
@@ -74,6 +75,7 @@
 	"metadata": {
 		"inclusion": "Press and release the top or bottom of the smart switch.",
 		"exclusion": "Press and release the top or bottom of the smart switch.",
-		"reset": "1. Pull the airgap switch.\n2. Press and hold the bottom button, push the airgap switch in and continue holding the bottom button for 10 seconds.\n3. The LED will flash once each of the 8 colors then stop."
+		"reset": "1. Pull the airgap switch.\n2. Press and hold the bottom button, push the airgap switch in and continue holding the bottom button for 10 seconds.\n3. The LED will flash once each of the 8 colors then stop.",
+		"manual": "https://products.z-wavealliance.org/wp-content/uploads/products/80387/76592-Z-WavePlusIn-WallSmartSwitchWhiteandLightAlmondPaddles800SUserManual.pdf"
 	}
 }

--- a/packages/config/config/devices/0x0063/templates/jasco_template.json
+++ b/packages/config/config/devices/0x0063/templates/jasco_template.json
@@ -477,6 +477,14 @@
 			}
 		]
 	},
+	"led_indicator_intensity_no_off": {
+		"label": "LED Indicator Intensity",
+		"valueSize": 1,
+		"minValue": 1,
+		"maxValue": 7,
+		"defaultValue": 4,
+		"unsigned": true
+	},
 	"smart_bulb_mode": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Smart Bulb Mode"


### PR DESCRIPTION
Add a new Z-Wave device configuration for the Jasco 76592 / ZWN4016 In-Wall Smart Switch (800S) at packages/config/config/devices/0x0063/76592_zwn4016.json. Includes manufacturer/device IDs, firmware range, association groups (Lifeline, Single Press, Double Press), and parameter imports for LED options, orientation, three-way setup, exclusion, control groups, and factory default. Adds compat mapping (mapBasicSet => event) for double-tap support and provides inclusion/exclusion/reset metadata instructions.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

PR description here
Thought I would test my current repository. would close #8780