### PR TITLE
fix: fall back to User Code CC when User Credential CC is unusable

### DIFF
--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -214,12 +214,49 @@ function supportsNonPINChars(supportedASCIIChars: string | undefined): boolean {
 
 /** High-level API for managing users and credentials on access control devices */
 export class AccessControlAPI extends FeatureAPI {
-	// FIXME: This is technically not correct. A node could support both CCs,
-	// and we may have to decide which one to use, or switch between them on
-	// the fly using Version CC / migration.
-	// This is not implemented yet, so checking for U3C first is fine for now.
+	// FIXME: Switching between both CCs on the fly using Version CC /
+	// migration is not implemented yet. For now, prefer User Credential CC
+	// when its interview yielded usable data, and fall back to User Code CC
+	// otherwise.
 	get #usesUserCredentialCC(): boolean {
-		return this.endpoint.supportsCC(CommandClasses["User Credential"]);
+		if (!this.endpoint.supportsCC(CommandClasses["User Credential"])) {
+			return false;
+		}
+		if (!this.endpoint.supportsCC(CommandClasses["User Code"])) {
+			return true;
+		}
+		// Some devices advertise support for User Credential CC, but report
+		// no users or no usable credential types. When such a device also
+		// supports User Code CC, manage users and credentials through that
+		// instead of pretending that none can exist.
+		return this.#u3cIsUsable;
+	}
+
+	/**
+	 * Whether the cached User Credential CC capabilities indicate that users
+	 * and credentials can actually be managed through it. This is the case
+	 * when the device reports at least one user and at least one credential
+	 * type with a non-zero number of slots.
+	 */
+	get #u3cIsUsable(): boolean {
+		const maxUsers = this.getValue<number>(
+			UserCredentialCCValues.supportedUsers.endpoint(
+				this.endpoint.index,
+			),
+		);
+		if (!maxUsers) return false;
+
+		const supportedTypes = this.getValue<UserCredentialType[]>(
+			UserCredentialCCValues.supportedCredentialTypes.endpoint(
+				this.endpoint.index,
+			),
+		) ?? [];
+		return supportedTypes.some((type) =>
+			this.getValue<UserCredentialCapability>(
+				UserCredentialCCValues.credentialCapabilities(type)
+					.endpoint(this.endpoint.index),
+			)?.numberOfCredentialSlots
+		);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/test/node/accessControl.DualCC.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.DualCC.test.ts
@@ -1,0 +1,212 @@
+import {
+	type UserCredentialCapability,
+	UserCredentialRule,
+	UserCredentialType,
+	UserCredentialUserType,
+	UserIDStatus,
+} from "@zwave-js/cc";
+import { UserCodeCCSet } from "@zwave-js/cc/UserCodeCC";
+import { UserCredentialCCCredentialSet } from "@zwave-js/cc/UserCredentialCC";
+import { CommandClasses } from "@zwave-js/core";
+import { MockZWaveFrameType, ccCaps } from "@zwave-js/testing";
+import { integrationTest } from "../integrationTestSuite.js";
+
+// These tests cover nodes that support BOTH User Code CC and
+// User Credential CC. The User Credential CC is preferred, but only
+// when its interview yielded usable capabilities. Otherwise the
+// User Code CC is used as a fallback.
+
+const userCodeCCCapabilities = ccCaps({
+	ccId: CommandClasses["User Code"],
+	version: 1,
+	numUsers: 10,
+	supportedASCIIChars: "0123456789",
+	supportedUserIDStatuses: [
+		UserIDStatus.Available,
+		UserIDStatus.Enabled,
+		UserIDStatus.Disabled,
+	],
+});
+
+integrationTest(
+	"Falls back to User Code CC when User Credential CC reports no users",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCCCapabilities,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 0,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 16,
+					supportedUserTypes: [UserCredentialUserType.General],
+					supportedCredentialTypes: new Map(),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Capabilities must be derived from User Code CC
+			const userCaps = node.accessControl!.getUserCapabilitiesCached();
+			t.expect(userCaps.maxUsers).toBe(10);
+
+			const credCaps = node.accessControl!
+				.getCredentialCapabilitiesCached();
+			const pinCap = credCaps.supportedCredentialTypes.get(
+				UserCredentialType.PINCode,
+			);
+			t.expect(pinCap).toBeDefined();
+			t.expect(pinCap!.numberOfCredentialSlots).toBe(10);
+
+			// ...and writes must go through User Code CC
+			await node.accessControl!.setCredential(
+				2,
+				UserCredentialType.PINCode,
+				2,
+				"5678",
+			);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof UserCodeCCSet,
+				{
+					errorMessage: "Should have used User Code Set",
+				},
+			);
+		},
+	},
+);
+
+integrationTest(
+	"Falls back to User Code CC when User Credential CC reports no usable credential types",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCCCapabilities,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 20,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 16,
+					supportedUserTypes: [UserCredentialUserType.General],
+					supportedCredentialTypes: new Map<
+						UserCredentialType,
+						UserCredentialCapability
+					>([
+						[UserCredentialType.PINCode, {
+							numberOfCredentialSlots: 0,
+							minCredentialLength: 4,
+							maxCredentialLength: 10,
+							maxCredentialHashLength: 0,
+							supportsCredentialLearn: false,
+						}],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Capabilities must be derived from User Code CC
+			const userCaps = node.accessControl!.getUserCapabilitiesCached();
+			t.expect(userCaps.maxUsers).toBe(10);
+
+			const credCaps = node.accessControl!
+				.getCredentialCapabilitiesCached();
+			const pinCap = credCaps.supportedCredentialTypes.get(
+				UserCredentialType.PINCode,
+			);
+			t.expect(pinCap).toBeDefined();
+			t.expect(pinCap!.numberOfCredentialSlots).toBe(10);
+
+			// ...and writes must go through User Code CC
+			await node.accessControl!.setCredential(
+				2,
+				UserCredentialType.PINCode,
+				2,
+				"5678",
+			);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof UserCodeCCSet,
+				{
+					errorMessage: "Should have used User Code Set",
+				},
+			);
+		},
+	},
+);
+
+integrationTest(
+	"Prefers User Credential CC when it reports usable capabilities",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCCCapabilities,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 20,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 16,
+					supportedUserTypes: [UserCredentialUserType.General],
+					supportedCredentialTypes: new Map<
+						UserCredentialType,
+						UserCredentialCapability
+					>([
+						[UserCredentialType.PINCode, {
+							numberOfCredentialSlots: 5,
+							minCredentialLength: 4,
+							maxCredentialLength: 10,
+							maxCredentialHashLength: 0,
+							supportsCredentialLearn: false,
+						}],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Capabilities must be derived from User Credential CC
+			const userCaps = node.accessControl!.getUserCapabilitiesCached();
+			t.expect(userCaps.maxUsers).toBe(20);
+
+			const credCaps = node.accessControl!
+				.getCredentialCapabilitiesCached();
+			const pinCap = credCaps.supportedCredentialTypes.get(
+				UserCredentialType.PINCode,
+			);
+			t.expect(pinCap).toBeDefined();
+			t.expect(pinCap!.numberOfCredentialSlots).toBe(5);
+
+			// ...and writes must go through User Credential CC. The user
+			// must exist first, since U3C does not auto-create users.
+			await node.accessControl!.setUser(2, {});
+			await node.accessControl!.setCredential(
+				2,
+				UserCredentialType.PINCode,
+				2,
+				"5678",
+			);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof UserCredentialCCCredentialSet,
+				{
+					errorMessage: "Should have used User Credential Set",
+				},
+			);
+		},
+	},
+);


### PR DESCRIPTION
The Access Control feature API dispatches between User Code CC and User Credential CC via `#usesUserCredentialCC`, which so far only checked `supportsCC(User Credential)` (with a FIXME noting that nodes may support both CCs).

For a node that advertises U3C but whose U3C interview yields no usable data — no users, no supported credential types, or only credential types with `numberOfCredentialSlots: 0` — this made the entire unified API unusable even when the node also supports User Code CC and works fine through it:

- `getUserCapabilitiesCached()` / `getCredentialCapabilitiesCached()` report 0 users / 0 slots
- `#assertValidSlot` consequently throws `Credential slot N is out of range for credential type PINCode` for every `setCredential` / `deleteCredential` call

Applications built on the unified API then fail every PIN operation. Seen in the wild via Home Assistant + Lock Code Manager, where users get `Credential slot for pin_code must be between 1 and 0` (HA validates against the same cached capabilities before calling the driver): raman325/lock_code_manager#1251

### Fix

`#usesUserCredentialCC` now prefers User Credential CC only when its cached capabilities are usable (at least one user and at least one credential type with a non-zero number of slots). When the node also supports User Code CC and U3C is unusable, the API falls back to User Code CC instead of pretending no users or credentials can exist.

Notes:

- Nodes supporting only one of the two CCs are unaffected (early returns).
- The check runs against cached interview data, consistent with the rest of the API: if a (re-)interview later yields usable U3C capabilities, dispatch switches to U3C automatically.
- The FIXME is retained for the full solution (switching CCs on the fly / migration via Version CC).

### Tests

New `accessControl.DualCC.test.ts` with three integration tests:

1. Both CCs, U3C reports 0 users → capabilities and writes use User Code CC
2. Both CCs, U3C reports a PIN credential type with 0 slots → capabilities and writes use User Code CC
3. Both CCs, U3C reports usable capabilities → U3C is preferred (existing behavior preserved)

Existing `accessControl.UserCode` / `accessControl.UserCredential` / `userCredentialInterview` suites pass unchanged (72/72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)