### PR TITLE
fix: validate untrusted fields in incoming reports

### DIFF
--- a/packages/cc/src/cc/BarrierOperatorCC.ts
+++ b/packages/cc/src/cc/BarrierOperatorCC.ts
@@ -831,6 +831,10 @@ export class BarrierOperatorCCEventSignalingReport extends BarrierOperatorCC {
 		validatePayload(raw.payload.length >= 2);
 		const subsystemType: SubsystemType = raw.payload[0];
 		const subsystemState: SubsystemState = raw.payload[1];
+		validatePayload(
+			isEnumMember(SubsystemType, subsystemType),
+			isEnumMember(SubsystemState, subsystemState),
+		);
 
 		return new this({
 			nodeId: ctx.sourceNodeId,

--- a/packages/cc/src/cc/BinarySensorCC.ts
+++ b/packages/cc/src/cc/BinarySensorCC.ts
@@ -388,6 +388,7 @@ export class BinarySensorCCReport extends BinarySensorCC {
 		if (raw.payload.length >= 2) {
 			type = raw.payload[1];
 		}
+		validatePayload(isEnumMember(BinarySensorType, type));
 
 		return new this({
 			nodeId: ctx.sourceNodeId,

--- a/packages/cc/src/cc/ColorSwitchCC.ts
+++ b/packages/cc/src/cc/ColorSwitchCC.ts
@@ -770,6 +770,7 @@ export class ColorSwitchCCReport extends ColorSwitchCC {
 	public static from(raw: CCRaw, ctx: CCParsingContext): ColorSwitchCCReport {
 		validatePayload(raw.payload.length >= 2);
 		const colorComponent: ColorComponent = raw.payload[0];
+		validatePayload(isEnumMember(ColorComponent, colorComponent));
 		const currentValue = raw.payload[1];
 		let targetValue: number | undefined;
 		let duration: Duration | undefined;

--- a/packages/cc/src/cc/LanguageCC.ts
+++ b/packages/cc/src/cc/LanguageCC.ts
@@ -261,9 +261,19 @@ export class LanguageCCReport extends LanguageCC {
 	public static from(raw: CCRaw, ctx: CCParsingContext): LanguageCCReport {
 		validatePayload(raw.payload.length >= 3);
 		const language = raw.payload.subarray(0, 3).toString("ascii");
+		// Enforce the same locale format the Set side requires, so a node
+		// cannot push codes that violate ISO 639-2 / ISO 3166-1
+		validatePayload(
+			language.length === 3,
+			language.toLowerCase() === language,
+		);
 		let country: MaybeNotKnown<string>;
 		if (raw.payload.length >= 5) {
 			country = raw.payload.subarray(3, 5).toString("ascii");
+			validatePayload(
+				country.length === 2,
+				country.toUpperCase() === country,
+			);
 		}
 
 		return new this({

--- a/packages/cc/src/cc/MultiChannelAssociationCC.ts
+++ b/packages/cc/src/cc/MultiChannelAssociationCC.ts
@@ -148,7 +148,9 @@ function deserializeMultiChannelAssociationDestination(data: BytesView): {
 		nodeIds.push(data[i]);
 	}
 	const endpoints: EndpointAddress[] = [];
-	for (let i = endpointOffset; i < data.length; i += 2) {
+	// Each endpoint destination is a (node id, endpoint) pair; stop when a
+	// full pair is no longer available so a dangling trailing byte is ignored
+	for (let i = endpointOffset; i + 1 < data.length; i += 2) {
 		const nodeId = data[i];
 		const isBitMask = !!(data[i + 1] & 0b1000_0000);
 		const destination = data[i + 1] & 0b0111_1111;

--- a/packages/cc/src/cc/ScheduleEntryLockCC.ts
+++ b/packages/cc/src/cc/ScheduleEntryLockCC.ts
@@ -1278,6 +1278,15 @@ export class ScheduleEntryLockCCWeekDayScheduleReport
 			}
 		}
 
+		validatePayload(
+			weekday == undefined
+				|| weekday <= ScheduleEntryLockWeekday.Saturday,
+			startHour == undefined || startHour <= 23,
+			startMinute == undefined || startMinute <= 59,
+			stopHour == undefined || stopHour <= 23,
+			stopMinute == undefined || stopMinute <= 59,
+		);
+
 		if (
 			weekday != undefined
 			&& startHour != undefined
@@ -1673,6 +1682,18 @@ export class ScheduleEntryLockCCYearDayScheduleReport
 				stopMinute = raw.payload[11];
 			}
 		}
+
+		validatePayload(
+			startMonth == undefined
+				|| (startMonth >= 1 && startMonth <= 12),
+			startDay == undefined || (startDay >= 1 && startDay <= 31),
+			startHour == undefined || startHour <= 23,
+			startMinute == undefined || startMinute <= 59,
+			stopMonth == undefined || (stopMonth >= 1 && stopMonth <= 12),
+			stopDay == undefined || (stopDay >= 1 && stopDay <= 31),
+			stopHour == undefined || stopHour <= 23,
+			stopMinute == undefined || stopMinute <= 59,
+		);
 
 		if (
 			startYear != undefined
@@ -2150,6 +2171,13 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleReport
 			const startMinute = raw.payload[4];
 			const durationHour = raw.payload[5];
 			const durationMinute = raw.payload[6];
+
+			validatePayload(
+				startHour <= 23,
+				startMinute <= 59,
+				durationHour <= 23,
+				durationMinute <= 59,
+			);
 
 			return new this({
 				nodeId: ctx.sourceNodeId,

--- a/packages/cc/src/cc/TimeCC.ts
+++ b/packages/cc/src/cc/TimeCC.ts
@@ -317,6 +317,13 @@ export class TimeCCDateReport extends TimeCC {
 		const month = raw.payload[2];
 		const day = raw.payload[3];
 
+		validatePayload(
+			month >= 1,
+			month <= 12,
+			day >= 1,
+			day <= 31,
+		);
+
 		return new this({
 			nodeId: ctx.sourceNodeId,
 			year,

--- a/packages/cc/src/cc/TimeParametersCC.ts
+++ b/packages/cc/src/cc/TimeParametersCC.ts
@@ -282,6 +282,13 @@ export class TimeParametersCCReport extends TimeParametersCC {
 			minute: raw.payload[5],
 			second: raw.payload[6],
 		};
+		validatePayload(
+			dateSegments.month >= 1 && dateSegments.month <= 12,
+			dateSegments.day >= 1 && dateSegments.day <= 31,
+			dateSegments.hour >= 0 && dateSegments.hour <= 23,
+			dateSegments.minute >= 0 && dateSegments.minute <= 59,
+			dateSegments.second >= 0 && dateSegments.second <= 59,
+		);
 		const dateAndTime: Date = segmentsToDate(
 			dateSegments,
 			// Assume we can use UTC and correct this assumption in persistValues

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -776,7 +776,6 @@ export class WindowCoveringCCReport extends WindowCoveringCC {
 		validatePayload(raw.payload.length >= 4);
 		const parameter: WindowCoveringParameter = raw.payload[0];
 		validatePayload(isEnumMember(WindowCoveringParameter, parameter));
-		// Levels are in the range 0..99
 		validatePayload(
 			raw.payload[1] <= 99,
 			raw.payload[2] <= 99,

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -13,7 +13,7 @@ import {
 	parseBitMask,
 	validatePayload,
 } from "@zwave-js/core";
-import { Bytes, getEnumMemberName, pick } from "@zwave-js/shared";
+import { Bytes, getEnumMemberName, isEnumMember, pick } from "@zwave-js/shared";
 import { validateArgs } from "@zwave-js/transformers";
 import {
 	CCAPI,
@@ -775,6 +775,12 @@ export class WindowCoveringCCReport extends WindowCoveringCC {
 	): WindowCoveringCCReport {
 		validatePayload(raw.payload.length >= 4);
 		const parameter: WindowCoveringParameter = raw.payload[0];
+		validatePayload(isEnumMember(WindowCoveringParameter, parameter));
+		// Levels are in the range 0..99
+		validatePayload(
+			raw.payload[1] <= 99,
+			raw.payload[2] <= 99,
+		);
 		const currentValue = raw.payload[1];
 		const targetValue = raw.payload[2];
 		const duration = Duration.parseReport(raw.payload[3])

--- a/packages/cc/src/lib/serializers.ts
+++ b/packages/cc/src/lib/serializers.ts
@@ -1,4 +1,4 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { ZWaveError, ZWaveErrorCodes, validatePayload } from "@zwave-js/core";
 import { Bytes, type BytesView } from "@zwave-js/shared";
 import { clamp } from "alcalzone-shared/math";
 import type {
@@ -90,6 +90,8 @@ export function encodeSwitchpoint(point: Switchpoint): Bytes {
  * Decodes timezone information used in time related CCs
  */
 export function parseTimezone(data: BytesView): Timezone {
+	// The timezone structure is 3 bytes: hour, minute, delta
+	validatePayload(data.length >= 3);
 	const hourSign = !!(data[0] & 0b1000_0000);
 	const hour = data[0] & 0b0111_1111;
 	const minute = data[1];


### PR DESCRIPTION
## Problem

A number of report parsers accepted device-provided data with only a length check, then persisted it or surfaced it to the application. Because the corresponding Set/Get parsers (the controller→device direction) already validate these fields but the report parsers (the device→controller direction) did not, a malicious or buggy device could push corrupt data through:

- out-of-range date/time components (year, month, day, hour, minute, second, weekday) stored as nonsensical timestamps/schedules;
- raw bytes used directly as enum values or as dynamic value-DB keys, creating spurious or unaddressable entries;
- level values outside the valid `0..99` range stored verbatim;
- locale codes that do not match the spec format the Set side enforces;
- a fixed-size timezone structure decoded without a length check, producing `NaN` offsets on a short payload;
- an endpoint-pair loop reading one byte past the buffer on an odd-length region, fabricating a destination from a byte that was never sent.

## Fix

Add the missing validation on the report side — range checks for numeric/date fields, enum-membership checks before using a byte as a value or key, level-range validation (0..99), locale-format validation, and proper buffer-length handling before decoding. Invalid frames are now dropped instead of corrupting stored state.

Commits are grouped by the kind of fix (date/time field validation, enum/level field validation, locale-code validation, and buffer length handling).