### PR TITLE
fix(cc): validate name length in AGI Group Name Report

### DIFF
--- a/packages/cc/src/cc/AssociationGroupInfoCC.ts
+++ b/packages/cc/src/cc/AssociationGroupInfoCC.ts
@@ -483,7 +483,7 @@ export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
 		validatePayload(raw.payload.length >= 2);
 		const groupId = raw.payload[0];
 		const nameLength = raw.payload[1];
-		// The Name Length field MUST be in the range 0..42 per the spec
+		// CC:0059.01.02.11.001: The Name Length field MUST be in the range 0..42
 		validatePayload(nameLength <= 42);
 		validatePayload(raw.payload.length >= 2 + nameLength);
 		// The specs don't allow 0-terminated string, but some devices use them

--- a/packages/cc/src/cc/AssociationGroupInfoCC.ts
+++ b/packages/cc/src/cc/AssociationGroupInfoCC.ts
@@ -483,6 +483,8 @@ export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
 		validatePayload(raw.payload.length >= 2);
 		const groupId = raw.payload[0];
 		const nameLength = raw.payload[1];
+		// The Name Length field MUST be in the range 0..42 per the spec
+		validatePayload(nameLength <= 42);
 		validatePayload(raw.payload.length >= 2 + nameLength);
 		// The specs don't allow 0-terminated string, but some devices use them
 		// So we need to cut them off


### PR DESCRIPTION
## Problem

A reported group name length was validated only against the number of bytes actually present in the frame, not against the maximum length the specification allows (0–42). A non-conforming or malicious device could set the length field beyond the spec maximum and have the over-long name accepted and persisted, then surfaced to applications as the group label.

## Fix

Validate the length field against the spec maximum (0–42) before decoding the name, mirroring the existing length-bound handling for other reported text fields. An out-of-range length now drops the frame.