### PR TITLE
feat(config): add Fortune Brands YRD4X0-F-ZW4

### DIFF
--- a/packages/config/config/devices/0x0463/yrd4x0-f-zw4.json
+++ b/packages/config/config/devices/0x0463/yrd4x0-f-zw4.json
@@ -1,0 +1,126 @@
+{
+	"manufacturer": "Fortune Brands",
+	"manufacturerId": "0x0463",
+	"label": [
+		{
+			"$if": "productId === 0x89d1",
+			"value": "YRD410-F-ZW4"
+		},
+		{
+			"$if": "productId === 0x89d2",
+			"value": "YRD420-F-ZW4"
+		},
+		{
+			"$if": "productId === 0x89d3",
+			"value": "YRD430-F-ZW4"
+		},
+		{
+			"$if": "productId === 0x89d5",
+			"value": "YRD450-F-ZW4"
+		},
+		"YRD4X0-F-ZW4"
+	],
+	"description": "Assure 2 Biometric Deadbolt",
+	"devices": [
+		// This device is a re-branded Yale
+		// YRD410-F-ZW4 (Keyed Push Button)
+		{
+			"productType": "0x8107",
+			"productId": "0x89d1"
+		},
+		// YRD420-F-ZW4 (Keyed Touch Screen)
+		{
+			"productType": "0x8107",
+			"productId": "0x89d2"
+		},
+		// YRD430-F-ZW4 (Keyless Push Button)
+		{
+			"productType": "0x8107",
+			"productId": "0x89d3"
+		},
+		// YRD450-F-ZW4 (Keyless Touch Screen)
+		{
+			"productType": "0x8107",
+			"productId": "0x89d5"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"$import": "~/0x0129/templates/yale_template.json#volume",
+			"defaultValue": 1
+		},
+		{
+			"#": "2",
+			"$import": "~/0x0129/templates/yale_template.json#auto_relock"
+		},
+		{
+			"#": "3",
+			"$import": "~/0x0129/templates/yale_template.json#auto_relock_time_180",
+			"minValue": 1
+		},
+		{
+			"#": "4",
+			"$import": "~/0x0129/templates/yale_template.json#wrong_code_limit_3_to_10",
+			"defaultValue": 3
+		},
+		{
+			"#": "7",
+			"$import": "~/0x0129/templates/yale_template.json#wrong_code_lockout_10_to_132",
+			"maxValue": 180
+		},
+		{
+			"#": "8",
+			"$import": "~/0x0129/templates/yale_template.json#operating_mode_normal_privacy_passage"
+		},
+		{
+			"#": "11",
+			"$import": "~/0x0129/templates/yale_template.json#one_touch",
+			"defaultValue": 255
+		},
+		{
+			"#": "13",
+			"$import": "~/0x0129/templates/yale_template.json#lock_status_led"
+		},
+		{
+			"#": "19",
+			"$import": "~/0x0129/templates/yale_template.json#dps_alarm",
+			"defaultValue": 255
+		},
+		{
+			"#": "28",
+			"$import": "~/0x0129/templates/yale_template.json#expiring_pin_lifetime"
+		},
+		{
+			"#": "34",
+			"label": "Handing Lock",
+			"description": "Set deadbolt direction and length",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 35,
+			"defaultValue": 0
+		},
+		{
+			"#": "35",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Invalid Entry Alarm",
+			"description": "Set whether the invalid entry alarm is enabled"
+		}
+	],
+	"compat": {
+		"alarmMapping": [
+			{
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_outside_schedule"
+			}
+		]
+	},
+	"metadata": {
+		"$import": "~/0x0129/templates/yale_template.json#assure2_zw3_metadata",
+		"reset": "1. Remove the inside lever with the lever removal tool\n2. Remove battery cover using hex wrench provided with lock\n3. Remove four AA batteries\n4. Remove the 10-32 x 3/4\" pan head screw from the center of the battery housing into the barrel nut of the outside assembly\n5. Remove inside escutcheon\n6. Reinstall batteries\n7. On the back of the PC board, push and hold the Reset Button with the lever removal tool for 3 seconds\n8. While continuing the press the reset button, temporarily remove one AA battery\n9. Reinstall the battery\n10. Release reset button and wait 15 seconds until speaker announces \"Welcome to Yale\"\n11. Reassemble escutcheon",
+		"manual": "https://products.z-wavealliance.org/wp-content/uploads/products/80612/YaleZ-Wave800SeriesSystemIntegratorsGuidev2.2_Connected_Biometric_Deadbolt_ZW4_ADT.pdf"
+	}
+}

--- a/packages/config/config/devices/0x0463/yrd4x0-f-zw4.json
+++ b/packages/config/config/devices/0x0463/yrd4x0-f-zw4.json
@@ -61,6 +61,7 @@
 		{
 			"#": "3",
 			"$import": "~/0x0129/templates/yale_template.json#auto_relock_time_180",
+			"description": "Values of 1 and 2 seconds are set to 3",
 			"minValue": 1
 		},
 		{
@@ -106,18 +107,10 @@
 		},
 		{
 			"#": "35",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Invalid Entry Alarm",
-			"description": "Set whether the invalid entry alarm is enabled"
+			"$import": "~/templates/master_template.json#base_enable_disable_255",
+			"label": "Invalid Entry Alarm"
 		}
 	],
-	"compat": {
-		"alarmMapping": [
-			{
-				"$import": "~/0x0129/templates/yale_template.json#alarm_map_outside_schedule"
-			}
-		]
-	},
 	"metadata": {
 		"$import": "~/0x0129/templates/yale_template.json#assure2_zw3_metadata",
 		"reset": "1. Remove the inside lever with the lever removal tool\n2. Remove battery cover using hex wrench provided with lock\n3. Remove four AA batteries\n4. Remove the 10-32 x 3/4\" pan head screw from the center of the battery housing into the barrel nut of the outside assembly\n5. Remove inside escutcheon\n6. Reinstall batteries\n7. On the back of the PC board, push and hold the Reset Button with the lever removal tool for 3 seconds\n8. While continuing the press the reset button, temporarily remove one AA battery\n9. Reinstall the battery\n10. Release reset button and wait 15 seconds until speaker announces \"Welcome to Yale\"\n11. Reassemble escutcheon",


### PR DESCRIPTION
Manual added for review convenience (also in json)
[YaleZ-Wave800SeriesSystemIntegratorsGuidev2.2_Connected_Biometric_Deadbolt_ZW4_ADT.pdf](https://github.com/user-attachments/files/29208759/YaleZ-Wave800SeriesSystemIntegratorsGuidev2.2_Connected_Biometric_Deadbolt_ZW4_ADT.pdf)


<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

Add device configuration for Fortune Brands Assure 2 Biometric Deadbolt (YRD4X0-F-ZW4). Supports productIds 0x89d1, 0x89d2, 0x89d3 and 0x89d5 with productType 0x8107 and manufacturerId 0x0463. Imports Yale template definitions for parameters and alarm mapping, defines device-specific parameters (volume, auto-relock, wrong-code limits, handing, invalid entry alarm, etc.), and includes reset procedure and manual link.

I don't have the device, but this looked challenging. 

closes #8713
closes #8717
