### PR TITLE
fix(config): add AUS/NZ fingerprint to Aeotec Water Sensor 7 Pro

### DIFF
--- a/packages/config/config/devices/0x0371/zwa019.json
+++ b/packages/config/config/devices/0x0371/zwa019.json
@@ -13,6 +13,10 @@
 			"productType": "0x0102",
 			"productId": "0x0013",
 			"zwaveAllianceId": 3951
+		},
+		{
+			"productType": "0x0202",
+			"productId": "0x0013"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
fixes: #8877