### PR TITLE
fix: improve handling of partial report CCs

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -921,6 +921,12 @@ interface ZWaveOptions {
 		 * How many attempts should be made for OTW firmware updates before giving up
 		 */
 		firmwareUpdateOTW: number; // [1...5], default: 3
+
+		/**
+		 * How often a response that is split into multiple reports should be re-requested
+		 * when some of the reports were not received. Set to 0 to disable re-requesting.
+		 */
+		partialReports: number; // [0...5], default: 2
 	};
 
 	/**

--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -672,8 +672,8 @@ export class AssociationCCReport extends AssociationCC {
 		return { groupId: this.groupId };
 	}
 
-	public expectMoreMessages(): boolean {
-		return this.reportsToFollow > 0;
+	public getRemainingSegments(): number | undefined {
+		return this.reportsToFollow;
 	}
 
 	public mergePartialCCs(

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -2445,12 +2445,29 @@ export class ConfigurationCCBulkReport extends ConfigurationCC {
 	}
 
 	public getPartialCCSessionId(): Record<string, any> | undefined {
-		// We don't expect the applHost to merge CCs but we want to wait until all reports have been received
 		return {};
 	}
 
-	public expectMoreMessages(): boolean {
-		return this.reportsToFollow > 0;
+	public getRemainingSegments(): number | undefined {
+		return this.reportsToFollow;
+	}
+
+	public mergePartialCCs(
+		partials: ConfigurationCCBulkReport[],
+		_ctx: CCParsingContext,
+	): Promise<void> {
+		// Merge the values of all partial reports
+		const merged = new Map<number, ConfigValue>();
+		for (const partial of partials) {
+			for (const [parameter, value] of partial._values) {
+				merged.set(parameter, value);
+			}
+		}
+		for (const [parameter, value] of this._values) {
+			merged.set(parameter, value);
+		}
+		this._values = merged;
+		return Promise.resolve();
 	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
@@ -2628,8 +2645,8 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
 		return { parameter: this.parameter };
 	}
 
-	public expectMoreMessages(): boolean {
-		return this.reportsToFollow > 0;
+	public getRemainingSegments(): number | undefined {
+		return this.reportsToFollow;
 	}
 
 	public mergePartialCCs(
@@ -2804,8 +2821,8 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
 		return { parameter: this.parameter };
 	}
 
-	public expectMoreMessages(): boolean {
-		return this.reportsToFollow > 0;
+	public getRemainingSegments(): number | undefined {
+		return this.reportsToFollow;
 	}
 
 	public mergePartialCCs(

--- a/packages/cc/src/cc/MultiChannelAssociationCC.ts
+++ b/packages/cc/src/cc/MultiChannelAssociationCC.ts
@@ -832,8 +832,8 @@ export class MultiChannelAssociationCCReport extends MultiChannelAssociationCC {
 		return { groupId: this.groupId };
 	}
 
-	public expectMoreMessages(): boolean {
-		return this.reportsToFollow > 0;
+	public getRemainingSegments(): number | undefined {
+		return this.reportsToFollow;
 	}
 
 	public mergePartialCCs(

--- a/packages/cc/src/cc/MultiChannelCC.ts
+++ b/packages/cc/src/cc/MultiChannelCC.ts
@@ -1165,8 +1165,8 @@ export class MultiChannelCCEndPointFindReport extends MultiChannelCC {
 		};
 	}
 
-	public expectMoreMessages(): boolean {
-		return this.reportsToFollow > 0;
+	public getRemainingSegments(): number | undefined {
+		return this.reportsToFollow;
 	}
 
 	public mergePartialCCs(

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -762,8 +762,10 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 		}
 	}
 
-	public expectMoreMessages(): boolean {
-		return !!this.sequenced && !this.secondFrame;
+	public getRemainingSegments(): number | undefined {
+		// Sequenced S0 commands are always split into exactly two frames
+		if (!this.sequenced) return 0;
+		return this.secondFrame ? 0 : 1;
 	}
 
 	public async mergePartialCCs(
@@ -1080,8 +1082,8 @@ export class SecurityCCCommandsSupportedReport extends SecurityCC {
 		return {};
 	}
 
-	public expectMoreMessages(): boolean {
-		return this.reportsToFollow > 0;
+	public getRemainingSegments(): number | undefined {
+		return this.reportsToFollow;
 	}
 
 	public mergePartialCCs(

--- a/packages/cc/src/cc/ThermostatOperatingStateCC.ts
+++ b/packages/cc/src/cc/ThermostatOperatingStateCC.ts
@@ -410,8 +410,8 @@ export class ThermostatOperatingStateCCLoggingReport
 		return {};
 	}
 
-	public expectMoreMessages(): boolean {
-		return this.reportsToFollow > 0;
+	public getRemainingSegments(): number | undefined {
+		return this.reportsToFollow;
 	}
 
 	public mergePartialCCs(

--- a/packages/cc/src/cc/TransportServiceCC.ts
+++ b/packages/cc/src/cc/TransportServiceCC.ts
@@ -5,8 +5,6 @@ import {
 	type MessageOrCCLogEntry,
 	type SinglecastCC,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
 	validatePayload,
 } from "@zwave-js/core";
 import { Bytes, type BytesView, buffer2hex } from "@zwave-js/shared";
@@ -140,7 +138,6 @@ export class TransportServiceCCFirstSegment extends TransportServiceCC {
 	public sessionId: number;
 	public headerExtension: BytesView | undefined;
 	public partialDatagram: BytesView;
-	public encapsulated!: CommandClass;
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		// Transport Service re-uses the lower 3 bits of the ccCommand as payload
@@ -174,15 +171,6 @@ export class TransportServiceCCFirstSegment extends TransportServiceCC {
 		this.payload.writeUInt16BE(crc, this.payload.length - 2);
 
 		return super.serialize(ctx);
-	}
-
-	public expectMoreMessages(): boolean {
-		return true; // The FirstSegment message always expects more messages
-	}
-
-	public getPartialCCSessionId(): Record<string, any> | undefined {
-		// Only use the session ID to identify the session, not the CC command
-		return { ccCommand: undefined, sessionId: this.sessionId };
 	}
 
 	protected computeEncapsulationOverhead(): number {
@@ -287,74 +275,6 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
 	public sessionId: number;
 	public headerExtension: BytesView | undefined;
 	public partialDatagram: BytesView;
-
-	// This can only be received
-	private _encapsulated!: CommandClass;
-	public get encapsulated(): CommandClass {
-		return this._encapsulated;
-	}
-
-	public expectMoreMessages(
-		session: [
-			TransportServiceCCFirstSegment,
-			...TransportServiceCCSubsequentSegment[],
-		],
-	): boolean {
-		if (!(session[0] instanceof TransportServiceCCFirstSegment)) {
-			// First segment is missing
-			return true;
-		}
-		const datagramSize = session[0].datagramSize;
-		const receivedBytes = Array.from<boolean>({ length: datagramSize })
-			.fill(false);
-		for (const segment of [...session, this]) {
-			const offset = segment instanceof TransportServiceCCFirstSegment
-				? 0
-				: segment.datagramOffset;
-			for (
-				let i = offset;
-				i <= offset + segment.partialDatagram.length;
-				i++
-			) {
-				receivedBytes[i] = true;
-			}
-		}
-		// Expect more messages as long as we haven't received everything
-		return receivedBytes.includes(false);
-	}
-
-	public getPartialCCSessionId(): Record<string, any> | undefined {
-		// Only use the session ID to identify the session, not the CC command
-		return { ccCommand: undefined, sessionId: this.sessionId };
-	}
-
-	public async mergePartialCCs(
-		partials: [
-			TransportServiceCCFirstSegment,
-			...TransportServiceCCSubsequentSegment[],
-		],
-		ctx: CCParsingContext,
-	): Promise<void> {
-		// Concat the CC buffers
-		const datagram = new Bytes(this.datagramSize);
-		for (const partial of [...partials, this]) {
-			// Ensure that we don't try to write out-of-bounds
-			const offset = partial instanceof TransportServiceCCFirstSegment
-				? 0
-				: partial.datagramOffset;
-			if (offset + partial.partialDatagram.length > datagram.length) {
-				throw new ZWaveError(
-					`The partial datagram offset and length in a segment are not compatible to the communicated datagram length`,
-					ZWaveErrorCodes.PacketFormat_InvalidPayload,
-				);
-			}
-			datagram.set(partial.partialDatagram, offset);
-		}
-
-		// and deserialize the CC
-		this._encapsulated = await CommandClass.parse(datagram, ctx);
-		this._encapsulated.encapsulatingCC = this as any;
-	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		// Transport Service re-uses the lower 3 bits of the ccCommand as payload

--- a/packages/cc/src/lib/CommandClass.ts
+++ b/packages/cc/src/lib/CommandClass.ts
@@ -953,14 +953,19 @@ export class CommandClass implements CCId {
 	}
 
 	/**
-	 * When a CC supports to be split into multiple partial CCs, this indicates that the last report hasn't been received yet.
-	 * @param _session The previously received set of messages received in this partial CC session
+	 * When a CC supports to be split into multiple partial CCs, this returns how many
+	 * more segments are expected after this one (e.g. the value of a "reports to follow" field).
+	 * The counter doubles as the segment's position within the session, which is used
+	 * to detect missing, duplicated and reordered segments.
 	 */
-	public expectMoreMessages(_session: CommandClass[]): boolean {
-		return false; // By default, all CCs are monolithic
+	public getRemainingSegments(): number | undefined {
+		return undefined; // By default, all CCs are monolithic
 	}
 
-	/** Include previously received partial responses into a final CC */
+	/**
+	 * Include previously received partial responses into a final CC.
+	 * The partials are deduplicated and ordered like they were transmitted by the node.
+	 */
 	public async mergePartialCCs(
 		_partials: CommandClass[],
 		_ctx: CCParsingContext,

--- a/packages/core/src/definitions/Transmission.ts
+++ b/packages/core/src/definitions/Transmission.ts
@@ -112,6 +112,12 @@ export type SendCommandOptions =
 		transmitOptions?: TransmitOptions;
 		/** Overwrite the default report timeout */
 		reportTimeoutMs?: number;
+		/**
+		 * @internal
+		 * Do not wait for the expected response to this command,
+		 * e.g. because another transaction is already waiting for it.
+		 */
+		ignoreNodeUpdate?: boolean;
 	};
 
 export type SendCommandReturnType<TResponse extends CCId | undefined> =

--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -373,6 +373,9 @@ export class Message {
 	/** Returns a message specific timeout used to wait for an update from the target node */
 	public nodeUpdateTimeout: number | undefined; // Default: use driver timeout
 
+	/** Whether the update from the target node should not be awaited, e.g. because something else is already waiting for it */
+	public ignoreNodeUpdate: boolean = false;
+
 	/** Checks if a message is an expected response for this message */
 	public isExpectedResponse(msg: Message): boolean {
 		return (

--- a/packages/serial/src/serialapi/transport/SendDataBridgeMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendDataBridgeMessages.ts
@@ -226,8 +226,10 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 
 	public expectsNodeUpdate(ctx: GetNode<NodeId & SupportsCC>): boolean {
 		return (
+			// The expected update may be handled by someone else
+			!this.ignoreNodeUpdate
 			// We can only answer this if the command is known
-			this.command != undefined
+			&& this.command != undefined
 			// Only true singlecast commands may expect a response
 			&& this.command.isSinglecast()
 			// ... and only if the command expects a response

--- a/packages/serial/src/serialapi/transport/SendDataMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.ts
@@ -213,8 +213,10 @@ export class SendDataRequest<CCType extends CommandClass = CommandClass>
 
 	public expectsNodeUpdate(ctx: GetNode<NodeId & SupportsCC>): boolean {
 		return (
+			// The expected update may be handled by someone else
+			!this.ignoreNodeUpdate
 			// We can only answer this if the command is known
-			this.command != undefined
+			&& this.command != undefined
 			// Only true singlecast commands may expect a response
 			&& this.command.isSinglecast()
 			// ... and only if the command expects a response

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -39,7 +39,6 @@ import {
 	SupervisionCC,
 	type SupervisionCCGet,
 	SupervisionCCReport,
-	TransportServiceCC,
 	TransportServiceCCFirstSegment,
 	TransportServiceCCSegmentComplete,
 	TransportServiceCCSegmentRequest,
@@ -681,8 +680,9 @@ type AwaitedIdleEntry = Omit<
 >;
 
 interface TransportServiceSession {
-	fragmentSize: number;
 	machine: TransportServiceRXMachine;
+	/** The reassembled datagram. Segments are copied here as they are received. */
+	datagram: Bytes;
 	timeout?: NodeJS.Timeout;
 }
 
@@ -4267,11 +4267,22 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 					});
 					wasMessageLogged = true;
 
-					void this.handleTransportServiceCommand(msg.command).catch(
-						() => {
-							// Don't care about errors in incoming transport service commands
-						},
-					);
+					const reassembled = await this
+						.handleTransportServiceCommand(
+							msg.command,
+						);
+					if (!reassembled) {
+						// The datagram is not complete yet.
+						// Check if a message timer needs to be refreshed.
+						this.refreshAwaitedMessageTimers(msg);
+						return;
+					}
+
+					// The reassembled command continues through the normal receive path.
+					// Transport Service is always the outermost CC, so nothing else needs to be preserved.
+					msg.command = reassembled;
+					// Now we do want to log the command again, so we can see what was inside
+					wasMessageLogged = false;
 				}
 
 				// Assemble partial CCs on the driver level. Only forward complete messages to the send thread machine
@@ -4322,13 +4333,6 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 					} else {
 						throw e;
 					}
-				}
-
-				// Transport Service CC can be eliminated from the encapsulation stack, since it is always the outermost CC
-				if (isTransportServiceEncapsulation(completeMsg.command)) {
-					completeMsg.command = completeMsg.command.encapsulated;
-					// Now we do want to log the command again, so we can see what was inside
-					wasMessageLogged = false;
 				}
 			}
 
@@ -5239,22 +5243,38 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 		}
 	}
 
-	/** Is called when a Transport Service command is received */
+	/**
+	 * Is called when a Transport Service command is received.
+	 * When the command completes a datagram, the reassembled command is returned.
+	 */
 	private async handleTransportServiceCommand(
 		command:
 			| TransportServiceCCFirstSegment
 			| TransportServiceCCSubsequentSegment,
-	): Promise<void> {
+	): Promise<CommandClass | undefined> {
 		const nodeSessions = this.ensureNodeSessions(command.nodeId);
 
 		// TODO: Figure out how to know which timeout is the correct one. For now use the larger one
 		const missingSegmentTimeout =
 			TransportServiceTimeouts.requestMissingSegmentR2;
 
-		const advanceTransportServiceSession = async (
+		const sendSegmentComplete = () => {
+			const cc = new TransportServiceCCSegmentComplete({
+				nodeId: command.nodeId,
+				sessionId: command.sessionId,
+			});
+			void this.sendCommand(cc, {
+				maxSendAttempts: 1,
+				priority: MessagePriority.Immediate,
+			}).catch(noop);
+		};
+
+		// The state handling is synchronous, all outgoing commands are sent in the
+		// background so the receive path is not blocked
+		const advanceTransportServiceSession = (
 			session: TransportServiceSession,
 			input: TransportServiceRXMachineInput,
-		): Promise<void> => {
+		): "completed" | undefined => {
 			const machine = session.machine;
 
 			// Figure out what needs to be done for this input
@@ -5278,12 +5298,13 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 						sessionId: command.sessionId,
 						datagramOffset: machine.state.offset,
 					});
-					await this.sendCommand(cc, {
+					this.sendCommand(cc, {
 						maxSendAttempts: 1,
 						priority: MessagePriority.Immediate,
-					}).catch(noop);
-
-					startMissingSegmentTimeout(session);
+					})
+						.catch(noop)
+						// Only time out waiting for the missing segment after requesting it
+						.finally(() => startMissingSegmentTimeout(session));
 				} else if (machine.state.value === "failure") {
 					this.controllerLog.logNode(command.nodeId, {
 						message:
@@ -5296,30 +5317,25 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 					if (session.timeout) {
 						clearTimeout(session.timeout);
 					}
-				}
-			}
+				} else if (machine.state.value === "success") {
+					this.controllerLog.logNode(command.nodeId, {
+						message:
+							`Transport Service RX session #${command.sessionId} complete`,
+						level: "debug",
+						direction: "inbound",
+					});
+					if (session.timeout) {
+						clearTimeout(session.timeout);
+					}
 
-			if (machine.state.value === "success") {
-				// This state may happen without a transition if we received the last segment before
-				// but the SegmentComplete message got lost
-				this.controllerLog.logNode(command.nodeId, {
-					message:
-						`Transport Service RX session #${command.sessionId} complete`,
-					level: "debug",
-					direction: "inbound",
-				});
-				if (session.timeout) {
-					clearTimeout(session.timeout);
+					sendSegmentComplete();
+					return "completed";
 				}
-
-				const cc = new TransportServiceCCSegmentComplete({
-					nodeId: command.nodeId,
-					sessionId: command.sessionId,
-				});
-				await this.sendCommand(cc, {
-					maxSendAttempts: 1,
-					priority: MessagePriority.Immediate,
-				}).catch(noop);
+			} else if (machine.state.value === "success") {
+				// The session was already complete, but the node re-sent the last segment
+				// because the SegmentComplete message got lost. Acknowledge it again, but
+				// do not hand the datagram to the application a second time.
+				sendSegmentComplete();
 			}
 		};
 
@@ -5332,11 +5348,14 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 
 			session.timeout = setTimeout(() => {
 				session.timeout = undefined;
-				void advanceTransportServiceSession(session, {
+				advanceTransportServiceSession(session, {
 					value: "timeout",
 				});
 			}, missingSegmentTimeout);
 		}
+
+		let session: TransportServiceSession | undefined;
+		let datagramOffset: number;
 
 		if (command instanceof TransportServiceCCFirstSegment) {
 			// This is the first message in a sequence. Create or re-initialize the session
@@ -5357,26 +5376,16 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				command.partialDatagram.length,
 			);
 
-			const session: TransportServiceSession = {
-				fragmentSize: command.partialDatagram.length,
+			session = {
 				machine,
+				datagram: new Bytes(command.datagramSize),
 			};
 			nodeSessions.transportService.set(command.sessionId, session);
-
-			// Time out waiting for subsequent segments
-			startMissingSegmentTimeout(session);
+			datagramOffset = 0;
 		} else {
 			// This is a subsequent message in a sequence. Continue executing the state machine
-			const transportSession = nodeSessions.transportService.get(
-				command.sessionId,
-			);
-			if (transportSession) {
-				await advanceTransportServiceSession(transportSession, {
-					value: "segment",
-					offset: command.datagramOffset,
-					length: command.partialDatagram.length,
-				});
-			} else {
+			session = nodeSessions.transportService.get(command.sessionId);
+			if (!session) {
 				// This belongs to a session we don't know... tell the sending node to try again
 				const cc = new TransportServiceCCSegmentWait({
 					nodeId: command.nodeId,
@@ -5386,7 +5395,49 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 					maxSendAttempts: 1,
 					priority: MessagePriority.Immediate,
 				}).catch(noop);
+				return;
 			}
+			datagramOffset = command.datagramOffset;
+		}
+
+		// Ensure that we don't try to write out-of-bounds
+		if (
+			datagramOffset + command.partialDatagram.length
+				> session.datagram.length
+		) {
+			this.controllerLog.logNode(command.nodeId, {
+				message:
+					`Transport Service RX session #${command.sessionId}: Ignoring segment because it is incompatible with the datagram length`,
+				level: "warn",
+				direction: "inbound",
+			});
+			return;
+		}
+		session.datagram.set(command.partialDatagram, datagramOffset);
+
+		const result = advanceTransportServiceSession(session, {
+			value: "segment",
+			offset: datagramOffset,
+			length: command.partialDatagram.length,
+		});
+		if (result !== "completed") return;
+
+		// The datagram is complete, reassemble the command it contains
+		try {
+			return await CommandClass.parse(session.datagram, {
+				...this.getCCParsingContext(),
+				sourceNodeId: command.nodeId,
+				// Transport Service is only used for singlecast commands
+				frameType: command.frameType ?? "singlecast",
+			});
+		} catch (e) {
+			this.driverLog.print(
+				`Dropping Transport Service datagram because the contained command could not be deserialized: ${
+					getErrorMessage(e)
+				}`,
+				"warn",
+			);
+			return;
 		}
 	}
 
@@ -5554,8 +5605,6 @@ ${handlers.length} left`,
 			return true;
 		}
 
-		// Transport Service has a special handler
-		if (cc instanceof TransportServiceCC) return false;
 		// CRC16 belongs outside of Security encapsulation
 		if (cc instanceof CRC16CCCommandEncapsulation) {
 			return this.isSecurityLevelTooLow(cc.encapsulated);

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -7453,6 +7453,10 @@ ${handlers.length} left`,
 			msg.nodeUpdateTimeout = options.reportTimeoutMs;
 		}
 
+		if (options.ignoreNodeUpdate) {
+			msg.ignoreNodeUpdate = true;
+		}
+
 		return msg as SendDataMessage & ContainsCC;
 	}
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4243,7 +4243,6 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 
 		// If the message could be decoded, forward it to the send thread
 		if (msg) {
-			let wasMessageLogged = false;
 			if (isCommandRequest(msg) && containsCC(msg)) {
 				// SecurityCCCommandEncapsulationNonceGet is two commands in one, but
 				// we're not set up to handle things like this. Reply to the nonce get
@@ -4265,7 +4264,6 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 						secondaryTags: ["partial"],
 						direction: "inbound",
 					});
-					wasMessageLogged = true;
 
 					const reassembled = await this
 						.handleTransportServiceCommand(
@@ -4278,23 +4276,21 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 						return;
 					}
 
-					// The reassembled command continues through the normal receive path.
-					// Transport Service is always the outermost CC, so nothing else needs to be preserved.
+					// The reassembled command continues through the normal receive
+					// path and is logged again there, so its contents are visible.
+					// Transport Service is always the outermost CC, so nothing else
+					// needs to be preserved.
 					msg.command = reassembled;
-					// Now we do want to log the command again, so we can see what was inside
-					wasMessageLogged = false;
 				}
 
 				// Make sure the command was received at the expected security level
 				// BEFORE assembling partial CCs. Otherwise it would be possible to
 				// inject unencrypted segments into a partial CC session.
 				if (this.isSecurityLevelTooLow(msg.command)) {
-					if (!wasMessageLogged) {
-						this.driverLog.logMessage(msg, {
-							direction: "inbound",
-							secondaryTags: ["discarded"],
-						});
-					}
+					this.driverLog.logMessage(msg, {
+						direction: "inbound",
+						secondaryTags: ["discarded"],
+					});
 					return;
 				}
 
@@ -4311,12 +4307,10 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 
 				// Now that the command is complete, the checks that depend on the actual payload can be done
 				if (this.shouldDiscardCC(completeMsg.command)) {
-					if (!wasMessageLogged) {
-						this.driverLog.logMessage(msg, {
-							direction: "inbound",
-							secondaryTags: ["discarded"],
-						});
-					}
+					this.driverLog.logMessage(msg, {
+						direction: "inbound",
+						secondaryTags: ["discarded"],
+					});
 					return;
 				}
 
@@ -4346,17 +4340,15 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				}
 			}
 
-			if (!wasMessageLogged) {
-				try {
-					this.driverLog.logMessage(msg, {
-						direction: "inbound",
-					});
-				} catch (e) {
-					// We shouldn't throw just because logging a message fails
-					this.driverLog.print(
-						`Logging a message failed: ${getErrorMessage(e)}`,
-					);
-				}
+			try {
+				this.driverLog.logMessage(msg, {
+					direction: "inbound",
+				});
+			} catch (e) {
+				// We shouldn't throw just because logging a message fails
+				this.driverLog.print(
+					`Logging a message failed: ${getErrorMessage(e)}`,
+				);
 			}
 
 			// // Check if this message is unsolicited by passing it to the Serial API command interpreter if possible
@@ -5070,8 +5062,7 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 		rerequestSession: (session) => this.rerequestPartialCCSession(session),
 		onSessionLost: (session) => {
 			this.controllerLog.logNode(session.nodeId, {
-				message:
-					`Dropping incomplete partial CC session`,
+				message: `Dropping incomplete partial CC session`,
 				level: "warn",
 				direction: "inbound",
 			});

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -52,6 +52,7 @@ import {
 	WakeUpCCValues,
 	type ZWaveProtocolCC,
 	getImplementedVersion,
+	getInnermostCommandClass,
 	isEncapsulatingCommandClass,
 	isMultiEncapsulatingCommandClass,
 	isTransportServiceEncapsulation,
@@ -258,6 +259,10 @@ import {
 	migrateLegacyNetworkCache,
 	serializeNetworkCacheValue,
 } from "./NetworkCache.js";
+import {
+	type PartialCCSession,
+	PartialCCSessionManager,
+} from "./PartialCCSessionManager.js";
 import { type SerialAPIQueueItem, TransactionQueue } from "./Queue.js";
 import {
 	type SerialAPICommandMachineInput,
@@ -333,6 +338,7 @@ const defaultOptions: ZWaveOptions = {
 		nodeInterview: 5,
 		smartStartInclusion: 5,
 		firmwareUpdateOTW: 3,
+		partialReports: 2,
 	},
 	disableOptimisticValueUpdate: false,
 	features: {
@@ -516,6 +522,15 @@ function checkOptions(options: ZWaveOptions): void {
 	) {
 		throw new ZWaveError(
 			`The OTW firmware update attempts must be between 1 and 5!`,
+			ZWaveErrorCodes.Driver_InvalidOptions,
+		);
+	}
+	if (
+		options.attempts.partialReports < 0
+		|| options.attempts.partialReports > 3
+	) {
+		throw new ZWaveError(
+			`The partial reports attempts must be between 0 and 3!`,
 			ZWaveErrorCodes.Driver_InvalidOptions,
 		);
 	}
@@ -4023,6 +4038,8 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 		) {
 			timeout?.clear();
 		}
+
+		this.partialCCSessions.clear();
 	}
 
 	private async handleSerialData(serial: ZWaveSerialStream): Promise<void> {
@@ -4258,22 +4275,20 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				}
 
 				// Assemble partial CCs on the driver level. Only forward complete messages to the send thread machine
-				if (!(await this.assemblePartialCCs(msg))) {
+				const completeMsg = await this.assemblePartialCCs(msg);
+				if (!completeMsg) {
 					// Check if a message timer needs to be refreshed.
-					for (const entry of this.awaitedMessages) {
-						if (entry.refreshPredicate?.(msg)) {
-							entry.timeout?.refresh();
-							// Since this is a partial message there may be no clear 1:1 match.
-							// Therefore we loop through all awaited messages
-						}
-					}
+					this.refreshAwaitedMessageTimers(msg);
 					return;
 				}
+				// Responses split into multiple messages are completed by the message
+				// containing the final segment, which may not be the current one
+				msg = completeMsg;
 
 				// Make sure we are allowed to handle this command
 				if (
-					this.isSecurityLevelTooLow(msg.command)
-					|| this.shouldDiscardCC(msg.command)
+					this.isSecurityLevelTooLow(completeMsg.command)
+					|| this.shouldDiscardCC(completeMsg.command)
 				) {
 					if (!wasMessageLogged) {
 						this.driverLog.logMessage(msg, {
@@ -4286,7 +4301,7 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 
 				// When we have a complete CC, save its values
 				try {
-					this.persistCCValues(msg.command);
+					this.persistCCValues(completeMsg.command);
 				} catch (e) {
 					// Indicate invalid payloads with a special CC type
 					if (
@@ -4310,8 +4325,8 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				}
 
 				// Transport Service CC can be eliminated from the encapsulation stack, since it is always the outermost CC
-				if (isTransportServiceEncapsulation(msg.command)) {
-					msg.command = msg.command.encapsulated;
+				if (isTransportServiceEncapsulation(completeMsg.command)) {
+					completeMsg.command = completeMsg.command.encapsulated;
 					// Now we do want to log the command again, so we can see what was inside
 					wasMessageLogged = false;
 				}
@@ -5034,116 +5049,173 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 		);
 	}
 
-	private partialCCSessions = new Map<string, CommandClass[]>();
-	private getPartialCCSession(
-		command: CommandClass,
-		createIfMissing: false,
-	): { partialSessionKey: string; session?: CommandClass[] } | undefined;
-	private getPartialCCSession(
-		command: CommandClass,
-		createIfMissing: true,
-	): { partialSessionKey: string; session: CommandClass[] } | undefined;
-	private getPartialCCSession(
-		command: CommandClass,
-		createIfMissing: boolean,
-	): { partialSessionKey: string; session?: CommandClass[] } | undefined {
-		const sessionId = command.getPartialCCSessionId();
-
-		if (sessionId) {
-			// This CC belongs to a partial session
-			const partialSessionKey = JSON.stringify({
-				nodeId: command.nodeId,
-				ccId: command.ccId,
-				ccCommand: command.ccCommand!,
-				...sessionId,
+	private partialCCSessions = new PartialCCSessionManager({
+		getSegmentTimeout: () => this._options.timeouts.report,
+		getMaxReRequestAttempts: () => this._options.attempts.partialReports,
+		findRequestCC: (command) => this.findPartialCCSessionRequest(command),
+		rerequestSession: (session) => this.rerequestPartialCCSession(session),
+		onSessionLost: (session) => {
+			this.controllerLog.logNode(session.nodeId, {
+				message:
+					`Dropping incomplete partial CC session`,
+				level: "warn",
+				direction: "inbound",
 			});
-			if (
-				createIfMissing
-				&& !this.partialCCSessions.has(partialSessionKey)
-			) {
-				this.partialCCSessions.set(partialSessionKey, []);
-			}
-			return {
-				partialSessionKey,
-				session: this.partialCCSessions.get(partialSessionKey),
-			};
-		}
-	}
+		},
+	});
+
 	/**
-	 * Assembles partial CCs of in a message body. Returns `true` when the message is complete and can be handled further.
-	 * If the message expects another partial one, this returns `false`.
+	 * Determines the request a new partial CC session is the response to, if any.
+	 * This is used to re-request the response when segments are missing.
+	 */
+	private findPartialCCSessionRequest(
+		command: CommandClass,
+	): CommandClass | undefined {
+		const currentMessage = this.queue.currentTransaction
+			?.getCurrentMessage();
+		if (
+			!currentMessage
+			|| !containsCC(currentMessage)
+			|| currentMessage.getNodeId() !== command.nodeId
+			|| !currentMessage.expectsNodeUpdate(this)
+		) {
+			return;
+		}
+
+		// The predicate does not check for complete commands or encapsulation,
+		// which is good enough to correlate a partial report with its request
+		const request = getInnermostCommandClass(currentMessage.command);
+		if (
+			!request.isExpectedCCResponse(
+				this,
+				getInnermostCommandClass(command),
+			)
+		) {
+			return;
+		}
+		return request;
+	}
+
+	/** Re-requests the response a partial CC session belongs to because segments are missing */
+	private rerequestPartialCCSession(session: PartialCCSession): void {
+		// Give the node more time to respond by refreshing the report timeout
+		// of the transaction the partial reports belong to
+		this.refreshAwaitedMessageTimers(session.lastSegmentMsg);
+
+		this.controllerLog.logNode(session.nodeId, {
+			message:
+				`Some expected reports were not received, requesting the response again...`,
+			level: "warn",
+			direction: "outbound",
+		});
+
+		// The original transaction is still waiting for the response, so the
+		// re-requested one must not be awaited again
+		void this.sendCommand(session.requestCC!, {
+			priority: MessagePriority.Immediate,
+			maxSendAttempts: 1,
+			ignoreNodeUpdate: true,
+		}).catch(noop);
+	}
+
+	/**
+	 * Assembles partial CCs in a message body. Returns the message containing the complete
+	 * command to continue handling. This is not necessarily the passed message, since responses
+	 * may be split into multiple messages.
+	 * If the message contains a partial CC and more segments are expected, this returns `undefined`.
 	 */
 	private async assemblePartialCCs(
 		msg: CommandRequest & ContainsCC,
-	): Promise<boolean> {
+	): Promise<(CommandRequest & ContainsCC) | undefined> {
 		let command: CommandClass | undefined = msg.command;
 		// We search for the every CC that provides us with a session ID
 		// There might be newly-completed CCs that contain a partial CC,
 		// so investigate the entire CC encapsulation stack.
 		while (true) {
-			const { partialSessionKey, session } =
-				this.getPartialCCSession(command, true) ?? {};
-			if (session) {
-				// This CC belongs to a partial session
-				if (command.expectMoreMessages(session)) {
-					// this is not the final one, store it
-					session.push(command);
-					if (!isTransportServiceEncapsulation(msg.command)) {
-						// and don't handle the command now
-						this.driverLog.logMessage(msg, {
-							secondaryTags: ["partial"],
-							direction: "inbound",
-						});
-					}
-					return false;
-				} else {
-					// this is the final one, merge the previous responses
-					this.partialCCSessions.delete(partialSessionKey!);
-					try {
-						await command.mergePartialCCs(session, {
-							...this.getCCParsingContext(),
-							sourceNodeId: msg.command.nodeId as number,
-							frameType: msg.frameType,
-						});
-						// Ensure there are no errors
-						assertValidCCs(msg);
-					} catch (e) {
-						if (isZWaveError(e)) {
-							switch (e.code) {
-								case ZWaveErrorCodes
-									.Deserialization_NotImplemented:
-								case ZWaveErrorCodes.CC_NotImplemented:
-									this.driverLog.print(
-										`Dropping message because it could not be deserialized: ${e.message}`,
-										"warn",
-									);
-									// Don't continue handling this message
-									return false;
-
-								case ZWaveErrorCodes
-									.PacketFormat_InvalidPayload:
-									this.driverLog.print(
-										`Could not assemble partial CCs because the payload is invalid. Dropping them.`,
-										"warn",
-									);
-									// Don't continue handling this message
-									return false;
-
-								case ZWaveErrorCodes.Driver_NotReady:
-									this.driverLog.print(
-										`Could not assemble partial CCs because the driver is not ready yet. Dropping them`,
-										"warn",
-									);
-									// Don't continue handling this message
-									return false;
-							}
-						}
-						throw e;
-					}
-					// Assembling this CC was successful - but it might contain another partial CC
+			const update = this.partialCCSessions.handleCommand(command, msg);
+			if (update?.type === "segment") {
+				if (update.duplicate) {
+					this.controllerLog.logNode(command.nodeId as number, {
+						message: `Ignoring duplicate partial CC segment:`,
+						level: "debug",
+						direction: "inbound",
+					});
 				}
-			} else {
-				// No partial CC, just continue
+				// This is not the final segment, don't handle the command now
+				this.driverLog.logMessage(msg, {
+					secondaryTags: ["partial"],
+					direction: "inbound",
+				});
+				return undefined;
+			} else if (update?.type === "complete") {
+				if (update.partials.length > 0) {
+					// Log the current segment like it was received. The merged
+					// command is logged when handling the final message continues.
+					this.driverLog.logMessage(msg, {
+						secondaryTags: ["partial"],
+						direction: "inbound",
+					});
+				}
+
+				// All segments were received, merge them into the final one
+				try {
+					await update.command.mergePartialCCs(update.partials, {
+						...this.getCCParsingContext(),
+						sourceNodeId: update.command.nodeId as number,
+						frameType: update.finalMsg.frameType,
+					});
+					// Ensure there are no errors
+					assertValidCCs(update.finalMsg);
+
+					if (update.partials.length > 0) {
+						this.controllerLog.logNode(
+							update.command.nodeId as number,
+							{
+								message: `Assembled partial CC from ${
+									update.partials.length + 1
+								} segments`,
+								level: "debug",
+								direction: "inbound",
+							},
+						);
+					}
+				} catch (e) {
+					if (isZWaveError(e)) {
+						switch (e.code) {
+							case ZWaveErrorCodes
+								.Deserialization_NotImplemented:
+							case ZWaveErrorCodes.CC_NotImplemented:
+								this.driverLog.print(
+									`Dropping message because it could not be deserialized: ${e.message}`,
+									"warn",
+								);
+								// Don't continue handling this message
+								return undefined;
+
+							case ZWaveErrorCodes
+								.PacketFormat_InvalidPayload:
+								this.driverLog.print(
+									`Could not assemble partial CCs because the payload is invalid. Dropping them.`,
+									"warn",
+								);
+								// Don't continue handling this message
+								return undefined;
+
+							case ZWaveErrorCodes.Driver_NotReady:
+								this.driverLog.print(
+									`Could not assemble partial CCs because the driver is not ready yet. Dropping them`,
+									"warn",
+								);
+								// Don't continue handling this message
+								return undefined;
+						}
+					}
+					throw e;
+				}
+				// Continue handling the message which contained the final segment.
+				// Assembling this CC was successful - but it might contain another partial CC
+				msg = update.finalMsg;
+				command = update.command;
 			}
 
 			// If this is an encapsulating CC, we need to look one level deeper
@@ -5153,7 +5225,18 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				break;
 			}
 		}
-		return true;
+		return msg;
+	}
+
+	/** Refreshes the timeouts of awaited messages which a partial message may belong to */
+	private refreshAwaitedMessageTimers(msg: Message): void {
+		// Since this is a partial message there may be no clear 1:1 match.
+		// Therefore we loop through all awaited messages
+		for (const entry of this.awaitedMessages) {
+			if (entry.refreshPredicate?.(msg)) {
+				entry.timeout?.refresh();
+			}
+		}
 	}
 
 	/** Is called when a Transport Service command is received */
@@ -5576,7 +5659,7 @@ ${handlers.length} left`,
 			// none found, don't accept the CC
 			this.controllerLog.logNode(
 				cc.nodeId as number,
-				`command was received at a lower security level than expected - discarding it...`,
+				`command was received at a lower security level than expected - discarding it:`,
 				"warn",
 			);
 			return true;

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4285,6 +4285,19 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 					wasMessageLogged = false;
 				}
 
+				// Make sure the command was received at the expected security level
+				// BEFORE assembling partial CCs. Otherwise it would be possible to
+				// inject unencrypted segments into a partial CC session.
+				if (this.isSecurityLevelTooLow(msg.command)) {
+					if (!wasMessageLogged) {
+						this.driverLog.logMessage(msg, {
+							direction: "inbound",
+							secondaryTags: ["discarded"],
+						});
+					}
+					return;
+				}
+
 				// Assemble partial CCs on the driver level. Only forward complete messages to the send thread machine
 				const completeMsg = await this.assemblePartialCCs(msg);
 				if (!completeMsg) {
@@ -4296,11 +4309,8 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				// containing the final segment, which may not be the current one
 				msg = completeMsg;
 
-				// Make sure we are allowed to handle this command
-				if (
-					this.isSecurityLevelTooLow(completeMsg.command)
-					|| this.shouldDiscardCC(completeMsg.command)
-				) {
+				// Now that the command is complete, the checks that depend on the actual payload can be done
+				if (this.shouldDiscardCC(completeMsg.command)) {
 					if (!wasMessageLogged) {
 						this.driverLog.logMessage(msg, {
 							direction: "inbound",

--- a/packages/zwave-js/src/lib/driver/PartialCCSessionManager.test.ts
+++ b/packages/zwave-js/src/lib/driver/PartialCCSessionManager.test.ts
@@ -1,0 +1,137 @@
+import { AssociationCCGet, AssociationCCReport } from "@zwave-js/cc";
+import { afterEach, test, vi } from "vitest";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+import {
+	PartialCCSessionManager,
+	type PartialCCSessionManagerHost,
+} from "./PartialCCSessionManager.js";
+
+function report(reportsToFollow: number, nodeIds: number[]) {
+	return new AssociationCCReport({
+		nodeId: 2,
+		groupId: 1,
+		maxNodes: 10,
+		nodeIds,
+		reportsToFollow,
+	});
+}
+
+function setup() {
+	const calls = { rerequested: 0, lost: 0 };
+	const requestCC = new AssociationCCGet({ nodeId: 2, groupId: 1 });
+	const host: PartialCCSessionManagerHost = {
+		getSegmentTimeout: () => 60000,
+		getMaxReRequestAttempts: () => 2,
+		findRequestCC: () => requestCC,
+		rerequestSession: () => void calls.rerequested++,
+		onSessionLost: () => void calls.lost++,
+	};
+	const manager = new PartialCCSessionManager(host);
+	return { manager, calls };
+}
+
+const dummyMsg = () => ({}) as any;
+
+test("a complete series is merged in transmission order, despite duplicates", (t) => {
+	const { manager } = setup();
+
+	t.expect(manager.handleCommand(report(2, [1]), dummyMsg())?.type).toBe(
+		"segment",
+	);
+	// Re-transmission of the same segment
+	const dup = manager.handleCommand(report(2, [1]), dummyMsg());
+	t.expect(dup).toMatchObject({ type: "segment", duplicate: true });
+
+	t.expect(manager.handleCommand(report(1, [2]), dummyMsg())?.type).toBe(
+		"segment",
+	);
+
+	const finalMsg = dummyMsg();
+	const update = manager.handleCommand(report(0, [3]), finalMsg);
+	t.expect(update?.type).toBe("complete");
+	if (update?.type === "complete") {
+		t.expect(
+			update.partials.map((cc) =>
+				(cc as AssociationCCReport).reportsToFollow
+			),
+		).toStrictEqual([2, 1]);
+		t.expect(update.finalMsg).toBe(finalMsg);
+	}
+
+	manager.clear();
+});
+
+test("a missing segment triggers a re-request after the segment timeout", (t) => {
+	vi.useFakeTimers();
+	const { manager, calls } = setup();
+
+	manager.handleCommand(report(2, [1]), dummyMsg());
+	// Segment 1 went missing
+	const update = manager.handleCommand(report(0, [3]), dummyMsg());
+	t.expect(update?.type).toBe("segment");
+
+	// The missing segment is only considered lost when it
+	// does not arrive within the segment timeout
+	t.expect(calls.rerequested).toBe(0);
+	vi.advanceTimersByTime(60000);
+	t.expect(calls.rerequested).toBe(1);
+
+	// The re-requested series patches the hole...
+	manager.handleCommand(report(2, [1]), dummyMsg());
+	const complete = manager.handleCommand(report(1, [2]), dummyMsg());
+	t.expect(complete?.type).toBe("complete");
+
+	// ...and the surplus tail is swallowed
+	const surplus = manager.handleCommand(report(0, [3]), dummyMsg());
+	t.expect(surplus).toMatchObject({ type: "segment", duplicate: true });
+
+	// Afterwards, a new single-segment response is handled normally again
+	const fresh = manager.handleCommand(report(0, [9]), dummyMsg());
+	t.expect(fresh?.type).toBe("complete");
+
+	manager.clear();
+});
+
+test("segments missing from the surplus tail do not start a new session", (t) => {
+	vi.useFakeTimers();
+	const { manager, calls } = setup();
+
+	// Segment 2 went missing
+	manager.handleCommand(report(3, [1]), dummyMsg());
+	manager.handleCommand(report(1, [3]), dummyMsg());
+	manager.handleCommand(report(0, [4]), dummyMsg());
+	vi.advanceTimersByTime(60000);
+	t.expect(calls.rerequested).toBe(1);
+
+	// The re-requested series fills the hole early
+	manager.handleCommand(report(3, [1]), dummyMsg());
+	const complete = manager.handleCommand(report(2, [2]), dummyMsg());
+	t.expect(complete?.type).toBe("complete");
+
+	// Segment 1 of the surplus tail goes missing as well. The remaining
+	// segment was already merged and must not look like a new response.
+	const surplus = manager.handleCommand(report(0, [4]), dummyMsg());
+	t.expect(surplus).toMatchObject({ type: "segment", duplicate: true });
+
+	manager.clear();
+});
+
+test("a segment with a higher count than the completed series ends the drain", (t) => {
+	const { manager } = setup();
+
+	// Complete a series by filling a hole, which arms the drain
+	manager.handleCommand(report(2, [1]), dummyMsg());
+	manager.handleCommand(report(0, [3]), dummyMsg());
+	manager.handleCommand(report(2, [1]), dummyMsg());
+	const complete = manager.handleCommand(report(1, [2]), dummyMsg());
+	t.expect(complete?.type).toBe("complete");
+
+	// A new, longer series starts before the surplus tail arrived
+	const fresh = manager.handleCommand(report(3, [5]), dummyMsg());
+	t.expect(fresh).toMatchObject({ type: "segment", duplicate: false });
+
+	manager.clear();
+});

--- a/packages/zwave-js/src/lib/driver/PartialCCSessionManager.ts
+++ b/packages/zwave-js/src/lib/driver/PartialCCSessionManager.ts
@@ -1,0 +1,238 @@
+import type { CommandClass } from "@zwave-js/cc";
+import type { CommandRequest, ContainsCC } from "@zwave-js/serial/serialapi";
+import { type Timer, setTimer } from "@zwave-js/shared";
+
+/** A partial CC session and the segments received for it so far */
+export interface PartialCCSession {
+	nodeId: number;
+	/** The received segments, keyed by their remaining segments count */
+	segments: Map<number, CommandClass>;
+	/** The message which contained the final segment, if it was already received */
+	finalMsg?: CommandRequest & ContainsCC;
+	/** The message which contained the most recent segment */
+	lastSegmentMsg: CommandRequest & ContainsCC;
+	/** The request this session is the response to, if known */
+	requestCC?: CommandClass;
+	/** How many times the response may still be re-requested when segments are missing */
+	attemptsLeft: number;
+	timeout?: Timer;
+}
+
+export type PartialCCUpdate =
+	// The command was stored and the session expects more segments
+	| { type: "segment"; duplicate: boolean }
+	// All segments were received and the command can be merged
+	| {
+		type: "complete";
+		/** The final segment, which the partials are merged into */
+		command: CommandClass;
+		/** The other segments, ordered like they were transmitted by the node */
+		partials: CommandClass[];
+		/** The message which contained the final segment */
+		finalMsg: CommandRequest & ContainsCC;
+	};
+
+export interface PartialCCSessionManagerHost {
+	/** How long to wait for the next segment of a session */
+	getSegmentTimeout(): number;
+	/** How many times the response of a session with missing segments may be re-requested */
+	getMaxReRequestAttempts(): number;
+	/** Determines the request CC a newly created session is the response to, if any */
+	findRequestCC(command: CommandClass): CommandClass | undefined;
+	/** Re-requests the response a session belongs to because segments are missing */
+	rerequestSession(session: PartialCCSession): void;
+	/** Called when an incomplete session is dropped */
+	onSessionLost(session: PartialCCSession): void;
+}
+
+/**
+ * Tracks the state of partial CC sessions, i.e. commands which are split into
+ * multiple segments that need to be reassembled before they can be handled.
+ *
+ * Segments are identified by their "remaining segments" counter (e.g. a
+ * "reports to follow" field), which decreases towards 0 for the final segment.
+ * Since Z-Wave commands from a node are received in order, this allows detecting
+ * duplicated and missing segments.
+ */
+export class PartialCCSessionManager {
+	public constructor(host: PartialCCSessionManagerHost) {
+		this.host = host;
+	}
+
+	private host: PartialCCSessionManagerHost;
+	private sessions = new Map<string, PartialCCSession>();
+	private drains = new Map<
+		string,
+		{ nextRemaining: number; timeout: Timer }
+	>();
+
+	/**
+	 * Determines if the given command belongs to a partial CC session and tracks it if so.
+	 * Returns `undefined` for commands that do not support partial sessions.
+	 */
+	public handleCommand(
+		command: CommandClass,
+		msg: CommandRequest & ContainsCC,
+	): PartialCCUpdate | undefined {
+		const sessionId = command.getPartialCCSessionId();
+		if (!sessionId) return undefined;
+
+		const remaining = command.getRemainingSegments() ?? 0;
+		const key = JSON.stringify({
+			nodeId: command.nodeId,
+			ccId: command.ccId,
+			ccCommand: command.ccCommand,
+			...sessionId,
+		});
+
+		// When a session completes while filling a hole from a previous session,
+		// the node keeps sending the remaining segments, which are already part of
+		// the merged command. These surplus segments are swallowed for a short time
+		// so they are not mistaken for the beginning of a new session.
+		const drain = this.drains.get(key);
+		if (drain) {
+			// Segments in the surplus tail may go missing too, so any segment that
+			// continues the completed series in descending order was already merged
+			if (remaining <= drain.nextRemaining) {
+				if (remaining === 0) {
+					this.deleteDrain(key);
+				} else {
+					drain.nextRemaining = remaining - 1;
+				}
+				return { type: "segment", duplicate: true };
+			}
+			// A higher count means a new series started, handle the segment normally
+			this.deleteDrain(key);
+		}
+
+		let session = this.sessions.get(key);
+
+		if (!session) {
+			// The response fits into a single segment, no need to track a session
+			if (remaining === 0) {
+				return {
+					type: "complete",
+					command,
+					partials: [],
+					finalMsg: msg,
+				};
+			}
+
+			session = {
+				nodeId: command.nodeId as number,
+				segments: new Map(),
+				lastSegmentMsg: msg,
+				requestCC: this.host.findRequestCC(command),
+				attemptsLeft: this.host.getMaxReRequestAttempts(),
+			};
+			this.sessions.set(key, session);
+		}
+
+		// A segment with a higher count than all previous ones means the node has started
+		// sending the response again, e.g. after it was re-requested. The data may have
+		// changed in the meantime, so discard the previous segments to avoid merging two
+		// different responses.
+		// Caution: This loses previously received segments when the first segment(s) of the
+		// original response were not received, where keeping them would have been valid.
+		// There is no way to distinguish the two cases though.
+		if (
+			session.segments.size > 0
+			&& remaining > Math.max(...session.segments.keys())
+		) {
+			session.segments.clear();
+			session.finalMsg = undefined;
+		}
+
+		const duplicate = session.segments.has(remaining);
+		// In case of a duplicate, assume the newest segment is the correct one
+		session.segments.set(remaining, command);
+		session.lastSegmentMsg = msg;
+		if (remaining === 0) session.finalMsg = msg;
+
+		// The session is complete when the final segment and everything before it was received
+		const expectedTotal = Math.max(...session.segments.keys()) + 1;
+		if (
+			session.segments.has(0)
+			&& session.segments.size === expectedTotal
+		) {
+			this.deleteSession(key);
+
+			// When this segment filled a hole, the segments after it are still
+			// being transmitted and need to be swallowed when they arrive
+			if (remaining > 0) {
+				this.deleteDrain(key);
+				this.drains.set(key, {
+					nextRemaining: remaining - 1,
+					timeout: setTimer(() => {
+						this.drains.delete(key);
+					}, this.host.getSegmentTimeout()),
+				});
+			}
+
+			const partials = [...session.segments.entries()]
+				.filter(([rem]) => rem > 0)
+				.toSorted(([a], [b]) => b - a)
+				.map(([, cc]) => cc);
+			return {
+				type: "complete",
+				command: session.segments.get(0)!,
+				partials,
+				finalMsg: session.finalMsg!,
+			};
+		}
+
+		// Wait for the missing segments, in case the node retransmits them.
+		// Anything still missing when the timer elapses is either re-requested
+		// or considered lost.
+		session.timeout?.clear();
+		session.timeout = setTimer(() => {
+			this.recoverOrDrop(key, session);
+		}, this.host.getSegmentTimeout());
+
+		return { type: "segment", duplicate };
+	}
+
+	/** Re-requests the response a session belongs to, or drops the session when that is not possible */
+	private recoverOrDrop(key: string, session: PartialCCSession): void {
+		if (session.requestCC && session.attemptsLeft > 0) {
+			session.attemptsLeft--;
+			this.host.rerequestSession(session);
+			// Limit how long to wait for the re-requested segments
+			session.timeout?.clear();
+			session.timeout = setTimer(() => {
+				this.recoverOrDrop(key, session);
+			}, this.host.getSegmentTimeout());
+		} else {
+			this.deleteSession(key);
+			this.host.onSessionLost(session);
+		}
+	}
+
+	private deleteSession(key: string): void {
+		const session = this.sessions.get(key);
+		if (session) {
+			session.timeout?.clear();
+			this.sessions.delete(key);
+		}
+	}
+
+	private deleteDrain(key: string): void {
+		const drain = this.drains.get(key);
+		if (drain) {
+			drain.timeout.clear();
+			this.drains.delete(key);
+		}
+	}
+
+	/** Drops all sessions and stops all timers */
+	public clear(): void {
+		for (const session of this.sessions.values()) {
+			session.timeout?.clear();
+		}
+		this.sessions.clear();
+		for (const drain of this.drains.values()) {
+			drain.timeout.clear();
+		}
+		this.drains.clear();
+	}
+}

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -117,6 +117,12 @@ export interface ZWaveOptions {
 		 * How many attempts should be made for OTW firmware updates before giving up
 		 */
 		firmwareUpdateOTW: number; // [1...5], default: 3
+
+		/**
+		 * How often a response that is split into multiple reports should be re-requested
+		 * when some of the reports were not received. Set to 0 to disable re-requesting.
+		 */
+		partialReports: number; // [0...5], default: 2
 	};
 
 	/**

--- a/packages/zwave-js/src/lib/test/cc/CommandClass.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CommandClass.test.ts
@@ -93,9 +93,9 @@ test("getImplementedVersionStatic() should work on inherited classes", (t) => {
 	t.expect(getImplementedVersionStatic(DummyCCSubClass1)).toBe(7);
 });
 
-test("expectMoreMessages() returns false by default", (t) => {
+test("getRemainingSegments() returns undefined by default", (t) => {
 	const cc = new DummyCC({ nodeId: 1 });
-	t.expect(cc.expectMoreMessages([])).toBe(false);
+	t.expect(cc.getRemainingSegments()).toBeUndefined();
 });
 
 test("getExpectedCCResponse() returns the expected CC response like it was defined", (t) => {

--- a/packages/zwave-js/src/lib/test/driver/assemblePartialCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/assemblePartialCCs.test.ts
@@ -59,17 +59,17 @@ const test = baseTest.extend<LocalTestContext>({
 	],
 });
 
-test("returns true when a non-partial CC is received", async ({ context, expect }) => {
+test("returns the message when a non-partial CC is received", async ({ context, expect }) => {
 	const { driver } = context;
 	const cc = new BasicCCSet({ nodeId: 2, targetValue: 50 });
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(await driver["assemblePartialCCs"](msg)).toBe(true);
+	expect(await driver["assemblePartialCCs"](msg)).toBe(msg);
 });
 
 test(
-	"returns true when a partial CC is received that expects no more reports",
+	"returns the message when a partial CC is received that expects no more reports",
 	async ({ context, expect }) => {
 		const { driver } = context;
 		const cc = await CommandClass.parse(
@@ -88,12 +88,12 @@ test(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(await driver["assemblePartialCCs"](msg)).toBe(true);
+		expect(await driver["assemblePartialCCs"](msg)).toBe(msg);
 	},
 );
 
 test(
-	"returns false when a partial CC is received that expects more reports",
+	"returns undefined when a partial CC is received that expects more reports",
 	async ({ context, expect }) => {
 		const { driver } = context;
 		const cc = await CommandClass.parse(
@@ -112,12 +112,12 @@ test(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(await driver["assemblePartialCCs"](msg)).toBe(false);
+		expect(await driver["assemblePartialCCs"](msg)).toBeUndefined();
 	},
 );
 
 test(
-	"returns true when the final partial CC is received and merges its data",
+	"returns the final message when the final partial CC is received and merges its data",
 	async ({ context, expect }) => {
 		const { driver } = context;
 		const cc1 = await CommandClass.parse(
@@ -149,12 +149,13 @@ test(
 		const msg1 = new ApplicationCommandRequest({
 			command: cc1,
 		});
-		await expect(driver["assemblePartialCCs"](msg1)).resolves.toBe(false);
+		await expect(driver["assemblePartialCCs"](msg1)).resolves
+			.toBeUndefined();
 
 		const msg2 = new ApplicationCommandRequest({
 			command: cc2,
 		});
-		await expect(driver["assemblePartialCCs"](msg2)).resolves.toBe(true);
+		await expect(driver["assemblePartialCCs"](msg2)).resolves.toBe(msg2);
 
 		expect(
 			(msg2.command as AssociationCCReport).nodeIds,
@@ -173,7 +174,7 @@ test("does not crash when receiving a Multi Command CC", async ({ context, expec
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(await driver["assemblePartialCCs"](msg)).toBe(true);
+	expect(await driver["assemblePartialCCs"](msg)).toBe(msg);
 });
 
 test("supports nested partial/non-partial CCs", async ({ context, expect }) => {
@@ -188,7 +189,7 @@ test("supports nested partial/non-partial CCs", async ({ context, expect }) => {
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(await driver["assemblePartialCCs"](msg)).toBe(true);
+	expect(await driver["assemblePartialCCs"](msg)).toBe(msg);
 });
 
 test("supports nested partial/partial CCs (part 1)", async ({ context, expect }) => {
@@ -211,7 +212,7 @@ test("supports nested partial/partial CCs (part 1)", async ({ context, expect })
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(await driver["assemblePartialCCs"](msg)).toBe(false);
+	expect(await driver["assemblePartialCCs"](msg)).toBeUndefined();
 });
 
 test("supports nested partial/partial CCs (part 2)", async ({ context, expect }) => {
@@ -234,11 +235,11 @@ test("supports nested partial/partial CCs (part 2)", async ({ context, expect })
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(await driver["assemblePartialCCs"](msg)).toBe(true);
+	expect(await driver["assemblePartialCCs"](msg)).toBe(msg);
 });
 
 test(
-	"returns false when a partial CC throws Deserialization_NotImplemented during merging",
+	"returns undefined when a partial CC throws Deserialization_NotImplemented during merging",
 	async ({ context, expect }) => {
 		const { driver } = context;
 		const cc = await CommandClass.parse(
@@ -263,12 +264,12 @@ test(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(await driver["assemblePartialCCs"](msg)).toBe(false);
+		expect(await driver["assemblePartialCCs"](msg)).toBeUndefined();
 	},
 );
 
 test(
-	"returns false when a partial CC throws CC_NotImplemented during merging",
+	"returns undefined when a partial CC throws CC_NotImplemented during merging",
 	async ({ context, expect }) => {
 		const { driver } = context;
 		const cc = await CommandClass.parse(
@@ -293,12 +294,12 @@ test(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(await driver["assemblePartialCCs"](msg)).toBe(false);
+		expect(await driver["assemblePartialCCs"](msg)).toBeUndefined();
 	},
 );
 
 test(
-	"returns false when a partial CC throws PacketFormat_InvalidPayload during merging",
+	"returns undefined when a partial CC throws PacketFormat_InvalidPayload during merging",
 	async ({ context, expect }) => {
 		const { driver } = context;
 		const cc = await CommandClass.parse(
@@ -323,7 +324,7 @@ test(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(await driver["assemblePartialCCs"](msg)).toBe(false);
+		expect(await driver["assemblePartialCCs"](msg)).toBeUndefined();
 	},
 );
 

--- a/packages/zwave-js/src/lib/test/driver/partialCCSessions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/partialCCSessions.test.ts
@@ -2,6 +2,11 @@ import {
 	ConfigurationCCNameGet,
 	ConfigurationCCNameReport,
 } from "@zwave-js/cc/ConfigurationCC";
+import {
+	MAX_SEGMENT_SIZE,
+	TransportServiceCCFirstSegment,
+	TransportServiceCCSubsequentSegment,
+} from "@zwave-js/cc/TransportServiceCC";
 import { CommandClasses } from "@zwave-js/core";
 import {
 	type MockNodeBehavior,
@@ -214,6 +219,198 @@ integrationTest(
 			// a complete response and succeeds.
 			const name2 = await node.commandClasses.Configuration.getName(1);
 			t.expect(name2).toBe("Test parameter");
+		},
+	},
+);
+
+integrationTest(
+	"Partial reports are merged when some are encapsulated with Transport Service and some are not",
+	{
+		// debug: true,
+
+		nodeCapabilities,
+
+		async customSetup(driver, mockController, mockNode) {
+			const part1 =
+				"Veeeeeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooooooooooooooooooong parameter name, ";
+			const part2 = "part 2";
+
+			const respondToConfigurationNameGet: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof ConfigurationCCNameGet) {
+						// The first report is too long for a single frame and
+						// gets sent using Transport Service
+						const report1 = new ConfigurationCCNameReport({
+							nodeId: controller.ownNodeId,
+							parameter: receivedCC.parameter,
+							name: part1,
+							reportsToFollow: 1,
+						});
+						const serialized = await report1.serialize(
+							mockNode.encodingContext,
+						);
+
+						const sessionId = 3;
+						let offset = 0;
+						while (offset < serialized.length) {
+							const partialDatagram = serialized.subarray(
+								offset,
+								offset + MAX_SEGMENT_SIZE,
+							);
+							const segment = offset === 0
+								? new TransportServiceCCFirstSegment({
+									nodeId: controller.ownNodeId,
+									sessionId,
+									datagramSize: serialized.length,
+									partialDatagram,
+								})
+								: new TransportServiceCCSubsequentSegment({
+									nodeId: controller.ownNodeId,
+									sessionId,
+									datagramSize: serialized.length,
+									datagramOffset: offset,
+									partialDatagram,
+								});
+							await self.sendToController(
+								createMockZWaveRequestFrame(segment, {
+									ackRequested: false,
+								}),
+							);
+							await wait(50);
+							offset += partialDatagram.length;
+						}
+
+						// The second report fits into a normal frame
+						const report2 = new ConfigurationCCNameReport({
+							nodeId: controller.ownNodeId,
+							parameter: receivedCC.parameter,
+							name: part2,
+							reportsToFollow: 0,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(report2, {
+								ackRequested: false,
+							}),
+						);
+
+						return { action: "stop" };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToConfigurationNameGet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const name = await node.commandClasses.Configuration.getName(1);
+			t.expect(name).toBe(
+				"Veeeeeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooooooooooooooooooong parameter name, part 2",
+			);
+		},
+	},
+);
+
+let queryCountMissingFinalTS = 0;
+integrationTest(
+	"A missing final report following a Transport Service encapsulated one is re-requested and patched together",
+	{
+		// debug: true,
+
+		nodeCapabilities,
+
+		async customSetup(driver, mockController, mockNode) {
+			const part1 =
+				"Veeeeeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooooooooooooooooooong parameter name, ";
+			const part2 = "part 2";
+
+			async function sendReportViaTransportService(
+				controller: typeof mockController,
+				self: typeof mockNode,
+				report: ConfigurationCCNameReport,
+				sessionId: number,
+			) {
+				const serialized = await report.serialize(
+					mockNode.encodingContext,
+				);
+				let offset = 0;
+				while (offset < serialized.length) {
+					const partialDatagram = serialized.subarray(
+						offset,
+						offset + MAX_SEGMENT_SIZE,
+					);
+					const segment = offset === 0
+						? new TransportServiceCCFirstSegment({
+							nodeId: controller.ownNodeId,
+							sessionId,
+							datagramSize: serialized.length,
+							partialDatagram,
+						})
+						: new TransportServiceCCSubsequentSegment({
+							nodeId: controller.ownNodeId,
+							sessionId,
+							datagramSize: serialized.length,
+							datagramOffset: offset,
+							partialDatagram,
+						});
+					await self.sendToController(
+						createMockZWaveRequestFrame(segment, {
+							ackRequested: false,
+						}),
+					);
+					await wait(50);
+					offset += partialDatagram.length;
+				}
+			}
+
+			const respondToConfigurationNameGet: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof ConfigurationCCNameGet) {
+						const queryCount = ++queryCountMissingFinalTS;
+
+						// The first report is too long for a single frame and
+						// gets sent using Transport Service
+						const report1 = new ConfigurationCCNameReport({
+							nodeId: controller.ownNodeId,
+							parameter: receivedCC.parameter,
+							name: part1,
+							reportsToFollow: 1,
+						});
+						await sendReportViaTransportService(
+							controller,
+							self,
+							report1,
+							queryCount,
+						);
+
+						// The non-encapsulated final report goes missing on the
+						// first attempt
+						if (queryCount > 1) {
+							const report2 = new ConfigurationCCNameReport({
+								nodeId: controller.ownNodeId,
+								parameter: receivedCC.parameter,
+								name: part2,
+								reportsToFollow: 0,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(report2, {
+									ackRequested: false,
+								}),
+							);
+						}
+
+						return { action: "stop" };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToConfigurationNameGet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const name = await node.commandClasses.Configuration.getName(1);
+			t.expect(name).toBe(
+				"Veeeeeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooooooooooooooooooong parameter name, part 2",
+			);
+
+			t.expect(queryCountMissingFinalTS).toBe(2);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/driver/partialCCSessions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/partialCCSessions.test.ts
@@ -1,0 +1,269 @@
+import {
+	ConfigurationCCNameGet,
+	ConfigurationCCNameReport,
+} from "@zwave-js/cc/ConfigurationCC";
+import { CommandClasses } from "@zwave-js/core";
+import {
+	type MockNodeBehavior,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite.js";
+
+const nodeCapabilities = {
+	commandClasses: [
+		CommandClasses.Version,
+		{
+			ccId: CommandClasses.Configuration,
+			isSupported: true,
+			version: 1,
+		},
+	],
+};
+
+integrationTest("Duplicated partial reports are only used once", {
+	// debug: true,
+
+	nodeCapabilities,
+
+	async customSetup(driver, mockController, mockNode) {
+		const respondToConfigurationNameGet: MockNodeBehavior = {
+			async handleCC(controller, self, receivedCC) {
+				if (receivedCC instanceof ConfigurationCCNameGet) {
+					const reports = [
+						["Test para", 1],
+						// The node re-transmits the first report
+						["Test para", 1],
+						["meter", 0],
+					] as const;
+					for (const [name, reportsToFollow] of reports) {
+						const cc = new ConfigurationCCNameReport({
+							nodeId: controller.ownNodeId,
+							parameter: receivedCC.parameter,
+							name,
+							reportsToFollow,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						await wait(100);
+					}
+					return { action: "stop" };
+				}
+			},
+		};
+		mockNode.defineBehavior(respondToConfigurationNameGet);
+	},
+
+	async testBody(t, driver, node, mockController, mockNode) {
+		const name = await node.commandClasses.Configuration.getName(1);
+		t.expect(name).toBe("Test parameter");
+	},
+});
+
+let queryCountMissingMiddle = 0;
+integrationTest(
+	"A response with a missing middle report is re-requested and patched together",
+	{
+		// debug: true,
+
+		nodeCapabilities,
+
+		async customSetup(driver, mockController, mockNode) {
+			const respondToConfigurationNameGet: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof ConfigurationCCNameGet) {
+						const queryCount = ++queryCountMissingMiddle;
+						const reports: (readonly [string, number])[] =
+							queryCount === 1
+								// The middle report goes missing on the first attempt
+								? [["Test ", 2], ["ter", 0]]
+								: [["Test ", 2], ["parame", 1], ["ter", 0]];
+						for (const [name, reportsToFollow] of reports) {
+							const cc = new ConfigurationCCNameReport({
+								nodeId: controller.ownNodeId,
+								parameter: receivedCC.parameter,
+								name,
+								reportsToFollow,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(cc, {
+									ackRequested: false,
+								}),
+							);
+							await wait(100);
+						}
+						return { action: "stop" };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToConfigurationNameGet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const name = await node.commandClasses.Configuration.getName(1);
+			t.expect(name).toBe("Test parameter");
+
+			// The driver should have re-requested the response exactly once
+			t.expect(queryCountMissingMiddle).toBe(2);
+		},
+	},
+);
+
+let queryCountMissingFinal = 0;
+integrationTest(
+	"A response with a missing final report is re-requested after a timeout",
+	{
+		// debug: true,
+
+		nodeCapabilities,
+
+		async customSetup(driver, mockController, mockNode) {
+			const respondToConfigurationNameGet: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof ConfigurationCCNameGet) {
+						const queryCount = ++queryCountMissingFinal;
+						const reports: (readonly [string, number])[] =
+							queryCount === 1
+								// The final report goes missing on the first attempt
+								? [["Test para", 1]]
+								: [["Test para", 1], ["meter", 0]];
+						for (const [name, reportsToFollow] of reports) {
+							const cc = new ConfigurationCCNameReport({
+								nodeId: controller.ownNodeId,
+								parameter: receivedCC.parameter,
+								name,
+								reportsToFollow,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(cc, {
+									ackRequested: false,
+								}),
+							);
+							await wait(100);
+						}
+						return { action: "stop" };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToConfigurationNameGet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const name = await node.commandClasses.Configuration.getName(1);
+			t.expect(name).toBe("Test parameter");
+
+			t.expect(queryCountMissingFinal).toBe(2);
+		},
+	},
+);
+
+let queryCountNoRerequest = 0;
+integrationTest(
+	"Responses with missing reports are dropped when re-requesting is disabled",
+	{
+		// debug: true,
+
+		nodeCapabilities,
+
+		additionalDriverOptions: {
+			attempts: {
+				partialReports: 0,
+			},
+		},
+
+		async customSetup(driver, mockController, mockNode) {
+			const respondToConfigurationNameGet: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof ConfigurationCCNameGet) {
+						const queryCount = ++queryCountNoRerequest;
+						const reports: (readonly [string, number])[] =
+							queryCount === 1
+								// The middle report goes missing on the first attempt
+								? [["Test ", 2], ["ter", 0]]
+								: [["Test ", 2], ["parame", 1], ["ter", 0]];
+						for (const [name, reportsToFollow] of reports) {
+							const cc = new ConfigurationCCNameReport({
+								nodeId: controller.ownNodeId,
+								parameter: receivedCC.parameter,
+								name,
+								reportsToFollow,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(cc, {
+									ackRequested: false,
+								}),
+							);
+							await wait(100);
+						}
+						return { action: "stop" };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToConfigurationNameGet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			// The incomplete response is dropped and the request fails
+			const name = await node.commandClasses.Configuration.getName(1);
+			t.expect(name).toBeUndefined();
+
+			// No stale segments must remain. A subsequent request receives
+			// a complete response and succeeds.
+			const name2 = await node.commandClasses.Configuration.getName(1);
+			t.expect(name2).toBe("Test parameter");
+		},
+	},
+);
+
+integrationTest(
+	"Incomplete sessions from unsolicited reports are dropped after a timeout",
+	{
+		// debug: true,
+
+		nodeCapabilities,
+
+		async customSetup(driver, mockController, mockNode) {
+			const respondToConfigurationNameGet: MockNodeBehavior = {
+				handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof ConfigurationCCNameGet) {
+						const cc = new ConfigurationCCNameReport({
+							nodeId: controller.ownNodeId,
+							parameter: receivedCC.parameter,
+							name: "fresh",
+							reportsToFollow: 0,
+						});
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToConfigurationNameGet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			// The node sends an unsolicited partial report whose
+			// remaining segments never arrive
+			const staleReport = new ConfigurationCCNameReport({
+				nodeId: 2,
+				parameter: 1,
+				name: "stale",
+				reportsToFollow: 1,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(staleReport, {
+					ackRequested: false,
+				}),
+			);
+
+			// Wait until the incomplete session is dropped
+			await wait(1500);
+
+			// The complete response to a subsequent request must not be
+			// merged with the stale segment
+			const name = await node.commandClasses.Configuration.getName(1);
+			t.expect(name).toBe("fresh");
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/driver/partialCCSessions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/partialCCSessions.test.ts
@@ -7,7 +7,7 @@ import {
 	TransportServiceCCFirstSegment,
 	TransportServiceCCSubsequentSegment,
 } from "@zwave-js/cc/TransportServiceCC";
-import { CommandClasses } from "@zwave-js/core";
+import { CommandClasses, SecurityClass } from "@zwave-js/core";
 import {
 	type MockNodeBehavior,
 	createMockZWaveRequestFrame,
@@ -461,6 +461,84 @@ integrationTest(
 			// merged with the stale segment
 			const name = await node.commandClasses.Configuration.getName(1);
 			t.expect(name).toBe("fresh");
+		},
+	},
+);
+
+integrationTest(
+	"Unencrypted reports cannot be injected into a partial CC session at a higher security level",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				CommandClasses["Security 2"],
+				{
+					ccId: CommandClasses.Configuration,
+					isSupported: true,
+					secure: true,
+					version: 1,
+				},
+			],
+			securityClasses: new Set([SecurityClass.S2_Unauthenticated]),
+		},
+
+		async customSetup(driver, mockController, mockNode) {
+			const respondToConfigurationNameGet: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof ConfigurationCCNameGet) {
+						// The genuine response is S2-encapsulated
+						const report1 = new ConfigurationCCNameReport({
+							nodeId: controller.ownNodeId,
+							parameter: receivedCC.parameter,
+							name: "Test para",
+							reportsToFollow: 1,
+						});
+						await self.sendResponse(receivedCC, {
+							action: "sendCC",
+							cc: report1,
+							ackRequested: false,
+						});
+						await wait(100);
+
+						// An attacker tries to replace the first report with a
+						// forged, unencrypted one
+						const evilReport = new ConfigurationCCNameReport({
+							nodeId: controller.ownNodeId,
+							parameter: receivedCC.parameter,
+							name: "Malicious para",
+							reportsToFollow: 1,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(evilReport, {
+								ackRequested: false,
+							}),
+						);
+						await wait(100);
+
+						const report2 = new ConfigurationCCNameReport({
+							nodeId: controller.ownNodeId,
+							parameter: receivedCC.parameter,
+							name: "meter",
+							reportsToFollow: 0,
+						});
+						await self.sendResponse(receivedCC, {
+							action: "sendCC",
+							cc: report2,
+							ackRequested: false,
+						});
+
+						return { action: "stop" };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToConfigurationNameGet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const name = await node.commandClasses.Configuration.getName(1);
+			t.expect(name).toBe("Test parameter");
 		},
 	},
 );


### PR DESCRIPTION
fixes: https://github.com/zwave-js/zwave-js/issues/7789
closes: https://github.com/zwave-js/zwave-js/pull/3401
fixes: https://github.com/zwave-js/zwave-js/issues/3368

This PR overhauls how we deal with partial CCs. This includes:
- supporting mixed `Transport Service CC` + bare `reportsToFollow`-style CCs
- detecting re-transmitted commands using the `reportsToFollow` pattern
- correctly ordering out-of-sequence commands using the `reportsToFollow` pattern
- and automatically re-requesting the report when some partial reports are missing.