### PR TITLE
feat: granular interview progress reporting

### DIFF
--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -464,7 +464,13 @@ On endpoints where [`supportsUsersWithoutCredentials`](#getusercapabilitiescache
 
 ```ts
 interface AddUserResult {
+	/** Result of adding the user. */
 	user: SetUserResult;
+	/**
+	 * Result of adding the credential. Only present when a credential was
+	 * provided. On User Code CC, the user and credential are written as a
+	 * single operation, so this mirrors {@link AddUserResult.user}.
+	 */
 	credential?: SetCredentialResult;
 }
 ```

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1312,7 +1312,7 @@ A state of the interview process for this node was completed. Only the name of t
 ```
 
 > [!NOTE] This event is deprecated. It has been found that it is not very useful to report interview progress due to most of the interview happening in the `CommandClasses` stage.
-It is recommended to instead use the `"interview progress"` event for granular interview progress reporting.
+> It is recommended to instead use the `"interview progress"` event for granular interview progress reporting.
 
 ### `"interview progress"`
 
@@ -1340,6 +1340,7 @@ interface InterviewProgress {
 ```
 
 The `stage` is the current interview stage in progress, with two exceptions:
+
 - When the interview has just started, the stage is `None` and the progress is `0%`.
 - When the interview has completed, the stage is `Complete` and the progress is `100%`.
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1311,6 +1311,36 @@ A state of the interview process for this node was completed. Only the name of t
 (node: ZWaveNode, stageName: string) => void
 ```
 
+> [!NOTE] This event is deprecated. It has been found that it is not very useful due to most of the interview happening in the `CommandClasses` stage. Use the `"interview progress"` event for granular interview progress reporting instead.
+
+### `"interview progress"`
+
+The interview made progress. This event is emitted frequently (throttled) during the interview and provides an approximate overall progress, which is useful to display a progress bar. The first and last interview stages are nearly instant, while interviewing the Command Classes takes the majority of the time, so the reported progress is weighted accordingly.
+
+```ts
+(node: ZWaveNode, progress: InterviewProgress) => void
+```
+
+<!-- #import InterviewProgress from "zwave-js" -->
+
+```ts
+interface InterviewProgress {
+	// The interview stage that is currently in progress
+	stage: InterviewStage;
+	// The approximate overall interview progress in %, rounded to two digits.
+	// This is monotonically non-decreasing within a single interview and only an approximation,
+	// as the exact amount of work cannot be known in advance.
+	progress: number;
+	// During the `CommandClasses` stage: the index of the endpoint that is currently being interviewed
+	endpoint?: number;
+	// During the `CommandClasses` stage: the Command Class that is currently being interviewed
+	commandClass?: CommandClasses;
+}
+```
+
+> [!NOTE]
+> The progress is an approximation. It advances per Command Class, with finer-grained updates while interviewing some long-running CCs (e.g. Version, Configuration, Association). A single long-running CC that does not report its internal progress may pause the reported progress until it completes.
+
 ### `"interview completed"`
 
 The initial interview or reinterview process for this node was completed. The node is passed as the single argument to the callback:

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1311,7 +1311,8 @@ A state of the interview process for this node was completed. Only the name of t
 (node: ZWaveNode, stageName: string) => void
 ```
 
-> [!NOTE] This event is deprecated. It has been found that it is not very useful due to most of the interview happening in the `CommandClasses` stage. Use the `"interview progress"` event for granular interview progress reporting instead.
+> [!NOTE] This event is deprecated. It has been found that it is not very useful to report interview progress due to most of the interview happening in the `CommandClasses` stage.
+It is recommended to instead use the `"interview progress"` event for granular interview progress reporting.
 
 ### `"interview progress"`
 
@@ -1337,6 +1338,10 @@ interface InterviewProgress {
 	commandClass?: CommandClasses;
 }
 ```
+
+The `stage` is the current interview stage in progress, with two exceptions:
+- When the interview has just started, the stage is `None` and the progress is `0%`.
+- When the interview has completed, the stage is `Complete` and the progress is `100%`.
 
 > [!NOTE]
 > The progress is an approximation. It advances per Command Class, with finer-grained updates while interviewing some long-running CCs (e.g. Version, Configuration, Association). A single long-running CC that does not report its internal progress may pause the reported progress until it completes.

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1326,15 +1326,19 @@ The interview made progress. This event is emitted frequently (throttled) during
 
 ```ts
 interface InterviewProgress {
-	// The interview stage that is currently in progress
+	/**
+	 * The interview stage that is currently in progress.
+	 * `None` at the interview start, and `Complete` once the interview has finished.
+	 */
 	stage: InterviewStage;
-	// The approximate overall interview progress in %, rounded to two digits.
-	// This is monotonically non-decreasing within a single interview and only an approximation,
-	// as the exact amount of work cannot be known in advance.
+	/**
+	 * The approximate overall interview progress in %, rounded to two digits.
+	 */
 	progress: number;
-	// During the `CommandClasses` stage: the index of the endpoint that is currently being interviewed
+
+	/** During the `CommandClasses` stage: the index of the endpoint that is currently being interviewed */
 	endpoint?: number;
-	// During the `CommandClasses` stage: the Command Class that is currently being interviewed
+	/** During the `CommandClasses` stage: the Command Class that is currently being interviewed */
 	commandClass?: CommandClasses;
 }
 ```

--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -424,7 +424,10 @@ export class AssociationCC extends CommandClass {
 		}
 
 		// Query each association group for its members
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed, total) =>
+				node.reportInterviewProgress(completed, total),
+		});
 
 		// Skip the remaining Association CC interview in favor of Multi Channel Association if possible
 		if (endpoint.supportsCC(CommandClasses["Multi Channel Association"])) {
@@ -483,6 +486,7 @@ currently assigned nodes: ${group.nodeIds.map(String).join(", ")}`;
 					direction: "inbound",
 				});
 			}
+			options?.onProgress?.(groupId, groupCount);
 		}
 	}
 }

--- a/packages/cc/src/cc/AssociationGroupInfoCC.ts
+++ b/packages/cc/src/cc/AssociationGroupInfoCC.ts
@@ -397,10 +397,20 @@ export class AssociationGroupInfoCC extends CommandClass {
 			});
 			await api.getCommands(groupId);
 			// Not sure how to log this
+
+			// This loop and the info query in refreshValues() each iterate over all groups,
+			// so they make up the first and second half of this CC's interview progress.
+			node.reportInterviewProgress(groupId, 2 * associationGroupCount);
 		}
 
 		// Finally query each group for its information
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed) =>
+				node.reportInterviewProgress(
+					associationGroupCount + completed,
+					2 * associationGroupCount,
+				),
+		});
 
 		// Remember that the interview is complete
 		this.setInterviewComplete(ctx, true);
@@ -455,6 +465,7 @@ profile:         ${
 					direction: "inbound",
 				});
 			}
+			options?.onProgress?.(groupId, associationGroupCount);
 		}
 	}
 }

--- a/packages/cc/src/cc/ColorSwitchCC.ts
+++ b/packages/cc/src/cc/ColorSwitchCC.ts
@@ -616,7 +616,10 @@ export class ColorSwitchCC extends CommandClass {
 		}
 
 		// Query all color components
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed, total) =>
+				node.reportInterviewProgress(completed, total),
+		});
 
 		// Remember that the interview is complete
 		this.setInterviewComplete(ctx, true);
@@ -641,7 +644,8 @@ export class ColorSwitchCC extends CommandClass {
 			ColorSwitchCCValues.supportedColorComponents,
 		) ?? [];
 
-		for (const color of supportedColors) {
+		for (let i = 0; i < supportedColors.length; i++) {
+			const color = supportedColors[i];
 			// Some devices report invalid colors, but the CC API checks
 			// for valid values and throws otherwise.
 			if (!isEnumMember(ColorComponent, color)) continue;
@@ -653,6 +657,8 @@ export class ColorSwitchCC extends CommandClass {
 				direction: "outbound",
 			});
 			await api.get(color);
+
+			options?.onProgress?.(i + 1, supportedColors.length);
 		}
 	}
 

--- a/packages/cc/src/cc/ColorSwitchCC.ts
+++ b/packages/cc/src/cc/ColorSwitchCC.ts
@@ -644,8 +644,7 @@ export class ColorSwitchCC extends CommandClass {
 			ColorSwitchCCValues.supportedColorComponents,
 		) ?? [];
 
-		for (let i = 0; i < supportedColors.length; i++) {
-			const color = supportedColors[i];
+		for (const [i, color] of supportedColors.entries()) {
 			// Some devices report invalid colors, but the CC API checks
 			// for valid values and throws otherwise.
 			if (!isEnumMember(ColorComponent, color)) continue;

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -297,6 +297,40 @@ function getParamInformationFromConfigFile(
 	}
 }
 
+/**
+ * Estimates the number of device queries the Configuration interview performs,
+ * depending on CC versions, availability of a config files, and compat flags.
+ */
+function estimateConfigurationInterviewQueryCount(
+	paramInfo: ParamInfoMap | undefined,
+	ccVersion: number,
+	assumedParamCount: number,
+	skipNameQuery: boolean,
+	skipInfoQuery: boolean,
+): number {
+	if (paramInfo?.size) {
+		const readableParameters = new Set(
+			[...paramInfo.keys()]
+				.filter((key) => !paramInfo.get(key)?.writeOnly)
+				.map((key) => key.parameter),
+		);
+		// v3+ queries each parameter's properties in addition to its value
+		// For parameters from config files, name and info are skipped.
+		return readableParameters.size * (ccVersion >= 3 ? 2 : 1);
+	}
+
+	// Before V3, only the value of each parameter is queried
+	if (ccVersion < 3) return assumedParamCount;
+
+	// On V3+, we query properties + value,
+	const queriesPerParam = 2
+		// optionally the name
+		+ (skipNameQuery ? 0 : 1)
+		// and optionally the description
+		+ (skipInfoQuery ? 0 : 1);
+	return assumedParamCount * queriesPerParam;
+}
+
 /** Builds a ConfigurationMetadata object from a ParamInformation entry */
 function configParamInfoToMetadata(
 	info: ParamInformation,
@@ -1205,6 +1239,10 @@ export class ConfigurationCC extends CommandClass {
 			Array.from(paramInfo?.keys() ?? []).map((k) => k.parameter),
 		);
 
+		// Fraction of the Configuration progress slice filled by the v3+ parameter scan.
+		// The value refresh below fills the remainder, so each value query advances progress.
+		let configScanProgress = 0;
+
 		if (api.version >= 3) {
 			ctx.logNode(node.id, {
 				endpoint: this.endpointIndex,
@@ -1234,6 +1272,16 @@ export class ConfigurationCC extends CommandClass {
 				return;
 			}
 
+			// Estimate (or calculate) the total number of queries needed during the interview.
+			const expectedQueryCount = estimateConfigurationInterviewQueryCount(
+				paramInfo,
+				api.version,
+				node.getInterviewProgressWeight(CommandClasses.Configuration),
+				!!deviceConfig?.compat?.skipConfigurationNameQuery,
+				!!deviceConfig?.compat?.skipConfigurationInfoQuery,
+			);
+			let scannedQueries = 0;
+
 			while (param > 0) {
 				ctx.logNode(node.id, {
 					endpoint: this.endpointIndex,
@@ -1256,6 +1304,10 @@ export class ConfigurationCC extends CommandClass {
 					break;
 				}
 				const { nextParameter, ...properties } = props;
+				node.reportInterviewProgress(
+					++scannedQueries,
+					expectedQueryCount,
+				);
 
 				let logMessage: string;
 				if (properties.valueSize === 0) {
@@ -1271,6 +1323,10 @@ export class ConfigurationCC extends CommandClass {
 								// If querying the name fails, don't abort the entire interview
 								() => undefined,
 							);
+							node.reportInterviewProgress(
+								++scannedQueries,
+								expectedQueryCount,
+							);
 						}
 
 						// Skip the info query for bugged devices
@@ -1278,6 +1334,10 @@ export class ConfigurationCC extends CommandClass {
 							await api.getInfo(param).catch(
 								// If querying the info fails, don't abort the entire interview
 								() => undefined,
+							);
+							node.reportInterviewProgress(
+								++scannedQueries,
+								expectedQueryCount,
 							);
 						}
 					}
@@ -1319,11 +1379,28 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 					break;
 				}
 			}
+
+			configScanProgress = Math.min(
+				1,
+				scannedQueries / expectedQueryCount,
+			);
 		}
 
 		await this.refreshValues(ctx, {
-			onProgress: (completed, total) =>
-				node.reportInterviewProgress(completed, total),
+			onProgress: (completed, total) => {
+				// To support reporting granular progress for devices where we don't
+				// know the parameter count in advance, we let the scan phase
+				// fill up the progress and map the value queries into the remainder.
+				// 
+				// For devices with known parameter counts, this mapping is uniform.
+				// For other devices it may yield larger, smaller, or no progress at all,
+				// depending on the actual parameter count.
+				const fraction = total > 0
+					? configScanProgress
+						+ (completed / total) * (1 - configScanProgress)
+					: configScanProgress;
+				node.reportInterviewProgress(fraction, 1);
+			},
 		});
 
 		// Apply recommended values from device config

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -1321,7 +1321,10 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 			}
 		}
 
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed, total) =>
+				node.reportInterviewProgress(completed, total),
+		});
 
 		// Apply recommended values from device config
 		if (
@@ -1432,37 +1435,37 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				this.endpointIndex,
 			);
 			if (paramInfo?.size) {
-				// Because partial params share the same parameter number,
-				// we need to remember which ones we have already queried.
-				const alreadyQueried = new Set<number>();
-				for (const param of paramInfo.keys()) {
-					// No need to query writeonly params
-					if (paramInfo.get(param)?.writeOnly) continue;
-					// Don't double-query params
-					if (alreadyQueried.has(param.parameter)) continue;
-					alreadyQueried.add(param.parameter);
-
+				// Partial params share the same parameter number. Collect the
+				// distinct readable parameter numbers so each is queried once.
+				const parametersToQuery = distinct(
+					[...paramInfo.keys()]
+						// No need to query writeonly params
+						.filter((param) => !paramInfo.get(param)?.writeOnly)
+						.map((param) => param.parameter),
+				);
+				for (let i = 0; i < parametersToQuery.length; i++) {
+					const parameter = parametersToQuery[i];
 					// Query the current value
 					ctx.logNode(node.id, {
 						endpoint: this.endpointIndex,
-						message:
-							`querying parameter #${param.parameter} value...`,
+						message: `querying parameter #${parameter} value...`,
 						direction: "outbound",
 					});
 					// ... at least try to
-					const paramValue = await api.get(param.parameter);
+					const paramValue = await api.get(parameter);
+					options?.onProgress?.(i + 1, parametersToQuery.length);
 					if (typeof paramValue === "number") {
 						ctx.logNode(node.id, {
 							endpoint: this.endpointIndex,
 							message:
-								`parameter #${param.parameter} has value: ${paramValue}`,
+								`parameter #${parameter} has value: ${paramValue}`,
 							direction: "inbound",
 						});
 					} else if (!paramValue) {
 						ctx.logNode(node.id, {
 							endpoint: this.endpointIndex,
 							message:
-								`received no value for parameter #${param.parameter}`,
+								`received no value for parameter #${parameter}`,
 							direction: "inbound",
 							level: "warn",
 						});
@@ -1483,7 +1486,8 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 					.map((v) => v.property)
 					.filter((p) => typeof p === "number"),
 			);
-			for (const param of parameters) {
+			for (let i = 0; i < parameters.length; i++) {
+				const param = parameters[i];
 				if (
 					this.getParamInformation(ctx, param).readable !== false
 				) {
@@ -1501,6 +1505,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 						direction: "none",
 					});
 				}
+				options?.onProgress?.(i + 1, parameters.length);
 			}
 		}
 	}

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -298,6 +298,26 @@ function getParamInformationFromConfigFile(
 }
 
 /**
+ * Returns the distinct parameter numbers in a ParamInfoMap. Partial parameters share a
+ * parameter number and are collapsed to a single entry, since they are queried together.
+ */
+export function getDistinctConfigParameters(paramInfo: ParamInfoMap): number[] {
+	return distinct([...paramInfo.keys()].map((key) => key.parameter));
+}
+
+/**
+ * Returns the distinct readable (non-write-only) parameter numbers in a ParamInfoMap.
+ * These are the parameters whose value is queried during the interview.
+ */
+export function getReadableConfigParameters(paramInfo: ParamInfoMap): number[] {
+	return distinct(
+		[...paramInfo.keys()]
+			.filter((key) => !paramInfo.get(key)?.writeOnly)
+			.map((key) => key.parameter),
+	);
+}
+
+/**
  * Estimates the number of device queries the Configuration interview performs,
  * depending on CC versions, availability of a config files, and compat flags.
  */
@@ -309,14 +329,14 @@ function estimateConfigurationInterviewQueryCount(
 	skipInfoQuery: boolean,
 ): number {
 	if (paramInfo?.size) {
-		const readableParameters = new Set(
-			[...paramInfo.keys()]
-				.filter((key) => !paramInfo.get(key)?.writeOnly)
-				.map((key) => key.parameter),
-		);
-		// v3+ queries each parameter's properties in addition to its value
-		// For parameters from config files, name and info are skipped.
-		return readableParameters.size * (ccVersion >= 3 ? 2 : 1);
+		// Before V3, only the value of each readable parameter is queried
+		if (ccVersion < 3) return getReadableConfigParameters(paramInfo).length;
+
+		// On V3+, the properties of every parameter are queried (including write-only
+		// ones, whose value is not), plus the value of each readable parameter. Name and
+		// info are skipped for parameters documented in a config file.
+		return getDistinctConfigParameters(paramInfo).length
+			+ getReadableConfigParameters(paramInfo).length;
 	}
 
 	// Before V3, only the value of each parameter is queried
@@ -1391,7 +1411,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				// To support reporting granular progress for devices where we don't
 				// know the parameter count in advance, we let the scan phase
 				// fill up the progress and map the value queries into the remainder.
-				// 
+				//
 				// For devices with known parameter counts, this mapping is uniform.
 				// For other devices it may yield larger, smaller, or no progress at all,
 				// depending on the actual parameter count.
@@ -1512,16 +1532,10 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				this.endpointIndex,
 			);
 			if (paramInfo?.size) {
-				// Partial params share the same parameter number. Collect the
-				// distinct readable parameter numbers so each is queried once.
-				const parametersToQuery = distinct(
-					[...paramInfo.keys()]
-						// No need to query writeonly params
-						.filter((param) => !paramInfo.get(param)?.writeOnly)
-						.map((param) => param.parameter),
+				const parametersToQuery = getReadableConfigParameters(
+					paramInfo,
 				);
-				for (let i = 0; i < parametersToQuery.length; i++) {
-					const parameter = parametersToQuery[i];
+				for (const [i, parameter] of parametersToQuery.entries()) {
 					// Query the current value
 					ctx.logNode(node.id, {
 						endpoint: this.endpointIndex,
@@ -1563,8 +1577,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 					.map((v) => v.property)
 					.filter((p) => typeof p === "number"),
 			);
-			for (let i = 0; i < parameters.length; i++) {
-				const param = parameters[i];
+			for (const [i, param] of parameters.entries()) {
 				if (
 					this.getParamInformation(ctx, param).readable !== false
 				) {

--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -843,13 +843,10 @@ export class IndicatorCC extends CommandClass {
 					});
 
 					for (
-						let i = 0;
-						i < manufacturerDefinedIndicatorIds.length;
-						i++
+						const [i, id] of manufacturerDefinedIndicatorIds
+							.entries()
 					) {
-						await api.getDescription(
-							manufacturerDefinedIndicatorIds[i],
-						);
+						await api.getDescription(id);
 
 						node.reportInterviewProgress(
 							i + 1,
@@ -896,8 +893,7 @@ export class IndicatorCC extends CommandClass {
 				ctx,
 				IndicatorCCValues.supportedIndicatorIds,
 			) ?? [];
-			for (let i = 0; i < supportedIndicatorIds.length; i++) {
-				const indicatorId = supportedIndicatorIds[i];
+			for (const [i, indicatorId] of supportedIndicatorIds.entries()) {
 				ctx.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message: `requesting current indicator value (id = ${

--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -842,15 +842,29 @@ export class IndicatorCC extends CommandClass {
 						direction: "outbound",
 					});
 
-					for (const id of manufacturerDefinedIndicatorIds) {
-						await api.getDescription(id);
+					for (
+						let i = 0;
+						i < manufacturerDefinedIndicatorIds.length;
+						i++
+					) {
+						await api.getDescription(
+							manufacturerDefinedIndicatorIds[i],
+						);
+
+						node.reportInterviewProgress(
+							i + 1,
+							manufacturerDefinedIndicatorIds.length,
+						);
 					}
 				}
 			}
 		}
 
 		// Query current values
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed, total) =>
+				node.reportInterviewProgress(completed, total),
+		});
 
 		// Remember that the interview is complete
 		this.setInterviewComplete(ctx, true);
@@ -882,7 +896,8 @@ export class IndicatorCC extends CommandClass {
 				ctx,
 				IndicatorCCValues.supportedIndicatorIds,
 			) ?? [];
-			for (const indicatorId of supportedIndicatorIds) {
+			for (let i = 0; i < supportedIndicatorIds.length; i++) {
+				const indicatorId = supportedIndicatorIds[i];
 				ctx.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message: `requesting current indicator value (id = ${
@@ -893,6 +908,8 @@ export class IndicatorCC extends CommandClass {
 					direction: "outbound",
 				});
 				await api.get(indicatorId);
+
+				options?.onProgress?.(i + 1, supportedIndicatorIds.length);
 			}
 		}
 	}

--- a/packages/cc/src/cc/IrrigationCC.ts
+++ b/packages/cc/src/cc/IrrigationCC.ts
@@ -1174,7 +1174,10 @@ max. valve table size: ${systemInfo.maxValveTableSize}`;
 		this.ensureMetadata(ctx, IrrigationCCValues.shutoffSystem);
 
 		// Query current values
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed, total) =>
+				node.reportInterviewProgress(completed, total),
+		});
 
 		// Remember that the interview is complete
 		this.setInterviewComplete(ctx, true);
@@ -1257,11 +1260,8 @@ moisture sensor polarity: ${
 			await api.getValveInfo("master");
 		}
 
-		for (
-			let i = 1;
-			i <= (IrrigationCC.getNumValvesCached(ctx, endpoint) ?? 0);
-			i++
-		) {
+		const numValves = IrrigationCC.getNumValvesCached(ctx, endpoint) ?? 0;
+		for (let i = 1; i <= numValves; i++) {
 			ctx.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message: `Querying configuration for valve ${
@@ -1285,6 +1285,8 @@ moisture sensor polarity: ${
 				direction: "outbound",
 			});
 			await api.getValveInfo(i);
+
+			options?.onProgress?.(i, numValves);
 		}
 	}
 

--- a/packages/cc/src/cc/MeterCC.ts
+++ b/packages/cc/src/cc/MeterCC.ts
@@ -692,7 +692,10 @@ supports reset:       ${suppResp.supportsReset}`;
 		}
 
 		// Query current meter values
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed, total) =>
+				node.reportInterviewProgress(completed, total),
+		});
 
 		// Remember that the interview is complete
 		this.setInterviewComplete(ctx, true);
@@ -732,6 +735,8 @@ supports reset:       ${suppResp.supportsReset}`;
 			const rateTypes = supportedRateTypes.length
 				? supportedRateTypes
 				: [undefined];
+			const total = rateTypes.length * supportedScales.length;
+			let completed = 0;
 			for (const rateType of rateTypes) {
 				for (const scale of supportedScales) {
 					ctx.logNode(node.id, {
@@ -754,6 +759,8 @@ supports reset:       ${suppResp.supportsReset}`;
 						direction: "outbound",
 					});
 					await api.get({ scale, rateType });
+
+					options?.onProgress?.(++completed, total);
 				}
 			}
 		}

--- a/packages/cc/src/cc/MultiChannelAssociationCC.ts
+++ b/packages/cc/src/cc/MultiChannelAssociationCC.ts
@@ -490,7 +490,10 @@ export class MultiChannelAssociationCC extends CommandClass {
 		}
 
 		// Query each association group for its members
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed, total) =>
+				node.reportInterviewProgress(completed, total),
+		});
 
 		// And set up lifeline associations
 		await ccUtils.configureLifelineAssociations(ctx, endpoint);
@@ -562,6 +565,7 @@ currently assigned endpoints: ${
 				message: logMessage,
 				direction: "inbound",
 			});
+			options?.onProgress?.(groupId, mcGroupCount);
 		}
 
 		// Check if there are more non-multi-channel association groups we haven't queried yet

--- a/packages/cc/src/cc/MultiChannelCC.ts
+++ b/packages/cc/src/cc/MultiChannelCC.ts
@@ -571,7 +571,12 @@ identical capabilities:      ${multiResponse.identicalCapabilities}`;
 
 		// Step 3: Query endpoints
 		let hasQueriedCapabilities = false;
+		let completedEndpoints = 0;
 		for (const endpoint of allEndpoints) {
+			node.reportInterviewProgress(
+				++completedEndpoints,
+				allEndpoints.length,
+			);
 			if (
 				endpoint > multiResponse.individualEndpointCount
 				&& ccVersion >= 4

--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -436,7 +436,8 @@ export class MultilevelSensorCC extends CommandClass {
 
 			// As well as the supported scales for each sensor
 
-			for (const type of sensorTypes) {
+			for (let i = 0; i < sensorTypes.length; i++) {
+				const type = sensorTypes[i];
 				ctx.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message: `querying supported scales for ${
@@ -469,10 +470,15 @@ export class MultilevelSensorCC extends CommandClass {
 					});
 					return;
 				}
+
+				node.reportInterviewProgress(i + 1, sensorTypes.length);
 			}
 		}
 
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed, total) =>
+				node.reportInterviewProgress(completed, total),
+		});
 
 		// Remember that the interview is complete
 		this.setInterviewComplete(ctx, true);
@@ -525,7 +531,8 @@ value:       ${mlsResponse.value}${
 				endpoint: this.endpointIndex,
 			}) || [];
 
-			for (const type of sensorTypes) {
+			for (let i = 0; i < sensorTypes.length; i++) {
+				const type = sensorTypes[i];
 				ctx.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message: `querying ${
@@ -545,6 +552,8 @@ value:       ${mlsResponse.value}${
 						direction: "inbound",
 					});
 				}
+
+				options?.onProgress?.(i + 1, sensorTypes.length);
 			}
 		}
 	}

--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -436,8 +436,7 @@ export class MultilevelSensorCC extends CommandClass {
 
 			// As well as the supported scales for each sensor
 
-			for (let i = 0; i < sensorTypes.length; i++) {
-				const type = sensorTypes[i];
+			for (const [i, type] of sensorTypes.entries()) {
 				ctx.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message: `querying supported scales for ${
@@ -531,8 +530,7 @@ value:       ${mlsResponse.value}${
 				endpoint: this.endpointIndex,
 			}) || [];
 
-			for (let i = 0; i < sensorTypes.length; i++) {
-				const type = sensorTypes[i];
+			for (const [i, type] of sensorTypes.entries()) {
 				ctx.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message: `querying ${

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -700,6 +700,11 @@ export class NotificationCC extends CommandClass {
 							direction: "inbound",
 						});
 					}
+
+					node.reportInterviewProgress(
+						i + 1,
+						supportedNotificationTypes.length,
+					);
 				}
 			}
 
@@ -722,10 +727,16 @@ export class NotificationCC extends CommandClass {
 			}
 
 			if (notificationMode === "pull") {
-				await this.refreshValues(ctx);
+				await this.refreshValues(ctx, {
+					onProgress: (completed, total) =>
+						node.reportInterviewProgress(completed, total),
+				});
 			} /* if (notificationMode === "push") */ else {
 				// First, query the current state of each supported notification
-				await this.refreshValues(ctx);
+				await this.refreshValues(ctx, {
+					onProgress: (completed, total) =>
+						node.reportInterviewProgress(completed, total),
+				});
 
 				for (let i = 0; i < supportedNotificationTypes.length; i++) {
 					const type = supportedNotificationTypes[i];
@@ -738,6 +749,11 @@ export class NotificationCC extends CommandClass {
 						direction: "outbound",
 					});
 					await api.set(type, true);
+
+					node.reportInterviewProgress(
+						i + 1,
+						supportedNotificationTypes.length,
+					);
 				}
 			}
 		}
@@ -1056,6 +1072,8 @@ export class NotificationCC extends CommandClass {
 				// @ts-expect-error
 				await node.handleCommand(response);
 			}
+
+			options?.onProgress?.(i + 1, supportedNotificationTypes.length);
 		}
 
 		// Remember when we did this

--- a/packages/cc/src/cc/SceneControllerConfigurationCC.ts
+++ b/packages/cc/src/cc/SceneControllerConfigurationCC.ts
@@ -457,6 +457,7 @@ dimming duration: ${group.dimmingDuration.toString()}`;
 					direction: "inbound",
 				});
 			}
+			options?.onProgress?.(groupId, groupCount);
 		}
 	}
 

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -459,8 +459,7 @@ export class ThermostatSetpointCC extends CommandClass {
 				return;
 			}
 
-			for (let i = 0; i < setpointTypes.length; i++) {
-				const type = setpointTypes[i];
+			for (const [i, type] of setpointTypes.entries()) {
 				const setpointName = getEnumMemberName(
 					ThermostatSetpointType,
 					type,
@@ -525,8 +524,7 @@ maximum value: ${setpointCaps.maxValue} ${maxValueUnit}`;
 		) ?? [];
 
 		// Query each setpoint's current value
-		for (let i = 0; i < setpointTypes.length; i++) {
-			const type = setpointTypes[i];
+		for (const [i, type] of setpointTypes.entries()) {
 			const setpointName = getEnumMemberName(
 				ThermostatSetpointType,
 				type,

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -409,6 +409,13 @@ export class ThermostatSetpointCC extends CommandClass {
 					message: logMessage,
 					direction: "inbound",
 				});
+
+				node.reportInterviewProgress(
+					type - ThermostatSetpointType.Heating + 1,
+					ThermostatSetpointType["Full Power"]
+						- ThermostatSetpointType.Heating
+						+ 1,
+				);
 			}
 
 			// Remember which setpoint types are actually supported
@@ -452,7 +459,8 @@ export class ThermostatSetpointCC extends CommandClass {
 				return;
 			}
 
-			for (const type of setpointTypes) {
+			for (let i = 0; i < setpointTypes.length; i++) {
+				const type = setpointTypes[i];
 				const setpointName = getEnumMemberName(
 					ThermostatSetpointType,
 					type,
@@ -482,10 +490,15 @@ maximum value: ${setpointCaps.maxValue} ${maxValueUnit}`;
 						direction: "inbound",
 					});
 				}
+
+				node.reportInterviewProgress(i + 1, setpointTypes.length);
 			}
 
 			// Query the current value for all setpoint types
-			await this.refreshValues(ctx);
+			await this.refreshValues(ctx, {
+				onProgress: (completed, total) =>
+					node.reportInterviewProgress(completed, total),
+			});
 		}
 
 		// Remember that the interview is complete
@@ -512,7 +525,8 @@ maximum value: ${setpointCaps.maxValue} ${maxValueUnit}`;
 		) ?? [];
 
 		// Query each setpoint's current value
-		for (const type of setpointTypes) {
+		for (let i = 0; i < setpointTypes.length; i++) {
+			const type = setpointTypes[i];
 			const setpointName = getEnumMemberName(
 				ThermostatSetpointType,
 				type,
@@ -536,6 +550,8 @@ maximum value: ${setpointCaps.maxValue} ${maxValueUnit}`;
 					direction: "inbound",
 				});
 			}
+
+			options?.onProgress?.(i + 1, setpointTypes.length);
 		}
 	}
 }

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -1048,6 +1048,8 @@ export class UserCodeCC extends CommandClass {
 			{
 				queryAllUserCodes: ctx.getInterviewOptions()?.queryAllUserCodes
 					?? false,
+				onProgress: (completed, total) =>
+					node.reportInterviewProgress(completed, total),
 			},
 		);
 
@@ -1182,6 +1184,7 @@ export class UserCodeCC extends CommandClass {
 						let nextUserId = 1;
 						while (nextUserId > 0 && nextUserId <= supportedUsers) {
 							const response = await api.get(nextUserId, true);
+							options?.onProgress?.(nextUserId, supportedUsers);
 							if (response) {
 								nextUserId = response.nextUserId;
 							} else {
@@ -1202,6 +1205,7 @@ export class UserCodeCC extends CommandClass {
 							userId++
 						) {
 							await api.get(userId);
+							options?.onProgress?.(userId, supportedUsers);
 						}
 					}
 				}
@@ -1225,6 +1229,7 @@ export class UserCodeCC extends CommandClass {
 				});
 				for (let userId = 1; userId <= supportedUsers; userId++) {
 					await api.get(userId);
+					options?.onProgress?.(userId, supportedUsers);
 				}
 			}
 		}

--- a/packages/cc/src/cc/UserCredentialCC.ts
+++ b/packages/cc/src/cc/UserCredentialCC.ts
@@ -29,6 +29,7 @@ import {
 	type InterviewContext,
 	type PersistValuesContext,
 	type RefreshValuesContext,
+	type RefreshValuesOptions,
 } from "../lib/CommandClass.js";
 import {
 	API,
@@ -1057,25 +1058,31 @@ export class UserCredentialCC extends CommandClass {
 			await api.getKeyLockerCapabilities();
 		}
 
-		await this.refreshValues(ctx);
+		await this.refreshValues(ctx, {
+			onProgress: (completed, total) =>
+				node.reportInterviewProgress(completed, total),
+		});
 
 		this.setInterviewComplete(ctx, true);
 	}
 
 	public async refreshValues(
 		ctx: RefreshValuesContext,
+		options?: RefreshValuesOptions,
 	): Promise<void> {
 		const node = this.getNode(ctx)!;
 		const endpoint = this.getEndpoint(ctx)!;
+
+		const supportedUsers = this.getValue<number>(
+			ctx,
+			UserCredentialCCValues.supportedUsers,
+		);
 
 		// CL:0083.01.21.00.4: The controlling node MUST use User Credential
 		// Command Class to control a supporting node unless the supporting
 		// node reports that (0) Users are supported.
 		// In that case, User Code CC is used instead of this CC:
-		if (
-			this.getValue<number>(ctx, UserCredentialCCValues.supportedUsers)
-				=== 0
-		) {
+		if (supportedUsers === 0) {
 			return;
 		}
 
@@ -1196,6 +1203,8 @@ export class UserCredentialCC extends CommandClass {
 						);
 					}
 				}
+
+				options?.onProgress?.(currentUserId, supportedUsers ?? 0);
 
 				previousUserId = currentUserId;
 				nextUserId = user.nextUserId ?? 0;

--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -585,13 +585,16 @@ export class VersionCC extends CommandClass {
 			message: "querying CC versions...",
 			direction: "outbound",
 		});
+		// Determine the CCs whose version we still need to query, so we can report progress
+		const ccsToQuery: CommandClasses[] = [];
 		// Basic CC is not included in the NIF, so it won't be returned by endpoint.getCCs() at this point
-		{
-			const cc = CommandClasses.Basic;
-			// Skip the query of endpoint CCs that are also supported by the root device
-			if (this.endpointIndex === 0 || node.getCCVersion(cc) === 0) {
-				await queryCCVersion(cc);
-			}
+		// Add it to the list if we are interviewing the root endpoint,
+		// or if we are on an endpoint and the root endpoint does not support it
+		if (
+			this.endpointIndex === 0
+			|| node.getCCVersion(CommandClasses.Basic) === 0
+		) {
+			ccsToQuery.push(CommandClasses.Basic);
 		}
 		for (const [cc] of endpoint.getCCs()) {
 			// We already queried the Version CC version at the start of this interview
@@ -600,7 +603,12 @@ export class VersionCC extends CommandClass {
 			if (cc === CommandClasses.Basic) continue;
 			// Skip the query of endpoint CCs that are also supported by the root device
 			if (this.endpointIndex > 0 && node.getCCVersion(cc) > 0) continue;
-			await queryCCVersion(cc);
+			ccsToQuery.push(cc);
+		}
+		// Actually query them
+		for (let i = 0; i < ccsToQuery.length; i++) {
+			await queryCCVersion(ccsToQuery[i]);
+			node.reportInterviewProgress(i + 1, ccsToQuery.length);
 		}
 
 		// Step 4: Query VersionCC capabilities (root device only)

--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -606,8 +606,8 @@ export class VersionCC extends CommandClass {
 			ccsToQuery.push(cc);
 		}
 		// Actually query them
-		for (let i = 0; i < ccsToQuery.length; i++) {
-			await queryCCVersion(ccsToQuery[i]);
+		for (const [i, cc] of ccsToQuery.entries()) {
+			await queryCCVersion(cc);
 			node.reportInterviewProgress(i + 1, ccsToQuery.length);
 		}
 

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -630,9 +630,7 @@ ${
 			param % 2 != 0
 		);
 
-		for (let i = 0; i < queryableParameters.length; i++) {
-			const param = queryableParameters[i];
-
+		for (const [i, param] of queryableParameters.entries()) {
 			ctx.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message: `querying position for parameter ${

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -596,7 +596,10 @@ ${
 			}
 
 			// Query current values for all supported parameters
-			await this.refreshValues(ctx);
+			await this.refreshValues(ctx, {
+				onProgress: (completed, total) =>
+					node.reportInterviewProgress(completed, total),
+			});
 		}
 
 		// Remember that the interview is complete
@@ -622,9 +625,13 @@ ${
 			WindowCoveringCCValues.supportedParameters,
 		) ?? [];
 
-		for (const param of parameters) {
-			// Only query odd parameters (with position support)
-			if (param % 2 == 0) continue;
+		// Only odd parameters have position support and need to be queried
+		const queryableParameters = parameters.filter((param) =>
+			param % 2 != 0
+		);
+
+		for (let i = 0; i < queryableParameters.length; i++) {
+			const param = queryableParameters[i];
 
 			ctx.logNode(node.id, {
 				endpoint: this.endpointIndex,
@@ -637,6 +644,8 @@ ${
 				direction: "outbound",
 			});
 			await api.get(param);
+
+			options?.onProgress?.(i + 1, queryableParameters.length);
 		}
 	}
 

--- a/packages/cc/src/lib/CommandClass.ts
+++ b/packages/cc/src/lib/CommandClass.ts
@@ -75,7 +75,7 @@ import {
 	defaultCCValueOptions,
 } from "./Values.js";
 import type { CCEncodingContext, CCParsingContext } from "./traits.js";
-import type { GetInterviewOptions } from "./traits.js";
+import type { GetInterviewOptions, ReportInterviewProgress } from "./traits.js";
 
 export interface CommandClassOptions extends CCAddress {
 	ccId?: number; // Used to overwrite the declared CC ID
@@ -112,6 +112,7 @@ export type InterviewContext =
 		& ControlsCC
 		& QuerySecurityClasses
 		& SetSecurityClass
+		& ReportInterviewProgress
 		& GetEndpoint<EndpointId & GetCCs & SupportsCC & ControlsCC & ModifyCCs>
 		& GetAllEndpoints<EndpointId & SupportsCC & ControlsCC>
 	>
@@ -125,6 +126,10 @@ export type RefreshValuesContext = CCAPIHost<
 export interface RefreshValuesOptions {
 	/** The priority to use for the refresh value queries */
 	priority?: MessagePriority;
+	/**
+	 * An optional callback to report fine-grained progress while refreshing values.
+	 */
+	onProgress?: (completed: number, total: number) => void;
 }
 
 export type PersistValuesContext =

--- a/packages/cc/src/lib/traits.ts
+++ b/packages/cc/src/lib/traits.ts
@@ -112,6 +112,15 @@ export interface GetInterviewOptions {
 	getInterviewOptions(): InterviewOptions;
 }
 
+/** Allows a Command Class to report fine-grained progress during its interview */
+export interface ReportInterviewProgress {
+	/**
+	 * Reports the granular progress of the current interview step, e.g. while iterating over
+	 * configuration parameters or association groups.
+	 */
+	reportInterviewProgress(completed: number, total: number): void;
+}
+
 /** Additional context needed for deserializing CCs */
 export interface CCParsingContext
 	extends Readonly<SecurityManagers>, GetDeviceConfig, HostIDs

--- a/packages/cc/src/lib/traits.ts
+++ b/packages/cc/src/lib/traits.ts
@@ -1,6 +1,7 @@
 import type { GetDeviceConfig } from "@zwave-js/config";
 import type {
 	CCId,
+	CommandClasses,
 	FrameType,
 	GetSupportedCCVersion,
 	HostIDs,
@@ -119,6 +120,14 @@ export interface ReportInterviewProgress {
 	 * configuration parameters or association groups.
 	 */
 	reportInterviewProgress(completed: number, total: number): void;
+
+	/**
+	 * Returns the relative interview weight of the given CC.
+	 * CCs with dynamic interview lengths, e.g. Configuration CC, can use this to
+	 * estimate a typical `total` of their interview progress without knowing the
+	 * exact amount of work up front.
+	 */
+	getInterviewProgressWeight(cc: CommandClasses): number;
 }
 
 /** Additional context needed for deserializing CCs */

--- a/packages/core/src/definitions/Interview.ts
+++ b/packages/core/src/definitions/Interview.ts
@@ -1,3 +1,5 @@
+import type { CommandClasses } from "./CommandClasses.js";
+
 export enum InterviewStage {
 	/** The interview process hasn't started for this node */
 	None,
@@ -22,4 +24,19 @@ export enum InterviewStage {
 
 	/** The interview process has finished */
 	Complete,
+}
+
+export interface InterviewProgress {
+	/** The interview stage that is currently in progress */
+	stage: InterviewStage;
+	/**
+	 * The approximate overall interview progress in %, rounded to two digits.
+	 * This is monotonically non-decreasing within a single interview and only an approximation,
+	 * as the exact amount of work cannot be known in advance.
+	 */
+	progress: number;
+	/** During the `CommandClasses` stage: the index of the endpoint that is currently being interviewed */
+	endpoint?: number;
+	/** During the `CommandClasses` stage: the Command Class that is currently being interviewed */
+	commandClass?: CommandClasses;
 }

--- a/packages/core/src/definitions/Interview.ts
+++ b/packages/core/src/definitions/Interview.ts
@@ -27,14 +27,16 @@ export enum InterviewStage {
 }
 
 export interface InterviewProgress {
-	/** The interview stage that is currently in progress */
+	/**
+	 * The interview stage that is currently in progress.
+	 * `None` at the interview start, and `Complete` once the interview has finished.
+	 */
 	stage: InterviewStage;
 	/**
 	 * The approximate overall interview progress in %, rounded to two digits.
-	 * This is monotonically non-decreasing within a single interview and only an approximation,
-	 * as the exact amount of work cannot be known in advance.
 	 */
 	progress: number;
+
 	/** During the `CommandClasses` stage: the index of the endpoint that is currently being interviewed */
 	endpoint?: number;
 	/** During the `CommandClasses` stage: the Command Class that is currently being interviewed */

--- a/packages/core/src/definitions/index.ts
+++ b/packages/core/src/definitions/index.ts
@@ -3,7 +3,7 @@ export * from "./ControllerCapabilities.js";
 export * from "./ControllerStatus.js";
 export * from "./EncapsulationFlags.js";
 export * from "./Frame.js";
-export * from "./InterviewStage.js";
+export * from "./Interview.js";
 export * from "./LibraryTypes.js";
 export * from "./MessagePriority.js";
 export * from "./NodeID.js";

--- a/packages/core/src/log/Controller.test.ts
+++ b/packages/core/src/log/Controller.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@zwave-js/core/bindings/log/node";
 import { beforeEach, test as baseTest } from "vitest";
 import { CommandClasses } from "../definitions/CommandClasses.js";
-import { InterviewStage } from "../definitions/InterviewStage.js";
+import { InterviewStage } from "../definitions/Interview.js";
 import {
 	SpyTransport,
 	assertLogInfo,

--- a/packages/core/src/log/Controller.ts
+++ b/packages/core/src/log/Controller.ts
@@ -1,6 +1,6 @@
 import { isObject } from "alcalzone-shared/typeguards";
 import { CommandClasses } from "../definitions/CommandClasses.js";
-import { InterviewStage } from "../definitions/InterviewStage.js";
+import { InterviewStage } from "../definitions/Interview.js";
 import type {
 	ValueAddedArgs,
 	ValueID,

--- a/packages/core/src/traits/Nodes.ts
+++ b/packages/core/src/traits/Nodes.ts
@@ -1,4 +1,4 @@
-import { type InterviewStage } from "../definitions/InterviewStage.js";
+import { type InterviewStage } from "../definitions/Interview.js";
 import type { FLiRS } from "../definitions/NodeInfo.js";
 import type { NodeStatus } from "../definitions/NodeStatus.js";
 import type { MaybeNotKnown } from "../values/Primitive.js";

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1050,6 +1050,8 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 				this.id,
 				`new node, doing a full interview...`,
 			);
+			// Reset the progress baseline for a fresh interview
+			this.resetInterviewProgressBaseline();
 			this.emit("interview started", this);
 			await this.queryProtocolInfo();
 		}
@@ -1116,6 +1118,8 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			this,
 			getEnumMemberName(InterviewStage, completedStage),
 		);
+		// Updates the interview progress according to the completed stage.
+		this.snapInterviewProgressToStage(completedStage);
 		this.driver.controllerLog.interviewStage(this);
 	}
 
@@ -1336,8 +1340,26 @@ protocol version:      ${this.protocolVersion}`;
 		);
 	}
 
-	/** Step #? of the node interview */
 	protected async interviewCCs(): Promise<boolean> {
+		// Interviewing CCs happens in two phases, because the full amount of work is unknown up
+		// front (endpoints are revealed by Multi Channel, secure CCs by Security):
+		//
+		// Discovery phase — establishes the complete CC inventory:
+		//   - Root device: Security S2/S0 → Manufacturer Specific → Version (loads device config)
+		//     → Wake Up → Multi Channel (discovers endpoints)
+		//   - Endpoint prefix pass: Security S2/S0 → Version per endpoint; remembers each
+		//     endpoint's interview order
+		//
+		// Bulk phase — inventory is final, interview the rest:
+		//   - Root device non-application CCs
+		//   - Each endpoint's remaining CCs
+		//   - Root device application CCs
+		//   - Basic CC for root device and endpoints
+		//
+		// Progress reporting (see the InterviewProgress mixin) mirrors this:
+		//   - Discovery: each CC advances the CommandClasses band by a small, capped fixed amount
+		//   - Bulk: the remaining band is split proportionally to the remaining interview weight.
+		//     CCs can report sub-progress in their progress slice.
 		if (this.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				this.id,
@@ -1346,6 +1368,9 @@ protocol version:      ${this.protocolVersion}`;
 			);
 			return true;
 		}
+
+		// Reset the per-stage progress tracking for this run of the CC interview
+		this.resetCCInterviewProgress();
 
 		const securityManager2 = this.driver.getSecurityManager2(this.id);
 
@@ -1357,62 +1382,78 @@ protocol version:      ${this.protocolVersion}`;
 			cc: CommandClasses,
 			force: boolean = false,
 		): Promise<"continue" | false | void> => {
-			let instance: CommandClass;
-			try {
-				if (force) {
-					instance = CommandClass.createInstanceUnchecked(
-						endpoint,
-						cc,
-					)!;
-				} else {
-					instance = endpoint.createCCInstance(cc)!;
+			// Reserve a progress slice for this CC so that fine-grained progress
+			// reported during its interview maps into the correct range.
+			this.reserveCCInterviewStepProgress(endpoint.index, cc);
+			const result = await (async (): Promise<
+				"continue" | false | void
+			> => {
+				let instance: CommandClass;
+				try {
+					if (force) {
+						instance = CommandClass.createInstanceUnchecked(
+							endpoint,
+							cc,
+						)!;
+					} else {
+						instance = endpoint.createCCInstance(cc)!;
+					}
+				} catch (e) {
+					if (
+						isZWaveError(e)
+						&& e.code === ZWaveErrorCodes.CC_NotSupported
+					) {
+						// The CC is no longer supported. This can happen if the node tells us
+						// something different in the Version interview than it did in its NIF
+						return "continue";
+					}
+					// we want to pass all other errors through
+					throw e;
 				}
-			} catch (e) {
 				if (
-					isZWaveError(e)
-					&& e.code === ZWaveErrorCodes.CC_NotSupported
+					endpoint.isCCSecure(cc)
+					&& !this.driver.securityManager
+					&& !securityManager2
 				) {
-					// The CC is no longer supported. This can happen if the node tells us
-					// something different in the Version interview than it did in its NIF
+					// The CC is only supported securely, but the network key is not set up
+					// Skip the CC
+					this.driver.controllerLog.logNode(
+						this.id,
+						`Skipping interview for secure CC ${
+							getCCName(
+								cc,
+							)
+						} because no network key is configured!`,
+						"error",
+					);
 					return "continue";
 				}
-				// we want to pass all other errors through
-				throw e;
-			}
-			if (
-				endpoint.isCCSecure(cc)
-				&& !this.driver.securityManager
-				&& !securityManager2
-			) {
-				// The CC is only supported securely, but the network key is not set up
-				// Skip the CC
-				this.driver.controllerLog.logNode(
-					this.id,
-					`Skipping interview for secure CC ${
-						getCCName(
-							cc,
-						)
-					} because no network key is configured!`,
-					"error",
-				);
-				return "continue";
-			}
 
-			// Skip this step if the CC was already interviewed
-			if (instance.isInterviewComplete(this.driver)) return "continue";
-
-			try {
-				await instance.interview(this.driver);
-			} catch (e) {
-				if (isTransmissionError(e)) {
-					// We had a CAN or timeout during the interview
-					// or the node is presumed dead. Abort the process
-					return false;
+				// Skip this step if the CC was already interviewed
+				if (instance.isInterviewComplete(this.driver)) {
+					return "continue";
 				}
-				// we want to pass all other errors through
-				throw e;
-			}
+
+				try {
+					await instance.interview(this.driver);
+				} catch (e) {
+					if (isTransmissionError(e)) {
+						// We had a CAN or timeout during the interview
+						// or the node is presumed dead. Abort the process
+						return false;
+					}
+					// we want to pass all other errors through
+					throw e;
+				}
+			})();
+			// Count this CC as completed (interviewed or skipped) unless the interview was aborted
+			if (result !== false) this.completeCCInterviewStepProgress();
+			return result;
 		};
+
+		// =====================================================================
+		// Discovery phase: root device
+		// -> Security, device identification, discover endpoints
 
 		// Always interview Security first because it changes the interview order
 		if (this.supportsCC(CommandClasses["Security 2"])) {
@@ -1600,6 +1641,27 @@ protocol version:      ${this.protocolVersion}`;
 
 		this.modifySupportedCCBeforeInterview(this);
 
+		// In order to be able to approximate the interview progress, we need to know
+		// early which endpoints exist and which CCs have to be interviewed on them.
+		if (this.supportsCC(CommandClasses["Multi Channel"])) {
+			this.driver.controllerLog.logNode(
+				this.id,
+				"Root device interview: Multi Channel",
+				"silly",
+			);
+
+			const action = await interviewEndpoint(
+				this,
+				CommandClasses["Multi Channel"],
+			);
+			if (typeof action === "boolean") return action;
+
+			// Now that the Multi Channel interview has discovered the endpoints, we may need to
+			// make some more changes to the CCs the device reports. This time, the non-root
+			// endpoints are relevant.
+			this.applyCommandClassesCompatFlag();
+		}
+
 		// We determine the correct interview order of the remaining CCs by topologically sorting two dependency graph
 		// In order to avoid emitting unnecessary value events for the root endpoint,
 		// we defer the application CC interview until after the other endpoints have been interviewed
@@ -1611,6 +1673,8 @@ protocol version:      ${this.protocolVersion}`;
 			CommandClasses["Manufacturer Specific"],
 			CommandClasses.Version,
 			CommandClasses["Wake Up"],
+			// Multi Channel is interviewed early because it discovers the endpoints
+			CommandClasses["Multi Channel"],
 			// Basic CC is interviewed last
 			CommandClasses.Basic,
 		];
@@ -1661,24 +1725,10 @@ protocol version:      ${this.protocolVersion}`;
 			"silly",
 		);
 
-		// Now that we know the correct order, do the interview in sequence
-		for (const cc of rootInterviewOrderBeforeEndpoints) {
-			this.driver.controllerLog.logNode(
-				this.id,
-				`Root device interview: ${getCCName(cc)}`,
-				"silly",
-			);
-
-			const action = await interviewEndpoint(this, cc);
-			if (action === "continue") continue;
-			else if (typeof action === "boolean") return action;
-		}
-
-		// Before querying the endpoints, we may need to make some more changes to the CCs the device reports
-		// This time, the non-root endpoints are relevant
-		this.applyCommandClassesCompatFlag();
-
-		// Now query ALL endpoints
+		// =====================================================================
+		// Discovery phase: endpoints
+		// -> discover supported CCs on each endpoint that differ from the root device
+		const endpointInterviewOrders = new Map<number, CommandClasses[]>();
 		for (const endpointIndex of this.getEndpointIndizes()) {
 			const endpoint = this.getEndpoint(endpointIndex);
 			if (!endpoint) continue;
@@ -1928,6 +1978,55 @@ protocol version:      ${this.protocolVersion}`;
 				level: "silly",
 			});
 
+			// Remember the order; the actual CC interview happens in the bulk phase below
+			endpointInterviewOrders.set(endpointIndex, endpointInterviewOrder);
+		}
+
+		// =====================================================================
+		// Discovery → bulk boundary
+		// We now know exactly which CCs are supported, so we can switch to
+		// proportional progress reporting.
+
+		// Basic CC is interviewed conditionally at the very end (root device + each endpoint),
+		// outside the interview orders above. Include an allowance for it so the bar keeps
+		// moving during those interviews instead of sitting at the band end.
+		const remainingBasicCCs = Array.from(
+			{ length: 1 + endpointInterviewOrders.size },
+			() => CommandClasses.Basic,
+		);
+		this.setupCCInterviewBulkProgress(
+			rootInterviewOrderBeforeEndpoints,
+			...endpointInterviewOrders.values(),
+			rootInterviewOrderAfterEndpoints,
+			remainingBasicCCs,
+		);
+
+		// =====================================================================
+		// Bulk phase: root device
+		// -> Remaining non-application CCs
+		for (const cc of rootInterviewOrderBeforeEndpoints) {
+			this.driver.controllerLog.logNode(
+				this.id,
+				`Root device interview: ${getCCName(cc)}`,
+				"silly",
+			);
+
+			const action = await interviewEndpoint(this, cc);
+			if (action === "continue") continue;
+			else if (typeof action === "boolean") return action;
+		}
+
+		// =====================================================================
+		// Bulk phase: endpoints
+		// -> All remaining CCs
+		for (const endpointIndex of this.getEndpointIndizes()) {
+			const endpoint = this.getEndpoint(endpointIndex);
+			if (!endpoint) continue;
+			const endpointInterviewOrder = endpointInterviewOrders.get(
+				endpointIndex,
+			);
+			if (!endpointInterviewOrder) continue;
+
 			// Now that we know the correct order, do the interview in sequence
 			for (const cc of endpointInterviewOrder) {
 				this.driver.controllerLog.logNode(this.id, {
@@ -1946,7 +2045,9 @@ protocol version:      ${this.protocolVersion}`;
 			}
 		}
 
-		// Continue with the application CCs for the root endpoint
+		// =====================================================================
+		// Bulk phase: root device
+		// -> Application CCs
 		for (const cc of rootInterviewOrderAfterEndpoints) {
 			this.driver.controllerLog.logNode(
 				this.id,
@@ -1959,7 +2060,8 @@ protocol version:      ${this.protocolVersion}`;
 			else if (typeof action === "boolean") return action;
 		}
 
-		// At the very end, figure out if Basic CC is supposed to be supported
+		// =====================================================================
+		// Bulk phase: Basic CC -> Figure out if it is supposed to be supported
 		// First on the root device
 		const compat = this.deviceConfig?.compat;
 		if (

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1050,9 +1050,9 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 				this.id,
 				`new node, doing a full interview...`,
 			);
-			// Reset the progress baseline for a fresh interview
-			this.resetInterviewProgressBaseline();
 			this.emit("interview started", this);
+			// Reset the progress baseline and announce the 0% starting point for a fresh interview
+			this.resetInterviewProgressBaseline();
 			await this.queryProtocolInfo();
 		}
 
@@ -1069,6 +1069,7 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			}
 
 			if (this.interviewStage === InterviewStage.ProtocolInfo) {
+				this.reportInterviewStageStarted(InterviewStage.NodeInfo);
 				if (
 					!(await tryInterviewStage(() => this.interviewNodeInfo()))
 				) {
@@ -1079,6 +1080,7 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			// At this point the basic interview of new nodes is done. Start here when re-interviewing known nodes
 			// to get updated information about command classes
 			if (this.interviewStage === InterviewStage.NodeInfo) {
+				this.reportInterviewStageStarted(InterviewStage.CommandClasses);
 				// Only advance the interview if it was completed, otherwise abort
 				if (await this.interviewCCs()) {
 					this.setInterviewStage(InterviewStage.CommandClasses);
@@ -1094,6 +1096,7 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			|| (!this.isControllerNode
 				&& this.interviewStage === InterviewStage.CommandClasses)
 		) {
+			this.reportInterviewStageStarted(InterviewStage.OverwriteConfig);
 			// Load a config file for this node if it exists and overwrite the previously reported information
 			await this.overwriteConfig();
 		}
@@ -1102,6 +1105,7 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 		this.cachedDeviceConfigHash = await this.deviceConfig?.getHash();
 
 		this.setInterviewStage(InterviewStage.Complete);
+		this.reportInterviewStageStarted(InterviewStage.Complete);
 		this.updateReadyMachine({ value: "INTERVIEW_DONE" });
 
 		// Tell listeners that the interview is completed
@@ -1118,8 +1122,6 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			this,
 			getEnumMemberName(InterviewStage, completedStage),
 		);
-		// Updates the interview progress according to the completed stage.
-		this.snapInterviewProgressToStage(completedStage);
 		this.driver.controllerLog.interviewStage(this);
 	}
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1376,6 +1376,70 @@ protocol version:      ${this.protocolVersion}`;
 
 		const securityManager2 = this.driver.getSecurityManager2(this.id);
 
+		const runCCInterview = async (
+			endpoint: Endpoint,
+			cc: CommandClasses,
+			force: boolean,
+		): Promise<"continue" | false | void> => {
+			let instance: CommandClass;
+			try {
+				if (force) {
+					instance = CommandClass.createInstanceUnchecked(
+						endpoint,
+						cc,
+					)!;
+				} else {
+					instance = endpoint.createCCInstance(cc)!;
+				}
+			} catch (e) {
+				if (
+					isZWaveError(e)
+					&& e.code === ZWaveErrorCodes.CC_NotSupported
+				) {
+					// The CC is no longer supported. This can happen if the node tells us
+					// something different in the Version interview than it did in its NIF
+					return "continue";
+				}
+				// we want to pass all other errors through
+				throw e;
+			}
+			if (
+				endpoint.isCCSecure(cc)
+				&& !this.driver.securityManager
+				&& !securityManager2
+			) {
+				// The CC is only supported securely, but the network key is not set up
+				// Skip the CC
+				this.driver.controllerLog.logNode(
+					this.id,
+					`Skipping interview for secure CC ${
+						getCCName(
+							cc,
+						)
+					} because no network key is configured!`,
+					"error",
+				);
+				return "continue";
+			}
+
+			// Skip this step if the CC was already interviewed
+			if (instance.isInterviewComplete(this.driver)) {
+				return "continue";
+			}
+
+			try {
+				await instance.interview(this.driver);
+			} catch (e) {
+				if (isTransmissionError(e)) {
+					// We had a CAN or timeout during the interview
+					// or the node is presumed dead. Abort the process
+					return false;
+				}
+				// we want to pass all other errors through
+				throw e;
+			}
+		};
+
 		/**
 		 * @param force When this is `true`, the interview will be attempted even when the CC is not supported by the endpoint.
 		 */
@@ -1387,67 +1451,7 @@ protocol version:      ${this.protocolVersion}`;
 			// Reserve a progress slice for this CC so that fine-grained progress
 			// reported during its interview maps into the correct range.
 			this.reserveCCInterviewStepProgress(endpoint.index, cc);
-			const result = await (async (): Promise<
-				"continue" | false | void
-			> => {
-				let instance: CommandClass;
-				try {
-					if (force) {
-						instance = CommandClass.createInstanceUnchecked(
-							endpoint,
-							cc,
-						)!;
-					} else {
-						instance = endpoint.createCCInstance(cc)!;
-					}
-				} catch (e) {
-					if (
-						isZWaveError(e)
-						&& e.code === ZWaveErrorCodes.CC_NotSupported
-					) {
-						// The CC is no longer supported. This can happen if the node tells us
-						// something different in the Version interview than it did in its NIF
-						return "continue";
-					}
-					// we want to pass all other errors through
-					throw e;
-				}
-				if (
-					endpoint.isCCSecure(cc)
-					&& !this.driver.securityManager
-					&& !securityManager2
-				) {
-					// The CC is only supported securely, but the network key is not set up
-					// Skip the CC
-					this.driver.controllerLog.logNode(
-						this.id,
-						`Skipping interview for secure CC ${
-							getCCName(
-								cc,
-							)
-						} because no network key is configured!`,
-						"error",
-					);
-					return "continue";
-				}
-
-				// Skip this step if the CC was already interviewed
-				if (instance.isInterviewComplete(this.driver)) {
-					return "continue";
-				}
-
-				try {
-					await instance.interview(this.driver);
-				} catch (e) {
-					if (isTransmissionError(e)) {
-						// We had a CAN or timeout during the interview
-						// or the node is presumed dead. Abort the process
-						return false;
-					}
-					// we want to pass all other errors through
-					throw e;
-				}
-			})();
+			const result = await runCCInterview(endpoint, cc, force);
 			// Count this CC as completed (interviewed or skipped) unless the interview was aborted
 			if (result !== false) this.completeCCInterviewStepProgress();
 			return result;

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -14,6 +14,7 @@ import type {
 import type { NotificationCCReport } from "@zwave-js/cc/NotificationCC";
 import type {
 	CommandClasses,
+	InterviewProgress,
 	MetadataUpdatedArgs,
 	NodeStatus,
 	TranslatedValueID,
@@ -36,7 +37,12 @@ export {
 	Powerlevel,
 	PowerlevelTestStatus,
 } from "@zwave-js/cc";
-export { ControllerStatus, InterviewStage, NodeStatus } from "@zwave-js/core";
+export {
+	ControllerStatus,
+	type InterviewProgress,
+	InterviewStage,
+	NodeStatus,
+} from "@zwave-js/core";
 
 export type NodeInterviewFailedEventArgs =
 	& {
@@ -88,6 +94,10 @@ export type ZWaveInterviewFailedCallback = (
 export type ZWaveNodeFirmwareUpdateProgressCallback = (
 	node: ZWaveNode,
 	progress: FirmwareUpdateProgress,
+) => void;
+export type ZWaveNodeInterviewProgressCallback = (
+	node: ZWaveNode,
+	progress: InterviewProgress,
 ) => void;
 export type ZWaveNodeFirmwareUpdateFinishedCallback = (
 	node: ZWaveNode,
@@ -281,6 +291,7 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 	"interview completed": (node: ZWaveNode) => void;
 	ready: (node: ZWaveNode) => void;
 	"interview stage completed": (node: ZWaveNode, stageName: string) => void;
+	"interview progress": ZWaveNodeInterviewProgressCallback;
 	"interview started": (node: ZWaveNode) => void;
 	"node info received": (node: ZWaveNode) => void;
 	"user added": (endpoint: Endpoint, args: UserData) => void;
@@ -322,6 +333,7 @@ export const zWaveNodeEvents = [
 	"interview completed",
 	"ready",
 	"interview stage completed",
+	"interview progress",
 	"interview started",
 	"value added",
 	"value updated",

--- a/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
+++ b/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
@@ -22,6 +22,9 @@ const INTERVIEW_PROGRESS_CC_BAND_END = 99;
 const INTERVIEW_PROGRESS_DISCOVERY_CAP = 30;
 const INTERVIEW_PROGRESS_DISCOVERY_UNIT = 0.4;
 
+/** The assumed number of configuration parameters when the count is not known from a config file */
+const ASSUMED_CONFIG_PARAM_COUNT = 30;
+
 /** The overall interview progress (percent in [0, 100]) reached when the given stage has completed */
 function interviewStageProgress(
 	stage: InterviewStage,
@@ -138,16 +141,17 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 	 *
 	 *   | Collection                          | Typical | Affected CC(s)                                            |
 	 *   | ----------------------------------- | ------- | --------------------------------------------------------- |
-	 *   | Configuration parameters            | 50+     | Configuration                                             |
+	 *   | Configuration parameters            | ~30*    | Configuration (*fallback when no config file)             |
 	 *   | Supported CCs (queried for version) | ~20     | Version                                                   |
-	 *   | Association groups                  | ~5      | Association, Association Group Information, Multi Channel Association, Scene Controller Configuration |
+	 *   | Association groups                  | ~5      | Association, Association Group Information,               |
+	 *   |                                     |         | Multi Channel Association, Scene Controller Configuration |
 	 *   | Notification types                  | ~3      | Notification                                              |
 	 *   | Multi Channel endpoints             | ~3      | Multi Channel                                             |
 	 *   | Multilevel Sensor types             | ~3      | Multilevel Sensor                                         |
 	 *   | Meter scales/rate types             | ~4      | Meter                                                     |
 	 *   | Alarm Sensor types                  | ~2      | Alarm Sensor                                              |
 	 *   | Binary Sensor types                 | ~1      | Binary Sensor                                             |
-	 *   | User codes / credentials            | ~30     | User Code (opt-in only), User Credential                  |
+	 *   | User codes / credentials            | ~25     | User Code (opt-in only), User Credential                  |
 	 */
 	private ccInterviewWeight(cc: CommandClasses): number {
 		switch (cc) {
@@ -155,12 +159,12 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 				return this.configurationCCInterviewWeight();
 			case CommandClasses["User Credential"]:
 				// The interview enumerates all users and their credentials
-				return 30;
+				return 25;
 			case CommandClasses["User Code"]:
 				// User codes are only enumerated when explicitly requested; otherwise the
 				// interview just queries capabilities
 				return this.driver.getInterviewOptions()?.queryAllUserCodes
-					? 30
+					? 25
 					: 2;
 			case CommandClasses.Version:
 				// Queries the version of every supported CC
@@ -214,14 +218,12 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 	/**
 	 * The interview weight of the Configuration CC scales with the number of parameters that get
 	 * queried. When they are known up front from the device config file, the weight is the count
-	 * of distinct readable parameters; otherwise (e.g. a v3+ device whose parameters are discovered
-	 * by scanning the device) it falls back to a value tuned for a parameter-heavy device.
+	 * of distinct readable parameters; otherwise we assume a typical count.
 	 */
 	private configurationCCInterviewWeight(): number {
-		const FALLBACK_WEIGHT = 50;
 		const paramInfo = this.deviceConfig?.paramInformation
 			?? this.deviceConfig?.endpoints?.get(0)?.paramInformation;
-		if (!paramInfo?.size) return FALLBACK_WEIGHT;
+		if (!paramInfo?.size) return ASSUMED_CONFIG_PARAM_COUNT;
 
 		// Partial parameters share a parameter number and are queried once; write-only
 		// parameters are not queried during the interview.
@@ -230,7 +232,7 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 				.filter((key) => !paramInfo.get(key)?.writeOnly)
 				.map((key) => key.parameter),
 		);
-		return queryableParameters.size || FALLBACK_WEIGHT;
+		return queryableParameters.size;
 	}
 
 	/** Computes the progress slice width for the CC that is about to be interviewed */
@@ -301,6 +303,15 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 			stageProgress,
 		);
 		this.emitInterviewProgressUpdate(completedStage);
+	}
+
+	/**
+	 * Returns the assumed interview weight of the given CC, used by CCs to estimate their own
+	 * interview progress when the actual amount of work is not known up front.
+	 * Implements the {@link ReportInterviewProgress} trait.
+	 */
+	public getInterviewProgressWeight(cc: CommandClasses): number {
+		return this.ccInterviewWeight(cc);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
+++ b/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
@@ -1,3 +1,4 @@
+import { getDistinctConfigParameters } from "@zwave-js/cc/ConfigurationCC";
 import {
 	CommandClasses,
 	type InterviewProgress,
@@ -225,21 +226,14 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 	/**
 	 * The interview weight of the Configuration CC scales with the number of parameters that get
 	 * queried. When they are known up front from the device config file, the weight is the count
-	 * of distinct readable parameters; otherwise we assume a typical count.
+	 * of distinct parameters, otherwise we assume a typical count.
 	 */
 	private configurationCCInterviewWeight(): number {
 		const paramInfo = this.deviceConfig?.paramInformation
 			?? this.deviceConfig?.endpoints?.get(0)?.paramInformation;
 		if (!paramInfo?.size) return ASSUMED_CONFIG_PARAM_COUNT;
 
-		// Partial parameters share a parameter number and are queried once; write-only
-		// parameters are not queried during the interview.
-		const queryableParameters = new Set(
-			[...paramInfo.keys()]
-				.filter((key) => !paramInfo.get(key)?.writeOnly)
-				.map((key) => key.parameter),
-		);
-		return queryableParameters.size;
+		return getDistinctConfigParameters(paramInfo).length;
 	}
 
 	/** Computes the progress slice width for the CC that is about to be interviewed */

--- a/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
+++ b/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
@@ -1,0 +1,249 @@
+import {
+	CommandClasses,
+	type InterviewProgress,
+	InterviewStage,
+} from "@zwave-js/core";
+import { throttle } from "@zwave-js/shared";
+import { roundTo } from "alcalzone-shared/math";
+import { DeviceConfigMixin } from "./80_DeviceConfig.js";
+
+// The interview progress is approximated as a percentage in [0, 100], matching the unit
+// used for firmware update progress. The CommandClasses stage dominates the total interview
+// time, so it occupies the largest band. The other stages are near-instant and snap to fixed
+// points (see snapInterviewProgressToStage).
+const INTERVIEW_PROGRESS_CC_BAND_START = 2;
+const INTERVIEW_PROGRESS_CC_BAND_END = 99;
+// The "discovery phase" (interviewing the CCs that establish the complete CC inventory:
+// Security, Manufacturer Specific, Version, Wake Up, Multi Channel on the root and
+// Security/Version on each endpoint) cannot know the total amount of work yet, so each of
+// those CCs advances progress by a fixed amount derived from its weight, bounded by this cap.
+const INTERVIEW_PROGRESS_DISCOVERY_CAP = 20;
+const INTERVIEW_PROGRESS_DISCOVERY_UNIT = 0.6;
+
+/**
+ * The relative weight of a CC's interview, used to distribute interview progress more realistically.
+ * Most CCs are quick (weight 1); CCs that are known to require many queries get a higher weight.
+ */
+function ccInterviewWeight(cc: CommandClasses): number {
+	switch (cc) {
+		case CommandClasses.Configuration:
+			// May scan hundreds of parameters
+			return 8;
+		case CommandClasses.Version:
+			// Queries the version of every supported CC
+			return 5;
+		case CommandClasses["User Code"]:
+			return 4;
+		case CommandClasses.Association:
+		case CommandClasses["Association Group Information"]:
+		case CommandClasses.Notification:
+			return 3;
+		case CommandClasses.Security:
+		case CommandClasses["Security 2"]:
+			// Security CCs can take a while because they may retry a few times to increase reliability
+			return 2;
+		case CommandClasses["Multi Channel"]:
+		case CommandClasses["Multilevel Sensor"]:
+			return 2;
+		default:
+			return 1;
+	}
+}
+
+/** The overall interview progress (percent in [0, 100]) reached when the given stage has completed */
+function interviewStageProgress(
+	stage: InterviewStage,
+): number | undefined {
+	switch (stage) {
+		case InterviewStage.ProtocolInfo:
+			return 1;
+		case InterviewStage.NodeInfo:
+			return INTERVIEW_PROGRESS_CC_BAND_START;
+		case InterviewStage.CommandClasses:
+		case InterviewStage.OverwriteConfig:
+			return INTERVIEW_PROGRESS_CC_BAND_END;
+		case InterviewStage.Complete:
+			return 100;
+		default:
+			return undefined;
+	}
+}
+
+export abstract class InterviewProgressMixin extends DeviceConfigMixin {
+	/** The last reported overall interview progress in percent [0, 100]. Monotonically non-decreasing. */
+	private _interviewProgress: number = 0;
+
+	// Working state for the CommandClasses interview stage only; reset between CC interviews.
+
+	/** Whether the CC interview has reached the bulk phase, where the total amount of work is known */
+	private _ccInterviewBulkPhase: boolean = false;
+	/** Total remaining CC interview weight at the start of the bulk phase */
+	private _ccInterviewBulkRemainingWeight: number = 0;
+	/** Width of the progress band [`_interviewProgress` … CC band end] available to the bulk phase */
+	private _ccInterviewBulkBand: number = 0;
+	/** Start of the progress slice allotted to the CC currently being interviewed */
+	private _ccInterviewStepStart: number = 0;
+	/** Width of the progress slice allotted to the CC currently being interviewed */
+	private _ccInterviewStepWidth: number = 0;
+	private _ccInterviewCurrentEndpoint: number | undefined;
+	private _ccInterviewCurrentCC: CommandClasses | undefined;
+
+	private emitInterviewProgress: (progress: InterviewProgress) => void =
+		throttle(
+			(progress) => this._emit("interview progress", this, progress),
+			250,
+			// trailing=true so the last update of a burst is never dropped
+			true,
+		);
+
+	private emitInterviewProgressUpdate(stage: InterviewStage): void {
+		this.emitInterviewProgress({
+			stage,
+			progress: roundTo(this._interviewProgress, 2),
+			endpoint: this._ccInterviewCurrentEndpoint,
+			commandClass: this._ccInterviewCurrentCC,
+		});
+	}
+
+	/** Resets the overall progress baseline to 0 for a fresh interview */
+	protected resetInterviewProgressBaseline(): void {
+		this._interviewProgress = 0;
+	}
+
+	/**
+	 * Resets the per-stage progress tracking at the start of the CC interview.
+	 * The overall progress baseline is intentionally NOT reset here, so it stays monotonic
+	 * across a resumed interview. It is reset for a fresh interview in `interviewInternal`.
+	 */
+	protected resetCCInterviewProgress(): void {
+		this._ccInterviewBulkPhase = false;
+		this._ccInterviewBulkRemainingWeight = 0;
+		this._ccInterviewBulkBand = 0;
+		this._ccInterviewStepStart = 0;
+		this._ccInterviewStepWidth = 0;
+		this._ccInterviewCurrentEndpoint = undefined;
+		this._ccInterviewCurrentCC = undefined;
+		// Make sure the CC band starts at its lower bound, even on a resumed interview
+		// where the earlier stage snaps did not happen in this session.
+		this._interviewProgress = Math.max(
+			this._interviewProgress,
+			INTERVIEW_PROGRESS_CC_BAND_START,
+		);
+	}
+
+	/**
+	 * Sets up proportional progress distribution for the bulk phase of the CC interview,
+	 * which is reached once the complete CC inventory is known. From here, progress is
+	 * distributed proportionally to the remaining interview weight, summed across every
+	 * not-yet-interviewed CC of the root device and all endpoints.
+	 */
+	protected setupCCInterviewBulkProgress(
+		...remainingCCs: Iterable<CommandClasses>[]
+	): void {
+		let remainingWeight = 0;
+		for (const ccs of remainingCCs) {
+			for (const cc of ccs) {
+				remainingWeight += ccInterviewWeight(cc);
+			}
+		}
+		this._ccInterviewBulkPhase = true;
+		this._ccInterviewBulkRemainingWeight = remainingWeight;
+		this._ccInterviewBulkBand = Math.max(
+			0,
+			INTERVIEW_PROGRESS_CC_BAND_END - this._interviewProgress,
+		);
+	}
+
+	/** Computes the progress slice width for the CC that is about to be interviewed */
+	private computeCCInterviewStepWidth(cc: CommandClasses): number {
+		if (this._ccInterviewBulkPhase) {
+			if (this._ccInterviewBulkRemainingWeight <= 0) return 0;
+			const width = ccInterviewWeight(cc)
+				/ this._ccInterviewBulkRemainingWeight
+				* this._ccInterviewBulkBand;
+			// Never advance past the end of the CC band
+			return Math.max(
+				0,
+				Math.min(
+					width,
+					INTERVIEW_PROGRESS_CC_BAND_END - this._ccInterviewStepStart,
+				),
+			);
+		} else {
+			// Discovery phase: a fixed amount derived from the CC's weight, bounded by the cap
+			const width = ccInterviewWeight(cc)
+				* INTERVIEW_PROGRESS_DISCOVERY_UNIT;
+			return Math.max(
+				0,
+				Math.min(
+					width,
+					INTERVIEW_PROGRESS_DISCOVERY_CAP
+						- this._ccInterviewStepStart,
+				),
+			);
+		}
+	}
+
+	/** Reserves a progress slice for the CC that is about to be interviewed */
+	protected reserveCCInterviewStepProgress(
+		endpoint: number,
+		cc: CommandClasses,
+	): void {
+		this._ccInterviewCurrentEndpoint = endpoint;
+		this._ccInterviewCurrentCC = cc;
+		this._ccInterviewStepStart = this._interviewProgress;
+		this._ccInterviewStepWidth = this.computeCCInterviewStepWidth(cc);
+	}
+
+	/** Completes the current CC's progress slice and emits an update */
+	protected completeCCInterviewStepProgress(): void {
+		this._interviewProgress = Math.max(
+			this._interviewProgress,
+			this._ccInterviewStepStart + this._ccInterviewStepWidth,
+		);
+		this.emitInterviewProgressUpdate(InterviewStage.CommandClasses);
+		this._ccInterviewCurrentEndpoint = undefined;
+		this._ccInterviewCurrentCC = undefined;
+	}
+
+	/**
+	 * Snaps the overall progress to the band end of a completed interview stage and emits an update.
+	 * The CommandClasses band (the bulk of the work) is filled granularly by the CC interview itself.
+	 */
+	protected snapInterviewProgressToStage(
+		completedStage: InterviewStage,
+	): void {
+		const stageProgress = interviewStageProgress(completedStage);
+		if (stageProgress == undefined) return;
+		this._ccInterviewCurrentEndpoint = undefined;
+		this._ccInterviewCurrentCC = undefined;
+		this._interviewProgress = Math.max(
+			this._interviewProgress,
+			stageProgress,
+		);
+		this.emitInterviewProgressUpdate(completedStage);
+	}
+
+	/**
+	 * Reports fine-grained progress from within the interview of the CC that is currently
+	 * being interviewed. Called by CCs (via `getNode(ctx)`) to keep the overall progress moving
+	 * during long-running interview steps. Implements the {@link ReportInterviewProgress} trait.
+	 */
+	public reportInterviewProgress(completed: number, total: number): void {
+		// Only meaningful while a specific CC is being interviewed
+		if (this._ccInterviewCurrentCC == undefined) return;
+		// This is called from many different CC interviews, so the inputs are sanitized
+		// here (not at each call site): the reported fraction is clamped into [0, 1],
+		// guarding against `completed > total`, negative values, and `total <= 0`.
+		const fraction = total > 0
+			? Math.min(1, Math.max(0, completed / total))
+			: 0;
+		const progress = this._ccInterviewStepStart
+			+ this._ccInterviewStepWidth * fraction;
+		// The overall progress must never go backwards
+		if (progress > this._interviewProgress) {
+			this._interviewProgress = progress;
+			this.emitInterviewProgressUpdate(InterviewStage.CommandClasses);
+		}
+	}
+}

--- a/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
+++ b/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
@@ -9,32 +9,32 @@ import { DeviceConfigMixin } from "./80_DeviceConfig.js";
 
 // The interview progress is approximated as a percentage in [0, 100], matching the unit
 // used for firmware update progress. The CommandClasses stage dominates the total interview
-// time, so it occupies the largest band. The other stages are near-instant and snap to fixed
-// points (see snapInterviewProgressToStage).
+// time, so it occupies the largest band. The other stages are near-instant and advance to fixed
+// points (see interviewStageStartProgress).
 const INTERVIEW_PROGRESS_CC_BAND_START = 2;
 const INTERVIEW_PROGRESS_CC_BAND_END = 99;
-// The "discovery phase" (interviewing the CCs that establish the complete CC inventory:
-// Security, Manufacturer Specific, Version, Wake Up, Multi Channel on the root and
-// Security/Version on each endpoint) cannot know the total amount of work yet, so each of
-// those CCs advances progress by a fixed amount derived from its weight, bounded by this cap.
-// The cap leaves headroom for endpoint-heavy devices (which repeat Security/Version per
-// endpoint) so the bar does not stall once the cap is reached.
+
+// During the "discovery phase" of the CC interview, we don't know how much work is
+// involved in total, so we instead advance the progress by a fixed amount,
+// up to a cap that should leave enough room for the devices with lots of endpoints
+// or CCs.
 const INTERVIEW_PROGRESS_DISCOVERY_CAP = 30;
 const INTERVIEW_PROGRESS_DISCOVERY_UNIT = 0.4;
 
 /** The assumed number of configuration parameters when the count is not known from a config file */
 const ASSUMED_CONFIG_PARAM_COUNT = 30;
 
-/** The overall interview progress (percent in [0, 100]) reached when the given stage has completed */
-function interviewStageProgress(
+/**
+ * At which percentage each stage is defined to start.
+ */
+function interviewStageStartProgress(
 	stage: InterviewStage,
 ): number | undefined {
 	switch (stage) {
-		case InterviewStage.ProtocolInfo:
-			return 1;
 		case InterviewStage.NodeInfo:
-			return INTERVIEW_PROGRESS_CC_BAND_START;
+			return 1;
 		case InterviewStage.CommandClasses:
+			return INTERVIEW_PROGRESS_CC_BAND_START;
 		case InterviewStage.OverwriteConfig:
 			return INTERVIEW_PROGRESS_CC_BAND_END;
 		case InterviewStage.Complete:
@@ -80,9 +80,16 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 		});
 	}
 
-	/** Resets the overall progress baseline to 0 for a fresh interview */
+	/**
+	 * Resets the overall progress baseline to 0 for a fresh interview and emits an initial
+	 * progress event (stage `None`). This gives consumers a meaningful 0% anchor right away,
+	 * even if the first interview stage never starts.
+	 */
 	protected resetInterviewProgressBaseline(): void {
 		this._interviewProgress = 0;
+		this._ccInterviewCurrentEndpoint = undefined;
+		this._ccInterviewCurrentCC = undefined;
+		this.emitInterviewProgressUpdate(InterviewStage.None);
 	}
 
 	/**
@@ -99,7 +106,7 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 		this._ccInterviewCurrentEndpoint = undefined;
 		this._ccInterviewCurrentCC = undefined;
 		// Make sure the CC band starts at its lower bound, even on a resumed interview
-		// where the earlier stage snaps did not happen in this session.
+		// where the earlier stage transitions did not happen in this session.
 		this._interviewProgress = Math.max(
 			this._interviewProgress,
 			INTERVIEW_PROGRESS_CC_BAND_START,
@@ -136,8 +143,8 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 	 * quick (weight 1); CCs that iterate over a runtime-enumerated collection get a higher weight
 	 * derived from the typical size of that collection.
 	 *
-	 * Typical collection sizes used to derive the weights below (median across a survey of ~34
-	 * certified products in the Z-Wave Alliance product database, plus maintainer input):
+	 * Typical collection sizes used to derive the weights below (median across a survey of ~30
+	 * certified products in the Z-Wave Alliance product database, plus some common sense):
 	 *
 	 *   | Collection                          | Typical | Affected CC(s)                                            |
 	 *   | ----------------------------------- | ------- | --------------------------------------------------------- |
@@ -288,21 +295,20 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 	}
 
 	/**
-	 * Snaps the overall progress to the band end of a completed interview stage and emits an update.
-	 * The CommandClasses band (the bulk of the work) is filled granularly by the CC interview itself.
+	 * Advances the overall progress to the start of the given interview stage and emits an update
+	 * reporting that stage as currently in progress.
 	 */
-	protected snapInterviewProgressToStage(
-		completedStage: InterviewStage,
-	): void {
-		const stageProgress = interviewStageProgress(completedStage);
+	protected reportInterviewStageStarted(stage: InterviewStage): void {
+		const stageProgress = interviewStageStartProgress(stage);
 		if (stageProgress == undefined) return;
+
 		this._ccInterviewCurrentEndpoint = undefined;
 		this._ccInterviewCurrentCC = undefined;
 		this._interviewProgress = Math.max(
 			this._interviewProgress,
 			stageProgress,
 		);
-		this.emitInterviewProgressUpdate(completedStage);
+		this.emitInterviewProgressUpdate(stage);
 	}
 
 	/**
@@ -322,9 +328,9 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 	public reportInterviewProgress(completed: number, total: number): void {
 		// Only meaningful while a specific CC is being interviewed
 		if (this._ccInterviewCurrentCC == undefined) return;
-		// This is called from many different CC interviews, so the inputs are sanitized
-		// here (not at each call site): the reported fraction is clamped into [0, 1],
-		// guarding against `completed > total`, negative values, and `total <= 0`.
+
+		// Make sure that we don't report garbage when the CC interviews
+		// call this with miscalculated progress values.
 		const fraction = total > 0
 			? Math.min(1, Math.max(0, completed / total))
 			: 0;

--- a/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
+++ b/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
@@ -152,8 +152,7 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 	private ccInterviewWeight(cc: CommandClasses): number {
 		switch (cc) {
 			case CommandClasses.Configuration:
-				// Scales with the number of config parameters; weighted for a heavy device
-				return 50;
+				return this.configurationCCInterviewWeight();
 			case CommandClasses["User Credential"]:
 				// The interview enumerates all users and their credentials
 				return 30;
@@ -210,6 +209,28 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 			default:
 				return 1;
 		}
+	}
+
+	/**
+	 * The interview weight of the Configuration CC scales with the number of parameters that get
+	 * queried. When they are known up front from the device config file, the weight is the count
+	 * of distinct readable parameters; otherwise (e.g. a v3+ device whose parameters are discovered
+	 * by scanning the device) it falls back to a value tuned for a parameter-heavy device.
+	 */
+	private configurationCCInterviewWeight(): number {
+		const FALLBACK_WEIGHT = 50;
+		const paramInfo = this.deviceConfig?.paramInformation
+			?? this.deviceConfig?.endpoints?.get(0)?.paramInformation;
+		if (!paramInfo?.size) return FALLBACK_WEIGHT;
+
+		// Partial parameters share a parameter number and are queried once; write-only
+		// parameters are not queried during the interview.
+		const queryableParameters = new Set(
+			[...paramInfo.keys()]
+				.filter((key) => !paramInfo.get(key)?.writeOnly)
+				.map((key) => key.parameter),
+		);
+		return queryableParameters.size || FALLBACK_WEIGHT;
 	}
 
 	/** Computes the progress slice width for the CC that is about to be interviewed */

--- a/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
+++ b/packages/zwave-js/src/lib/node/mixins/90_InterviewProgress.ts
@@ -17,38 +17,10 @@ const INTERVIEW_PROGRESS_CC_BAND_END = 99;
 // Security, Manufacturer Specific, Version, Wake Up, Multi Channel on the root and
 // Security/Version on each endpoint) cannot know the total amount of work yet, so each of
 // those CCs advances progress by a fixed amount derived from its weight, bounded by this cap.
-const INTERVIEW_PROGRESS_DISCOVERY_CAP = 20;
-const INTERVIEW_PROGRESS_DISCOVERY_UNIT = 0.6;
-
-/**
- * The relative weight of a CC's interview, used to distribute interview progress more realistically.
- * Most CCs are quick (weight 1); CCs that are known to require many queries get a higher weight.
- */
-function ccInterviewWeight(cc: CommandClasses): number {
-	switch (cc) {
-		case CommandClasses.Configuration:
-			// May scan hundreds of parameters
-			return 8;
-		case CommandClasses.Version:
-			// Queries the version of every supported CC
-			return 5;
-		case CommandClasses["User Code"]:
-			return 4;
-		case CommandClasses.Association:
-		case CommandClasses["Association Group Information"]:
-		case CommandClasses.Notification:
-			return 3;
-		case CommandClasses.Security:
-		case CommandClasses["Security 2"]:
-			// Security CCs can take a while because they may retry a few times to increase reliability
-			return 2;
-		case CommandClasses["Multi Channel"]:
-		case CommandClasses["Multilevel Sensor"]:
-			return 2;
-		default:
-			return 1;
-	}
-}
+// The cap leaves headroom for endpoint-heavy devices (which repeat Security/Version per
+// endpoint) so the bar does not stall once the cap is reached.
+const INTERVIEW_PROGRESS_DISCOVERY_CAP = 30;
+const INTERVIEW_PROGRESS_DISCOVERY_UNIT = 0.4;
 
 /** The overall interview progress (percent in [0, 100]) reached when the given stage has completed */
 function interviewStageProgress(
@@ -143,7 +115,7 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 		let remainingWeight = 0;
 		for (const ccs of remainingCCs) {
 			for (const cc of ccs) {
-				remainingWeight += ccInterviewWeight(cc);
+				remainingWeight += this.ccInterviewWeight(cc);
 			}
 		}
 		this._ccInterviewBulkPhase = true;
@@ -154,11 +126,97 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 		);
 	}
 
+	/**
+	 * The relative weight of a CC's interview, used to distribute interview progress more
+	 * realistically. The weight approximates the number of device queries the CC's interview
+	 * performs, so the progress bar advances at a roughly constant per-query rate. Most CCs are
+	 * quick (weight 1); CCs that iterate over a runtime-enumerated collection get a higher weight
+	 * derived from the typical size of that collection.
+	 *
+	 * Typical collection sizes used to derive the weights below (median across a survey of ~34
+	 * certified products in the Z-Wave Alliance product database, plus maintainer input):
+	 *
+	 *   | Collection                          | Typical | Affected CC(s)                                            |
+	 *   | ----------------------------------- | ------- | --------------------------------------------------------- |
+	 *   | Configuration parameters            | 50+     | Configuration                                             |
+	 *   | Supported CCs (queried for version) | ~20     | Version                                                   |
+	 *   | Association groups                  | ~5      | Association, Association Group Information, Multi Channel Association, Scene Controller Configuration |
+	 *   | Notification types                  | ~3      | Notification                                              |
+	 *   | Multi Channel endpoints             | ~3      | Multi Channel                                             |
+	 *   | Multilevel Sensor types             | ~3      | Multilevel Sensor                                         |
+	 *   | Meter scales/rate types             | ~4      | Meter                                                     |
+	 *   | Alarm Sensor types                  | ~2      | Alarm Sensor                                              |
+	 *   | Binary Sensor types                 | ~1      | Binary Sensor                                             |
+	 *   | User codes / credentials            | ~30     | User Code (opt-in only), User Credential                  |
+	 */
+	private ccInterviewWeight(cc: CommandClasses): number {
+		switch (cc) {
+			case CommandClasses.Configuration:
+				// Scales with the number of config parameters; weighted for a heavy device
+				return 50;
+			case CommandClasses["User Credential"]:
+				// The interview enumerates all users and their credentials
+				return 30;
+			case CommandClasses["User Code"]:
+				// User codes are only enumerated when explicitly requested; otherwise the
+				// interview just queries capabilities
+				return this.driver.getInterviewOptions()?.queryAllUserCodes
+					? 30
+					: 2;
+			case CommandClasses.Version:
+				// Queries the version of every supported CC
+				return 20;
+			case CommandClasses["Association Group Information"]:
+				// Two queries (name + commands) per association group
+				return 10;
+			case CommandClasses.Notification:
+				return 7;
+			case CommandClasses.Association:
+			case CommandClasses["Multi Channel Association"]:
+			case CommandClasses["Multilevel Sensor"]:
+				return 6;
+			case CommandClasses["Scene Controller Configuration"]:
+			case CommandClasses.Meter:
+			case CommandClasses.Irrigation:
+				return 5;
+			case CommandClasses["Color Switch"]:
+			case CommandClasses["Thermostat Setpoint"]:
+			case CommandClasses["Multi Channel"]:
+				return 4;
+			case CommandClasses.Indicator:
+			case CommandClasses["Barrier Operator"]:
+				return 3;
+			case CommandClasses.Security:
+			case CommandClasses["Security 2"]:
+				// Security CCs can take a while because they may retry a few times to increase reliability
+				return 2;
+			case CommandClasses["Window Covering"]:
+			case CommandClasses.Battery:
+			case CommandClasses["Central Scene"]:
+			case CommandClasses["Node Naming and Location"]:
+			case CommandClasses["Sound Switch"]:
+			case CommandClasses["Entry Control"]:
+			case CommandClasses["Door Lock"]:
+			case CommandClasses["Wake Up"]:
+			case CommandClasses["Energy Production"]:
+			case CommandClasses["Alarm Sensor"]:
+			case CommandClasses["Thermostat Mode"]:
+			case CommandClasses["Thermostat Fan Mode"]:
+			case CommandClasses["Thermostat Fan State"]:
+			case CommandClasses["Thermostat Operating State"]:
+			case CommandClasses["Thermostat Setback"]:
+				// A handful of fixed queries each
+				return 2;
+			default:
+				return 1;
+		}
+	}
+
 	/** Computes the progress slice width for the CC that is about to be interviewed */
 	private computeCCInterviewStepWidth(cc: CommandClasses): number {
 		if (this._ccInterviewBulkPhase) {
 			if (this._ccInterviewBulkRemainingWeight <= 0) return 0;
-			const width = ccInterviewWeight(cc)
+			const width = this.ccInterviewWeight(cc)
 				/ this._ccInterviewBulkRemainingWeight
 				* this._ccInterviewBulkBand;
 			// Never advance past the end of the CC band
@@ -171,7 +229,7 @@ export abstract class InterviewProgressMixin extends DeviceConfigMixin {
 			);
 		} else {
 			// Discovery phase: a fixed amount derived from the CC's weight, bounded by the cap
-			const width = ccInterviewWeight(cc)
+			const width = this.ccInterviewWeight(cc)
 				* INTERVIEW_PROGRESS_DISCOVERY_UNIT;
 			return Math.max(
 				0,

--- a/packages/zwave-js/src/lib/node/mixins/index.ts
+++ b/packages/zwave-js/src/lib/node/mixins/index.ts
@@ -1,3 +1,3 @@
-import { DeviceConfigMixin } from "./80_DeviceConfig.js";
+import { InterviewProgressMixin } from "./90_InterviewProgress.js";
 
-export abstract class ZWaveNodeMixins extends DeviceConfigMixin {}
+export abstract class ZWaveNodeMixins extends InterviewProgressMixin {}

--- a/packages/zwave-js/src/lib/test/node/Node.interviewOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.interviewOrder.test.ts
@@ -43,6 +43,7 @@ test("the CC interviews happen in the correct order", (t) => {
 		CommandClasses["Security 2"],
 		CommandClasses["Manufacturer Specific"],
 		CommandClasses.Version,
+		CommandClasses["Multi Channel"],
 		...applicationCCs,
 	]);
 	const rootInterviewGraphPart2 = node.buildCCInterviewGraph([
@@ -59,7 +60,6 @@ test("the CC interviews happen in the correct order", (t) => {
 		"Device Reset Locally",
 		"Firmware Update Meta Data",
 		"CRC-16 Encapsulation",
-		"Multi Channel",
 		"Association",
 		"Multi Channel Association",
 		"Association Group Information",


### PR DESCRIPTION
This PR introduces a new `"interview progress"` event that is meant to supersede the `"interview stage completed"` event. This new event supports more granular progress reporting that gives feedback during the `CommandClasses` stage, and allows seeing progress during the interview of individual command classes like `Configuration` that typically have very long interview processes.