### PR TITLE
fix: prevent driver crash on oversized numeric report value

### DIFF
--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -1604,6 +1604,13 @@ export class NotificationCCReport extends NotificationCC {
 			if (!isUint8Array(this.eventParameters)) {
 				return;
 			}
+			// readUIntBE supports at most 6 bytes; a longer (or empty) value
+			// must not reach it, or it throws a RangeError that would escape
+			// the parser and crash the driver
+			validatePayload(
+				this.eventParameters.length >= 1
+					&& this.eventParameters.length <= 6,
+			);
 			// The parameters contain a named value
 			this.eventParameters = {
 				[valueConfig.parameter.propertyName]: Bytes.view(

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationOversizedValueParamNoCrash.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationOversizedValueParamNoCrash.test.ts
@@ -1,0 +1,89 @@
+import {
+	NotificationCCReport,
+	NotificationCCValues,
+} from "@zwave-js/cc/NotificationCC";
+import { Bytes } from "@zwave-js/shared";
+import { createMockZWaveRequestFrame } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"A Notification Report with an oversized value event parameter is discarded instead of crashing the driver",
+	{
+		// The node supports Notification CC; see the fixture
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/notificationCC",
+		),
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// A "value"-type event parameter is decoded via Buffer.readUIntBE,
+			// which throws a RangeError for more than 6 bytes. That error used to
+			// escape the message handler as an unhandled rejection and crash the
+			// process, so we watch for it explicitly.
+			const escaped: Error[] = [];
+			const onError = (e: unknown) => {
+				if (
+					e instanceof RangeError
+					|| (e as { code?: string })?.code === "ERR_OUT_OF_RANGE"
+				) {
+					escaped.push(e as Error);
+				}
+			};
+			process.on("unhandledRejection", onError);
+			process.on("uncaughtException", onError);
+
+			try {
+				// Access Control / "Lock operation with User Code" carries a
+				// "value"-type parameter; 7 bytes is one more than readUIntBE allows.
+				const malicious = new NotificationCCReport({
+					nodeId: mockController.ownNodeId,
+					notificationType: 0x06,
+					notificationEvent: 0x21,
+					eventParameters: Bytes.from([0, 0, 0, 0, 0, 0, 1]),
+				});
+				await mockNode.sendToController(
+					createMockZWaveRequestFrame(malicious, {
+						ackRequested: false,
+					}),
+				);
+				await wait(100);
+
+				// No RangeError escaped the parser
+				t.expect(escaped).toStrictEqual([]);
+				// The driver is still running and processing commands
+				t.expect(driver.ready).toBe(true);
+
+				// And it still processes a subsequent, valid Notification Report
+				const valid = new NotificationCCReport({
+					nodeId: mockController.ownNodeId,
+					notificationType: 0x06,
+					notificationEvent: 0xfd, // Manual Lock Operation
+				});
+				await mockNode.sendToController(
+					createMockZWaveRequestFrame(valid, {
+						ackRequested: false,
+					}),
+				);
+				await wait(100);
+
+				t.expect(
+					node.getValueMetadata(
+						NotificationCCValues.unknownNotificationVariable(
+							0x06,
+							"Access Control",
+						).id,
+					),
+				).toMatchObject({
+					ccSpecific: {
+						notificationType: 0x06,
+					},
+				});
+			} finally {
+				process.off("unhandledRejection", onError);
+				process.off("uncaughtException", onError);
+			}
+		},
+	},
+);


### PR DESCRIPTION
## Problem

A multi-byte numeric value parameter was decoded from an incoming report payload without first bounding its length. The underlying integer buffer read only supports up to 6 bytes and throws a `RangeError` for anything larger (or for an empty buffer). Because that error was raised during value persistence rather than during payload validation, it escaped the parser and could crash the driver — a malicious or buggy device could trigger it with a single frame.

## Fix

Validate the parameter length (1–6 bytes) before reading it. An out-of-range length now fails payload validation, so the malformed frame is dropped cleanly instead of throwing an unhandled exception.