### PR TITLE
fix: update Zooz ZEN35 for firmware 1.40 and unique dimmer wording

### DIFF
--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -303,6 +303,57 @@
 			}
 		]
 	},
+	"led_indicator_brightness_1_10": {
+		"label": "LED Indicator Brightness",
+		"valueSize": 1,
+		"minValue": 1,
+		"maxValue": 10,
+		"defaultValue": 5,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "10%",
+				"value": 1
+			},
+			{
+				"label": "20%",
+				"value": 2
+			},
+			{
+				"label": "30%",
+				"value": 3
+			},
+			{
+				"label": "40%",
+				"value": 4
+			},
+			{
+				"label": "50%",
+				"value": 5
+			},
+			{
+				"label": "60%",
+				"value": 6
+			},
+			{
+				"label": "70%",
+				"value": 7
+			},
+			{
+				"label": "80%",
+				"value": 8
+			},
+			{
+				"label": "90%",
+				"value": 9
+			},
+			{
+				"label": "100%",
+				"value": 10
+			}
+		]
+	},
 	"led_confirm_config_change": {
 		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 		"label": "LED Indicator: Confirm Configuration Change",

--- a/packages/config/config/devices/0x027a/zen35.json
+++ b/packages/config/config/devices/0x027a/zen35.json
@@ -69,7 +69,7 @@
 		{
 			"#": "1",
 			"$import": "~/templates/master_template.json#led_indicator_four_options",
-			"label": "LED Indicator (Relay)"
+			"label": "LED Indicator (Dimmer)"
 		},
 		{
 			"#": "2",
@@ -94,7 +94,7 @@
 		{
 			"#": "6",
 			"$import": "templates/zooz_template.json#led_indicator_color_extended",
-			"label": "LED Indicator Color (Relay)",
+			"label": "LED Indicator Color (Dimmer)",
 			"defaultValue": 0
 		},
 		{
@@ -123,53 +123,89 @@
 		},
 		{
 			"#": "11",
+			"$if": "firmwareVersion < 1.40",
 			"$import": "templates/zooz_template.json#led_indicator_brightness",
-			"label": "LED Indicator Brightness (Relay)"
+			"label": "LED Indicator Brightness (Dimmer)"
+		},
+		{
+			"#": "11",
+			"$if": "firmwareVersion >= 1.40",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
+			"label": "LED Indicator Brightness (Dimmer)"
 		},
 		{
 			"#": "12",
+			"$if": "firmwareVersion < 1.40",
 			"$import": "templates/zooz_template.json#led_indicator_brightness",
 			"label": "LED Indicator Brightness (Button 1)"
 		},
 		{
+			"#": "12",
+			"$if": "firmwareVersion >= 1.40",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
+			"label": "LED Indicator Brightness (Button 1)"
+		},
+		{
 			"#": "13",
+			"$if": "firmwareVersion < 1.40",
 			"$import": "templates/zooz_template.json#led_indicator_brightness",
 			"label": "LED Indicator Brightness (Button 2)"
 		},
 		{
+			"#": "13",
+			"$if": "firmwareVersion >= 1.40",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
+			"label": "LED Indicator Brightness (Button 2)"
+		},
+		{
 			"#": "14",
+			"$if": "firmwareVersion < 1.40",
 			"$import": "templates/zooz_template.json#led_indicator_brightness",
 			"label": "LED Indicator Brightness (Button 3)"
 		},
 		{
+			"#": "14",
+			"$if": "firmwareVersion >= 1.40",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
+			"label": "LED Indicator Brightness (Button 3)"
+		},
+		{
 			"#": "15",
+			"$if": "firmwareVersion < 1.40",
 			"$import": "templates/zooz_template.json#led_indicator_brightness",
+			"label": "LED Indicator Brightness (Button 4)"
+		},
+		{
+			"#": "15",
+			"$if": "firmwareVersion >= 1.40",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
 			"label": "LED Indicator Brightness (Button 4)"
 		},
 		{
 			"#": "16",
 			"$import": "templates/zooz_template.json#auto_off_timer_0x_1x_3x_7x",
-			"label": "Auto-Off Timer (Relay)"
+			"label": "Auto-Off Timer (Dimmer)"
 		},
 		{
 			"#": "17",
 			"$import": "templates/zooz_template.json#auto_on_timer_0x_1x_3x_7x",
-			"label": "Auto-On Timer (Relay)"
+			"label": "Auto-On Timer (Dimmer)"
 		},
 		{
 			"#": "18",
-			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev",
+			"defaultValue": 0
 		},
 		{
 			"#": "19",
 			"$import": "~/templates/master_template.json#smart_switch_mode_0-2",
-			"label": "Relay Control"
+			"label": "Load Control (Smart Bulb Mode)"
 		},
 		{
 			"#": "20",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Send Report and Toggle LED on Button Press If Relay Disabled",
-			"defaultValue": 0
+			"label": "Send Report and Toggle LED on Button Press If Dimmer Disabled",
+			"defaultValue": 1
 		},
 		{
 			"#": "21",
@@ -182,7 +218,8 @@
 		},
 		{
 			"#": "23",
-			"$import": "templates/zooz_template.json#local_dimming_speed"
+			"$import": "templates/zooz_template.json#local_dimming_speed",
+			"defaultValue": 5
 		},
 		{
 			"#": "24",
@@ -194,15 +231,18 @@
 		},
 		{
 			"#": "26",
-			"$import": "templates/zooz_template.json#local_dimming_speed_group_3_and_4"
+			"$import": "templates/zooz_template.json#local_dimming_speed_group_3_and_4",
+			"defaultValue": 5
 		},
 		{
 			"#": "27",
-			"$import": "templates/zooz_template.json#min_brightness"
+			"$import": "templates/zooz_template.json#min_brightness",
+			"defaultValue": 1
 		},
 		{
 			"#": "28",
-			"$import": "templates/zooz_template.json#max_brightness"
+			"$import": "templates/zooz_template.json#max_brightness",
+			"defaultValue": 99
 		},
 		{
 			"#": "29",
@@ -220,7 +260,7 @@
 					"value": 1
 				},
 				{
-					"label": "Configured maximum brightness",
+					"label": "Configured maximum brightness  (Parameter 28)",
 					"value": 2
 				},
 				{
@@ -231,8 +271,28 @@
 		},
 		{
 			"#": "30",
-			"$import": "#paramInformation/29",
-			"label": "Dimmer Button Single Tap"
+			"label": "Dimmer Button Single Tap",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Last brightness level",
+					"value": 0
+				},
+				{
+					"label": "Configured custom brightness (Parameter 31)",
+					"value": 1
+				},
+				{
+					"label": "Configured maximum brightness (Parameter 28)",
+					"value": 2
+				},
+				{
+					"label": "Full brightness",
+					"value": 3
+				}
+			]
 		},
 		{
 			"#": "31",
@@ -249,7 +309,8 @@
 		},
 		{
 			"#": "34",
-			"$import": "templates/zooz_template.json#local_programming"
+			"$import": "templates/zooz_template.json#local_programming",
+			"defaultValue": 0
 		},
 		{
 			"#": "35[0x01]",
@@ -282,7 +343,7 @@
 		{
 			"#": "36",
 			"$import": "templates/zooz_template.json#enable_scene_control",
-			"defaultValue": 1
+			"defaultValue": 0
 		},
 		{
 			"#": "37",
@@ -321,7 +382,13 @@
 			"valueSize": 1,
 			"minValue": 10,
 			"maxValue": 50,
-			"defaultValue": 10
+			"defaultValue": 10,
+			"options": [
+				{
+					"label": "1.0",
+					"value": 10
+				}
+			]
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
Update LED indicator labels for brightness settings. Existing options no longer function with firmware update 1.40. Update wording to specify dimmer instead of relay, that was carryover from the ZEN32 switch.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

PR description here
