### PR TITLE
fix(config): add missing product IDs for SimonTech 10002080-13X Roller Blind

### DIFF
--- a/packages/config/config/devices/0x0267/10002080-13x.json
+++ b/packages/config/config/devices/0x0267/10002080-13x.json
@@ -19,6 +19,18 @@
 		},
 		{
 			"productType": "0x0004",
+		    "productId": "0x006a"
+		},
+		{
+			"productType": "0x0004",
+			"productId": "0x006c"
+		},
+		{
+			"productType": "0x0004",
+			"productId": "0x006d"
+		},
+		{
+			"productType": "0x0004",
 			"productId": "0x0091"
 		},
 		{
@@ -40,6 +52,10 @@
 		{
 			"productType": "0x0004",
 			"productId": "0x0177"
+		},
+		{
+			"productType": "0x0004",
+			"productId": "0x0393"
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x0267/10002080-13x.json
+++ b/packages/config/config/devices/0x0267/10002080-13x.json
@@ -19,7 +19,7 @@
 		},
 		{
 			"productType": "0x0004",
-		    "productId": "0x006a"
+			"productId": "0x006a"
 		},
 		{
 			"productType": "0x0004",


### PR DESCRIPTION
This PR adds additional product identifiers for the SimonTech 10002080-13X Roller Blind device.

The following product IDs have been observed in the field and are currently reported as unknown products by Z-Wave JS, despite sharing the same manufacturer ID (0x0267), product type (0x0004), firmware family, and behavior as the already supported 10002080-13X devices.

Added product IDs:

* 0x006a
* 0x006c
* 0x006d
* 0x0393

Tested device information:

Manufacturer ID: 0x0267
Product Type: 0x0004
Firmware Version: 4.24

Without this change, the devices are detected as "Unknown product" and do not receive the associated configuration parameters. After adding these identifiers, the existing 10002080-13X configuration is correctly applied and all configuration parameters become available.

This change only extends the list of known product identifiers and does not modify any device behavior or configuration parameters.
