### PR TITLE
fix(config): add missing product ID 0x01ba for SimonTech 10002020-13X

### DIFF
--- a/packages/config/config/devices/0x0267/10002020-13x.json
+++ b/packages/config/config/devices/0x0267/10002020-13x.json
@@ -8,6 +8,10 @@
 			"productType": "0x0007",
 			"productId": "0x0000",
 			"zwaveAllianceId": 2590
+		},
+		{
+			"productType": "0x0007",
+			"productId": "0x01ba"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
This PR adds product ID `0x01ba` to the existing SimonTech 10002020-13X device configuration.

The device reports the following identifiers:

* Manufacturer ID: `0x0267`
* Product Type: `0x0007`
* Product ID: `0x01ba`

The device is functionally identical to the already supported 10002020-13X variants and correctly uses the same configuration file. However, because this product ID is not currently listed in the device definition, Z-Wave JS identifies it as an unknown product and does not apply the available configuration parameters.

This change only extends the list of supported product identifiers and does not modify any existing configuration values or device behavior.