### PR TITLE
chore(mcp): add navigation and diagnostic tools

### DIFF
--- a/.github/instructions/config-files.instructions.md
+++ b/.github/instructions/config-files.instructions.md
@@ -289,12 +289,21 @@ Templates allow reusing common parameter definitions across devices to maintain 
 1. **Master Template** (`~/templates/master_template.json`):
    - Common parameter bases usable across all manufacturers
    - Examples: `base_enable_disable`, `base_0-99_nounit`, `orientation`, `led_indicator_three_options`
-   - Modifying existing master templates affects ALL devices using them, be careful with changes
+   - Modifying existing master templates affects ALL devices using them, be careful with changes (use `find_template_references` to see which devices are affected)
 
 2. **Manufacturer-specific Templates** (in each manufacturer's `templates/` folder):
    - Parameters common to devices from that specific manufacturer
    - Should only be created if there are multiple devices from that manufacturer reusing the same parameter definitions
-   - Changing existing manufacturer templates affects all devices from that manufacturer
+   - Changing existing manufacturer templates affects all devices from that manufacturer (use `find_template_references` to see which devices are affected)
+
+### Tools for Working with Templates
+
+The `zwave-dev` MCP server provides tools to inspect templates without manually tracing `$import`s. They read fresh from disk, resolve nested imports recursively, and mirror the config editor:
+
+- `resolve_config_import` - resolve an `$import` specifier to the exact JSON it pulls in. Use this to verify a template matches the documented device behavior before importing it.
+- `resolve_config_param` - resolve a parameter to its final JSON with all templates applied (optionally evaluating `$if` conditionals for a given firmware version). Use this to confirm overrides produce the intended result.
+- `find_template_definition` - jump to where a template (or a parameter's `$import`) is defined.
+- `find_template_references` - list every device file that imports a given template. Use this before changing a shared template to assess the impact.
 
 ### When Reviewing Templates
 

--- a/.github/prompts/author-config-from-web.prompt.md
+++ b/.github/prompts/author-config-from-web.prompt.md
@@ -46,6 +46,7 @@ Before creating parameters from scratch, identify reusable templates:
 - Check manufacturer-specific templates in `packages/config/config/devices/<manufacturerId>/templates/`
 - Check master templates in `packages/config/config/devices/templates/master_template.json`
 - Look for existing parameters in other config files from the same manufacturer that could be reused via templates
+- Use the `find_template_definition` tool to jump to a template's definition, and `find_template_references` to see which existing devices already use a template (good evidence that it fits a common pattern)
 
 ## 4. Reference File Analysis
 
@@ -97,11 +98,12 @@ For each parameter found on the website:
 
 **ALWAYS verify template compatibility before using any template:**
 
-1. **Read the actual template definition** from the template file to understand:
+1. **Resolve the actual template definition** with the `resolve_config_import` tool (or `find_template_definition` to open it) to understand:
    - Value ranges (minValue, maxValue)
    - Default values
    - Option labels and values
    - Data types and units
+   - After importing, use `resolve_config_param` to confirm the fully resolved parameter (template plus your overrides) matches the documented behavior
 
 2. **Compare with website parameter description** to ensure exact match:
    - Value mappings must be identical

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+	"mcpServers": {
+		"zwave-dev": {
+			"command": "node",
+			"args": ["packages/mcp-server-dev/build/index.js"],
+			"env": {}
+		}
+	}
+}

--- a/packages/config/src/JsonTemplate.ts
+++ b/packages/config/src/JsonTemplate.ts
@@ -127,6 +127,132 @@ function getImportStack(
 	return "";
 }
 
+/**
+ * Resolves the filename portion of an `$import` specifier to an absolute path.
+ *
+ * @param fs The filesystem used to check whether candidate files exist
+ * @param importFilename The filename portion of the specifier, e.g. `~/templates/foo.json` or `templates/foo.json`
+ * @param contextFilename The file the specifier appears in, used to resolve relative paths
+ * @param rootDirs The root directories that `~/`-prefixed specifiers are resolved against
+ * @param visited The import stack so far, included in error messages
+ * @param selector The selector portion of the specifier, included in error messages
+ */
+async function resolveImportFilename(
+	fs: ReadFileSystemInfo & ReadFile,
+	importFilename: string,
+	contextFilename: string,
+	rootDirs: string[] | undefined,
+	visited: string[],
+	selector: string | undefined,
+): Promise<string> {
+	if (importFilename.startsWith("~/")) {
+		// This is a special import specifier that is relative to the root directory
+		// Try to find at least one root directory that contains the referenced file
+		if (!rootDirs) {
+			throw new ZWaveError(
+				`An $import specifier cannot start with ~/ when no root directory is defined!${
+					getImportStack(visited, selector)
+				}`,
+				ZWaveErrorCodes.Config_Invalid,
+			);
+		}
+		for (const rootDir of rootDirs) {
+			const candidate = path.join(rootDir, importFilename.slice(2));
+			if (await pathExists(fs, candidate)) return candidate;
+		}
+		throw new ZWaveError(
+			`Could not find the referenced file ${
+				importFilename.slice(2)
+			} in any of the root directories: ${
+				rootDirs.map((d) => `\n· ${d}`).join("")
+			}\n${getImportStack(visited, selector)}`,
+			ZWaveErrorCodes.Config_Invalid,
+		);
+	} else {
+		return path.join(path.dirname(contextFilename), importFilename);
+	}
+}
+
+/**
+ * Resolves a single `$import` specifier (as used in device config files) to the
+ * JSON it pulls in, with the imported file's own `$import`s resolved recursively.
+ *
+ * @param fs The filesystem used to read config and template files
+ * @param contextFilename The file the specifier appears in, used to resolve relative paths and same-file (`#selector`) imports
+ * @param specifier The `$import` specifier to resolve, e.g. `~/templates/master_template.json#base_enable_disable`
+ * @param rootDirs The root directories that `~/`-prefixed specifiers are resolved against
+ */
+export async function resolveTemplateImport(
+	fs: ReadFileSystemInfo & ReadFile,
+	contextFilename: string,
+	specifier: string,
+	rootDirs?: string | string[],
+): Promise<Record<string, unknown>> {
+	assertImportSpecifier(specifier);
+	if (typeof rootDirs === "string") rootDirs = [rootDirs];
+
+	const { filename: importFilename, selector } = importSpecifierRegex
+		.exec(specifier)!.groups!;
+
+	const newFilename = importFilename
+		? await resolveImportFilename(
+			fs,
+			importFilename,
+			contextFilename,
+			rootDirs,
+			[],
+			selector,
+		)
+		: path.normalize(contextFilename);
+
+	const fileCache = new Map(templateCache);
+	return readJsonWithTemplateInternal(
+		fs,
+		newFilename,
+		selector,
+		[],
+		fileCache,
+		rootDirs,
+	);
+}
+
+/**
+ * Resolves the target file of an `$import` specifier to an absolute path,
+ * without reading or resolving the file's contents. Returns `undefined` if the
+ * specifier is invalid or the referenced file cannot be located.
+ *
+ * @param fs The filesystem used to locate `~/`-prefixed files
+ * @param contextFilename The file the specifier appears in, used to resolve relative and same-file imports
+ * @param specifier The `$import` specifier
+ * @param rootDirs The root directories that `~/`-prefixed specifiers are resolved against
+ */
+export async function resolveImportPath(
+	fs: ReadFileSystemInfo & ReadFile,
+	contextFilename: string,
+	specifier: string,
+	rootDirs?: string | string[],
+): Promise<string | undefined> {
+	if (!importSpecifierRegex.test(specifier)) return undefined;
+	if (typeof rootDirs === "string") rootDirs = [rootDirs];
+
+	const { filename: importFilename } = importSpecifierRegex
+		.exec(specifier)!.groups!;
+	if (!importFilename) return path.normalize(contextFilename);
+
+	try {
+		return await resolveImportFilename(
+			fs,
+			importFilename,
+			contextFilename,
+			rootDirs,
+			[],
+			undefined,
+		);
+	} catch {
+		return undefined;
+	}
+}
+
 async function readJsonWithTemplateInternal(
 	fs: ReadFileSystemInfo & ReadFile,
 	filename: string,
@@ -218,66 +344,17 @@ async function resolveJsonImports(
 				.exec(val)!.groups!;
 
 			// Resolve the correct import path
-			let newFilename: string | undefined;
-			if (importFilename) {
-				if (importFilename.startsWith("~/")) {
-					// This is a special import specifier that is relative to the root directory
-					// Try to find at least one root directory that contains the referenced file
-					if (rootDirs) {
-						for (const rootDir of rootDirs) {
-							newFilename = path.join(
-								rootDir,
-								importFilename.slice(2),
-							);
-							if (await pathExists(fs, newFilename)) {
-								break;
-							} else {
-								// Try the next
-								newFilename = undefined!;
-							}
-						}
+			const newFilename = importFilename
+				? await resolveImportFilename(
+					fs,
+					importFilename,
+					filename,
+					rootDirs,
+					visited,
+					selector,
+				)
+				: filename;
 
-						if (!newFilename) {
-							throw new ZWaveError(
-								`Could not find the referenced file ${
-									importFilename.slice(
-										2,
-									)
-								} in any of the root directories: ${
-									rootDirs
-										.map((d) => `\n· ${d}`)
-										.join("")
-								}\n${
-									getImportStack(
-										visited,
-										selector,
-									)
-								}`,
-								ZWaveErrorCodes.Config_Invalid,
-							);
-						}
-					} else {
-						throw new ZWaveError(
-							`An $import specifier cannot start with ~/ when no root directory is defined!${
-								getImportStack(
-									visited,
-									selector,
-								)
-							}`,
-							ZWaveErrorCodes.Config_Invalid,
-						);
-					}
-				} else {
-					newFilename = path.join(
-						path.dirname(filename),
-						importFilename,
-					);
-				}
-			} else {
-				newFilename = filename;
-			}
-
-			// const importFilename = path.join(path.dirname(filename), val);
 			const imported = await readJsonWithTemplateInternal(
 				fs,
 				newFilename,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,10 @@
 export * from "./ConfigManager.js";
+export {
+	clearTemplateCache,
+	readJsonWithTemplate,
+	resolveImportPath,
+	resolveTemplateImport,
+} from "./JsonTemplate.js";
 export * from "./Logger_safe.js";
 export * from "./Manufacturers.js";
 export { PACKAGE_VERSION } from "./_version.js";

--- a/packages/mcp-server-dev/package.json
+++ b/packages/mcp-server-dev/package.json
@@ -37,6 +37,15 @@
   "engines": {
     "node": ">=20"
   },
+  "dependencies": {
+    "@zwave-js/config": "workspace:*",
+    "@zwave-js/core": "workspace:*",
+    "@zwave-js/shared": "workspace:*",
+    "jsonc-parser": "^3.2.0",
+    "p-queue": "^9.1.0",
+    "vscode-json-languageservice": "^5.1.3",
+    "vscode-languageserver-textdocument": "^1.0.13"
+  },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node": "^20.19.35",

--- a/packages/mcp-server-dev/src/configDoc/astUtils.ts
+++ b/packages/mcp-server-dev/src/configDoc/astUtils.ts
@@ -1,0 +1,174 @@
+import type {
+	ASTNode,
+	ArrayASTNode,
+	ObjectASTNode,
+	Position,
+	PropertyASTNode,
+	Range,
+	StringASTNode,
+	TextDocument,
+} from "vscode-json-languageservice";
+
+// Ported from the zwave-js config editor VS Code extension. The original uses
+// vscode.Range/Position; here the framework-agnostic LSP Range/Position from
+// vscode-json-languageservice are used instead so the logic runs headless.
+
+export type PropertyNameASTNode = StringASTNode & { parent: PropertyASTNode };
+export type PropertyValueASTNode = ASTNode & { parent: PropertyASTNode };
+export type ObjectPropertyASTNode = PropertyASTNode & { parent: ObjectASTNode };
+
+export function nodeIsPropertyName(
+	node: ASTNode | undefined,
+): node is PropertyNameASTNode {
+	return node?.parent?.type === "property" && node === node.parent.keyNode;
+}
+
+export function nodeIsPropertyValue(
+	node: ASTNode | undefined,
+): node is PropertyValueASTNode {
+	return node?.parent?.type === "property" && node === node.parent.valueNode;
+}
+
+export function nodeIsPropertyNameOrValue(
+	node: ASTNode | undefined,
+): node is PropertyValueASTNode | PropertyNameASTNode {
+	return node?.parent?.type === "property";
+}
+
+export function getPropertyNameFromNode(
+	node: PropertyValueASTNode | PropertyNameASTNode,
+): string {
+	return node.parent.keyNode.value;
+}
+
+export function getPropertyValueFromNode(
+	node: PropertyValueASTNode | PropertyNameASTNode,
+): string | number | boolean | null | undefined {
+	return node.parent.valueNode?.value;
+}
+
+export function rangeFromNode(document: TextDocument, node: ASTNode): Range {
+	return {
+		start: document.positionAt(node.offset),
+		end: document.positionAt(node.offset + node.length),
+	};
+}
+
+export function tryExpandPropertyRange(
+	document: TextDocument,
+	node: ObjectPropertyASTNode,
+): Range {
+	const siblings = node.parent.properties;
+	if (siblings.length === 1) return rangeFromNode(document, node);
+	const index = siblings.indexOf(node);
+	if (index > 0) {
+		// Select everything from the end of the previous property to the end of this one
+		return {
+			start: document.positionAt(
+				siblings[index - 1].offset + siblings[index - 1].length,
+			),
+			end: document.positionAt(node.offset + node.length),
+		};
+	} else {
+		// Select everything from the start of this property to the start of the next one
+		return {
+			start: document.positionAt(node.offset),
+			end: document.positionAt(siblings[index + 1].offset),
+		};
+	}
+}
+
+export function findSurroundingParamDefinition(
+	node: ASTNode,
+): ObjectASTNode | undefined {
+	while (node.parent) {
+		if (
+			node.type === "object"
+			&& node.parent.type === "array"
+			&& nodeIsPropertyValue(node.parent)
+			&& getPropertyNameFromNode(node.parent) === "paramInformation"
+		) {
+			return node;
+		}
+		node = node.parent;
+	}
+}
+
+export function getPropertyDefinitionFromObject(
+	node: ObjectASTNode,
+	propertyName: string,
+): PropertyASTNode | undefined {
+	return node.properties.find((p) => p.keyNode.value === propertyName);
+}
+
+export function isJSONDifferentToAST(json: unknown, ast: ASTNode): boolean {
+	const jsonType = typeof json === "object"
+		? Array.isArray(json)
+			? "array"
+			: "object"
+		: typeof json;
+
+	// If the property is undefined in the JSON but present in the AST it will return here
+	if (jsonType !== ast.type) {
+		return true;
+	}
+
+	if (isArrayASTNode(ast) && Array.isArray(json)) {
+		if (ast.items.length !== json.length) {
+			return true;
+		}
+
+		for (let i = 0; i < ast.items.length; i++) {
+			if (isJSONDifferentToAST(json[i], ast.items[i])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	if (isObjectASTNode(ast) && typeof json === "object" && json !== null) {
+		if (ast.properties.length !== Object.keys(json).length) {
+			return true;
+		}
+
+		for (const property of ast.properties) {
+			if (!property.valueNode) {
+				return true;
+			}
+
+			if (
+				isJSONDifferentToAST(
+					(json as Record<string, unknown>)[property.keyNode.value],
+					property.valueNode,
+				)
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	return ast.value !== json;
+}
+
+export function isArrayASTNode(node: ASTNode): node is ArrayASTNode {
+	return node.type === "array";
+}
+
+export function isObjectASTNode(node: ASTNode): node is ObjectASTNode {
+	return node.type === "object";
+}
+
+/** Whether position `a` is before or equal to position `b` */
+export function positionBeforeOrEqual(a: Position, b: Position): boolean {
+	if (a.line !== b.line) return a.line < b.line;
+	return a.character <= b.character;
+}
+
+/** Whether the `inner` range lies completely within the `outer` range */
+export function rangeContains(outer: Range, inner: Range): boolean {
+	return positionBeforeOrEqual(outer.start, inner.start)
+		&& positionBeforeOrEqual(inner.end, outer.end);
+}

--- a/packages/mcp-server-dev/src/configDoc/configDocument.ts
+++ b/packages/mcp-server-dev/src/configDoc/configDocument.ts
@@ -1,0 +1,119 @@
+import { resolveTemplateImport } from "@zwave-js/config";
+import { readTextFile } from "@zwave-js/shared";
+import type { ReadFile, ReadFileSystemInfo } from "@zwave-js/shared/bindings";
+import { pathToFileURL } from "node:url";
+import {
+	type ASTNode,
+	type JSONDocument,
+	type SymbolInformation,
+	getLanguageService,
+} from "vscode-json-languageservice";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+	getPropertyValueFromNode,
+	nodeIsPropertyNameOrValue,
+} from "./astUtils.js";
+
+const ls = getLanguageService({});
+
+export interface ParsedSymbols {
+	/** The text document the JSON document is based on */
+	document: TextDocument;
+	/** The parsed JSON document */
+	json: JSONDocument;
+	/** All symbols in the document */
+	symbols: SymbolInformation[];
+}
+
+/** Parses a config/template file's text into a JSON AST and its symbols */
+export function parseSymbols(filename: string, text: string): ParsedSymbols {
+	const document = TextDocument.create(
+		pathToFileURL(filename).toString(),
+		"jsonc",
+		1,
+		text,
+	);
+	const json = ls.parseJSONDocument(document);
+	const symbols = ls.findDocumentSymbols(document, json);
+	return { document, json, symbols };
+}
+
+/**
+ * Headless equivalent of the config editor extension's ConfigDocument: parsed
+ * JSON AST plus the resolved templates referenced via `$import`. Built from a
+ * file on disk instead of a vscode.TextDocument.
+ */
+export class ConfigDocument {
+	public constructor(
+		/** The text document the JSON document is based on */
+		public readonly text: TextDocument,
+		/** The parsed JSON document */
+		public readonly json: JSONDocument,
+		/** Resolved template imports (specifier => template) */
+		public readonly templates: Record<string, Record<string, unknown>>,
+		/** All symbols in the document */
+		public readonly symbols: SymbolInformation[],
+	) {}
+
+	public getNodeFromSymbol(symbol: SymbolInformation): ASTNode | undefined {
+		return this.json.getNodeFromOffset(
+			this.text.offsetAt(symbol.location.range.start),
+		);
+	}
+}
+
+/**
+ * Parses the given config file and resolves all referenced templates.
+ * `text` may be passed to analyze in-memory content instead of reading from
+ * disk (the on-disk file is still used to resolve template imports).
+ */
+export async function parseConfigDocument(
+	fs: ReadFileSystemInfo & ReadFile,
+	filename: string,
+	rootDirs?: string | string[],
+	text?: string,
+): Promise<ConfigDocument> {
+	const fileContent = text ?? await readTextFile(fs, filename, "utf8");
+	const {
+		document: textDoc,
+		json: jsonDoc,
+		symbols,
+	} = parseSymbols(filename, fileContent);
+
+	// Collect the distinct $import specifiers in the document
+	const importSpecifiers = new Set(
+		symbols
+			.filter((s) => s.name === "$import")
+			.map((s) =>
+				jsonDoc.getNodeFromOffset(
+					textDoc.offsetAt(s.location.range.start),
+				)
+			)
+			.filter((n): n is ASTNode => !!n)
+			.map((n) =>
+				nodeIsPropertyNameOrValue(n)
+					? getPropertyValueFromNode(n)
+					: undefined
+			)
+			.filter((s): s is string => typeof s === "string"),
+	);
+
+	const templates: Record<string, Record<string, unknown>> = {};
+	await Promise.all(
+		[...importSpecifiers].map(async (spec) => {
+			try {
+				templates[spec] = await resolveTemplateImport(
+					fs,
+					filename,
+					spec,
+					rootDirs,
+				);
+			} catch {
+				// Unresolvable imports are simply absent from the map; the
+				// diagnostics skip any specifier without a resolved template.
+			}
+		}),
+	);
+
+	return new ConfigDocument(textDoc, jsonDoc, templates, symbols);
+}

--- a/packages/mcp-server-dev/src/configDoc/diagnostics.ts
+++ b/packages/mcp-server-dev/src/configDoc/diagnostics.ts
@@ -1,0 +1,34 @@
+import type { Range } from "vscode-json-languageservice";
+
+// Ported from the zwave-js config editor VS Code extension, with vscode.Range
+// replaced by the framework-agnostic LSP Range.
+
+export enum DiagnosticType {
+	UnnecessaryImportOverride,
+	ImportOverride,
+	AllowedMinMaxConflict,
+}
+
+export type Diagnostic =
+	| UnnecessaryImportOverrideDiagnostic
+	| ImportOverrideDiagnostic
+	| AllowedMinMaxConflictDiagnostic;
+
+export interface UnnecessaryImportOverrideDiagnostic {
+	type: DiagnosticType.UnnecessaryImportOverride;
+	range: Range;
+}
+
+export interface ImportOverrideDiagnostic {
+	type: DiagnosticType.ImportOverride;
+	range: Range;
+	value: any;
+	originalValue: any;
+}
+
+export interface AllowedMinMaxConflictDiagnostic {
+	type: DiagnosticType.AllowedMinMaxConflict;
+	range: Range;
+	localHasAllowed: boolean;
+	templateHasAllowed: boolean;
+}

--- a/packages/mcp-server-dev/src/configDoc/importOverrideDiagnostics.ts
+++ b/packages/mcp-server-dev/src/configDoc/importOverrideDiagnostics.ts
@@ -1,0 +1,179 @@
+import type {
+	ASTNode,
+	PropertyASTNode,
+	SymbolInformation,
+} from "vscode-json-languageservice";
+import {
+	type PropertyNameASTNode,
+	type PropertyValueASTNode,
+	getPropertyNameFromNode,
+	getPropertyValueFromNode,
+	isJSONDifferentToAST,
+	nodeIsPropertyNameOrValue,
+	positionBeforeOrEqual,
+	rangeContains,
+	rangeFromNode,
+} from "./astUtils.js";
+import type { ConfigDocument } from "./configDocument.js";
+import { type Diagnostic, DiagnosticType } from "./diagnostics.js";
+
+// Ported from the config editor VS Code extension. Substitutions vs. the
+// original: ranges stay LSP ranges (no j2vRange), and the vscode.Range/Position
+// methods are replaced by rangeContains()/positionBeforeOrEqual().
+
+type ImportNode = PropertyValueASTNode | PropertyNameASTNode;
+type ImportProperty = readonly [
+	name: string,
+	valueNode: ASTNode | undefined,
+	node: ImportNode,
+];
+
+/**
+ * For each import, pairs the resolved template with the properties that follow
+ * it within the same block, exist in the template, and match `predicate`.
+ * Imports whose template could not be resolved, or that have no matching
+ * property, are dropped.
+ */
+function collectImportOverrides(
+	config: ConfigDocument,
+	importsAndSymbolsAfter:
+		readonly (readonly [ImportNode, SymbolInformation[]])[],
+	predicate: (
+		name: string,
+		resolvedImport: Record<string, unknown>,
+	) => boolean,
+): (readonly [Record<string, unknown>, ImportProperty[]])[] {
+	const ret: (readonly [Record<string, unknown>, ImportProperty[]])[] = [];
+	for (const [imp, symbols] of importsAndSymbolsAfter) {
+		const importSpecifier = getPropertyValueFromNode(imp);
+		if (typeof importSpecifier !== "string") continue;
+		const resolvedImport = config.templates[importSpecifier];
+		if (!resolvedImport) continue;
+
+		const properties = symbols
+			.map((s) => config.getNodeFromSymbol(s))
+			.filter(nodeIsPropertyNameOrValue)
+			.map((n) =>
+				[getPropertyNameFromNode(n), n.parent.valueNode, n] as const
+			)
+			.filter(([name]) => predicate(name, resolvedImport));
+		if (properties.length > 0) ret.push([resolvedImport, properties]);
+	}
+	return ret;
+}
+
+export function generateImportOverrideDiagnostics(
+	config: ConfigDocument,
+): Diagnostic[] {
+	const ret: Diagnostic[] = [];
+
+	const importsInParamInformation = config.symbols
+		.filter(
+			(s) =>
+				s.name === "$import" && s.containerName === "paramInformation",
+		)
+		.map((s) => config.getNodeFromSymbol(s))
+		.filter(nodeIsPropertyNameOrValue);
+
+	const importsAndContainingBlocks = importsInParamInformation
+		.filter(
+			(
+				n,
+			): n is ASTNode & {
+				parent: PropertyASTNode & { parent: ASTNode };
+			} => !!n?.parent?.parent,
+		)
+		.map((n) => [n, n.parent.parent] as const);
+
+	const symbolsInParamInformationWithRanges = config.symbols
+		.filter((s) => s.containerName === "paramInformation")
+		.map((s) => [s, s.location.range] as const);
+
+	const importsAndSymbolsAfter = importsAndContainingBlocks
+		.map(([imp, block]) => {
+			const blockRange = rangeFromNode(config.text, block);
+			const importRange = rangeFromNode(config.text, imp);
+			// We're looking for symbols within the containing block
+			return [
+				imp,
+				symbolsInParamInformationWithRanges
+					.filter(([, r]) => rangeContains(blockRange, r))
+					// but after the import
+					.filter(([, r]) =>
+						positionBeforeOrEqual(importRange.end, r.start)
+					)
+					.map(([s]) => s),
+			] as const;
+		})
+		.filter(([, s]) => s.length > 0);
+
+	const propertiesOverwritingImports = collectImportOverrides(
+		config,
+		importsAndSymbolsAfter,
+		(name, resolvedImport) => name in resolvedImport,
+	);
+
+	for (const [imp, properties] of propertiesOverwritingImports) {
+		for (const [name, valueNode, propNode] of properties) {
+			const originalValue = imp[name];
+
+			if (valueNode && !isJSONDifferentToAST(originalValue, valueNode)) {
+				ret.push({
+					type: DiagnosticType.UnnecessaryImportOverride,
+					range: rangeFromNode(config.text, propNode.parent),
+				});
+			} else {
+				ret.push({
+					type: DiagnosticType.ImportOverride,
+					range: rangeFromNode(config.text, propNode),
+					value: getPropertyValueFromNode(propNode),
+					originalValue,
+				});
+			}
+		}
+	}
+
+	// Check for allowed/minValue-maxValue conflicts across import boundaries
+	const allowedAndMinMaxConflicts = collectImportOverrides(
+		config,
+		importsAndSymbolsAfter,
+		(name, resolvedImport) =>
+			(name === "allowed"
+				&& ("minValue" in resolvedImport
+					|| "maxValue" in resolvedImport))
+			|| ((name === "minValue" || name === "maxValue")
+				&& "allowed" in resolvedImport),
+	);
+
+	for (const [imp, properties] of allowedAndMinMaxConflicts) {
+		for (const [name, , propNode] of properties) {
+			const templateHasMinMax = "minValue" in imp || "maxValue" in imp;
+			const templateHasAllowed = "allowed" in imp;
+
+			// Template has minValue/maxValue, local has allowed -> error on allowed
+			if (templateHasMinMax && name === "allowed") {
+				ret.push({
+					type: DiagnosticType.AllowedMinMaxConflict,
+					range: rangeFromNode(config.text, propNode),
+					localHasAllowed: true,
+					templateHasAllowed: false,
+				});
+			}
+
+			// Template has allowed, local has minValue/maxValue -> error on minValue/maxValue
+			if (
+				templateHasAllowed
+				&& (name === "minValue" || name === "maxValue")
+			) {
+				ret.push({
+					type: DiagnosticType.AllowedMinMaxConflict,
+					range: rangeFromNode(config.text, propNode),
+					localHasAllowed: false,
+					templateHasAllowed: true,
+				});
+			}
+		}
+	}
+
+	return ret;
+}

--- a/packages/mcp-server-dev/src/configEnv.ts
+++ b/packages/mcp-server-dev/src/configEnv.ts
@@ -1,0 +1,16 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Get the repository root (go up from packages/mcp-server-dev/build to root)
+export const REPO_ROOT = resolve(__dirname, "../../..");
+
+// Root directory for device config files. This is the `rootDir` against which
+// `~/`-prefixed `$import` specifiers (e.g. "~/templates/master_template.json")
+// are resolved, matching how the config linter loads device files.
+export const DEVICES_DIR = resolve(REPO_ROOT, "packages/config/config/devices");
+
+// Node.js filesystem binding used by the @zwave-js/config loaders
+export { fs } from "@zwave-js/core/bindings/fs/node";

--- a/packages/mcp-server-dev/src/index.ts
+++ b/packages/mcp-server-dev/src/index.ts
@@ -9,8 +9,12 @@ import {
 import { McpToolRegistry } from "./registry.js";
 import {
 	autofixConfigTool,
+	findTemplateDefinitionTool,
+	findTemplateReferencesTool,
 	formatTool,
 	lintConfigTool,
+	resolveImportTool,
+	resolveParamTool,
 } from "./tools/index.js";
 
 class DevMCPServer {
@@ -40,6 +44,10 @@ class DevMCPServer {
 		this.registry.register(formatTool);
 		this.registry.register(autofixConfigTool);
 		this.registry.register(lintConfigTool);
+		this.registry.register(resolveParamTool);
+		this.registry.register(resolveImportTool);
+		this.registry.register(findTemplateDefinitionTool);
+		this.registry.register(findTemplateReferencesTool);
 	}
 
 	private setupToolHandlers() {

--- a/packages/mcp-server-dev/src/tools/autofixConfig.ts
+++ b/packages/mcp-server-dev/src/tools/autofixConfig.ts
@@ -1,15 +1,17 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { clearTemplateCache } from "@zwave-js/config";
 import spawn from "nano-spawn";
 import { readFile, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import type { ASTNode } from "vscode-json-languageservice";
+import {
+	type ObjectPropertyASTNode,
+	tryExpandPropertyRange,
+} from "../configDoc/astUtils.js";
+import { parseConfigDocument } from "../configDoc/configDocument.js";
+import { DiagnosticType } from "../configDoc/diagnostics.js";
+import { generateImportOverrideDiagnostics } from "../configDoc/importOverrideDiagnostics.js";
+import { DEVICES_DIR, REPO_ROOT, fs } from "../configEnv.js";
 import type { ToolHandler } from "../types.js";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-// Get the repository root (go up from packages/mcp-server-dev/build/tools to root)
-const REPO_ROOT = resolve(__dirname, "../../../..");
 
 export const TOOL_NAME = "autofix_config";
 
@@ -51,26 +53,15 @@ interface AutofixConfigArgs {
 	filename: string;
 }
 
-async function handleAutofixConfig(
-	args: AutofixConfigArgs,
-): Promise<CallToolResult> {
-	const { filename } = args;
-
-	if (!filename) {
-		return {
-			content: [
-				{
-					type: "text",
-					text: "Error: filename argument is required",
-				},
-			],
-			isError: true,
-		};
-	}
-
+/**
+ * Runs ESLint with `--fix`, then applies the first suggestion of each
+ * remaining error (these are typically produced by the custom @zwave-js/...
+ * rules). Returns a human-readable description of each applied suggestion.
+ */
+async function applyEslintFixes(filename: string): Promise<string[]> {
 	let eslintResult;
 	try {
-		// Run ESLint on the file and apply all fixes that ESLint can apply automatically
+		// ESLint already writes its own auto-fixes to disk here
 		eslintResult = await spawn(
 			"yarn",
 			[
@@ -89,7 +80,7 @@ async function handleAutofixConfig(
 			},
 		);
 	} catch (error: any) {
-		// ESLint returns non-zero exit code when there are issues,
+		// ESLint returns a non-zero exit code when there are issues,
 		// but we still want to parse the output
 		eslintResult = error;
 	}
@@ -98,32 +89,17 @@ async function handleAutofixConfig(
 	try {
 		results = JSON.parse(eslintResult.stdout);
 	} catch (parseError) {
-		return {
-			content: [
-				{
-					type: "text",
-					text: `Failed to parse ESLint output: ${
-						String(parseError)
-					}\n\nRaw output:\n${eslintResult.stdout}\n\nStderr:\n${eslintResult.stderr}`,
-				},
-			],
-			isError: true,
-		};
+		throw new Error(
+			`Failed to parse ESLint output: ${
+				String(parseError)
+			}\n\nRaw output:\n${eslintResult.stdout}\n\nStderr:\n${eslintResult.stderr}`,
+		);
 	}
 
-	if (!results || results.length === 0) {
-		return {
-			content: [
-				{
-					type: "text",
-					text: "No ESLint results found for the file.",
-				},
-			],
-		};
-	}
+	if (!results || results.length === 0) return [];
 
-	// Now find all messages that have suggestions, which are likely created by @zwave-js/... rules
-	// and apply those suggestions to the file
+	// Find all messages that have suggestions, which are likely created by
+	// @zwave-js/... rules, and apply those suggestions to the file
 	const fileResult = results[0];
 	const errorsWithSuggestions = fileResult.messages.filter(
 		(msg) =>
@@ -132,41 +108,24 @@ async function handleAutofixConfig(
 			&& msg.suggestions.length > 0,
 	);
 
-	if (errorsWithSuggestions.length === 0) {
-		return {
-			content: [
-				{
-					type: "text",
-					text:
-						`No fixable errors found. Total messages: ${fileResult.messages.length}`,
-				},
-			],
-		};
-	}
+	if (errorsWithSuggestions.length === 0) return [];
 
-	// Read the original file
 	const originalContent = await readFile(filename, "utf-8");
 
 	// Sort errors by position (last to first) to avoid range shifting
 	errorsWithSuggestions.sort((a, b) => {
-		if (a.line !== b.line) {
-			return b.line - a.line;
-		}
+		if (a.line !== b.line) return b.line - a.line;
 		return b.column - a.column;
 	});
 
 	let modifiedContent = originalContent;
 	const appliedFixes: string[] = [];
 
-	// Apply fixes from last to first
 	for (const error of errorsWithSuggestions) {
 		const suggestion = error.suggestions![0]; // Use the first suggestion
 		const [start, end] = suggestion.fix.range;
-		const fixText = suggestion.fix.text;
-
-		// Apply the fix
 		modifiedContent = modifiedContent.slice(0, start)
-			+ fixText
+			+ suggestion.fix.text
 			+ modifiedContent.slice(end);
 
 		appliedFixes.push(
@@ -174,25 +133,172 @@ async function handleAutofixConfig(
 		);
 	}
 
-	// Write the modified content back to the file
 	await writeFile(filename, modifiedContent, "utf-8");
+	return appliedFixes;
+}
+
+/**
+ * Deletes properties that redundantly re-state an imported template's value
+ * (the config editor's "Remove unnecessary override" quick fix). Returns the
+ * number of properties removed.
+ *
+ * @param filename Absolute path to the device config file to fix
+ */
+async function removeUnnecessaryOverrides(filename: string): Promise<number> {
+	let text = await readFile(filename, "utf8");
+
+	// Read templates fresh from disk, then resolve the whole file once
+	clearTemplateCache();
+	const doc = await parseConfigDocument(fs, filename, DEVICES_DIR, text);
+
+	// Collect the text range to delete for each unnecessary override. The
+	// diagnostic only ever flags direct param properties that follow their
+	// `$import`, so tryExpandPropertyRange always extends backwards to the
+	// preceding comma and the resulting ranges are mutually disjoint.
+	const ranges: { start: number; end: number }[] = [];
+	for (const diag of generateImportOverrideDiagnostics(doc)) {
+		if (diag.type !== DiagnosticType.UnnecessaryImportOverride) continue;
+
+		const node: ASTNode | undefined = doc.json.getNodeFromOffset(
+			doc.text.offsetAt(diag.range.start),
+		);
+		const propNode = node?.parent;
+		if (!propNode || propNode.type !== "property") continue;
+
+		const range = tryExpandPropertyRange(
+			doc.text,
+			propNode as ObjectPropertyASTNode,
+		);
+		ranges.push({
+			start: doc.text.offsetAt(range.start),
+			end: doc.text.offsetAt(range.end),
+		});
+	}
+
+	// Delete back to front so each removal leaves the earlier offsets intact
+	ranges.sort((a, b) => b.start - a.start);
+	for (const { start, end } of ranges) {
+		text = text.slice(0, start) + text.slice(end);
+	}
+
+	if (ranges.length > 0) await writeFile(filename, text, "utf8");
+	return ranges.length;
+}
+
+/**
+ * Returns the import-override issues that cannot be fixed automatically and
+ * require manual attention (allowed vs. minValue/maxValue conflicts across an
+ * import boundary). These are flagged by the config editor but not by ESLint.
+ *
+ * @param filename Absolute path to the device config file to check
+ */
+async function remainingImportOverrideIssues(
+	filename: string,
+): Promise<string[]> {
+	clearTemplateCache();
+	const doc = await parseConfigDocument(fs, filename, DEVICES_DIR);
+	const issues: { message: string; line: number; column: number }[] = [];
+
+	for (const diag of generateImportOverrideDiagnostics(doc)) {
+		if (diag.type !== DiagnosticType.AllowedMinMaxConflict) continue;
+		issues.push({
+			message: diag.localHasAllowed
+				? `The "allowed" field cannot be used when the imported template defines "minValue" or "maxValue".`
+				: `"minValue"/"maxValue" cannot be used when the imported template defines "allowed".`,
+			line: diag.range.start.line + 1,
+			column: diag.range.start.character + 1,
+		});
+	}
+
+	issues.sort((a, b) => a.line - b.line || a.column - b.column);
+	return issues.map(
+		(i) => `${i.message} (line ${i.line}, column ${i.column})`,
+	);
+}
+
+async function handleAutofixConfig(
+	args: AutofixConfigArgs,
+): Promise<CallToolResult> {
+	const { filename } = args;
+
+	if (!filename) {
+		return {
+			content: [
+				{ type: "text", text: "Error: filename argument is required" },
+			],
+			isError: true,
+		};
+	}
+
+	let eslintFixes: string[];
+	try {
+		eslintFixes = await applyEslintFixes(filename);
+	} catch (error: any) {
+		return {
+			content: [{ type: "text", text: String(error.message ?? error) }],
+			isError: true,
+		};
+	}
+
+	let removedOverrides: number;
+	let remainingIssues: string[];
+	try {
+		removedOverrides = await removeUnnecessaryOverrides(filename);
+		remainingIssues = await remainingImportOverrideIssues(filename);
+	} catch (error: any) {
+		return {
+			content: [
+				{
+					type: "text",
+					text: `Failed to fix import overrides in ${filename}: ${
+						String(error)
+					}`,
+				},
+			],
+			isError: true,
+		};
+	}
+
+	const sections: string[] = [];
+	if (eslintFixes.length > 0) {
+		sections.push(
+			`Applied ${eslintFixes.length} ESLint fix${
+				eslintFixes.length === 1 ? "" : "es"
+			}:\n${eslintFixes.join("\n")}`,
+		);
+	}
+	if (removedOverrides > 0) {
+		sections.push(
+			`Removed ${removedOverrides} unnecessary import override${
+				removedOverrides === 1 ? "" : "s"
+			}.`,
+		);
+	}
+	if (sections.length === 0) {
+		sections.push(`No automatic fixes were necessary in ${filename}.`);
+	}
+	if (remainingIssues.length > 0) {
+		sections.push(
+			`Import-override issues requiring manual attention:\n${
+				remainingIssues.map((i) => `- ${i}`).join("\n")
+			}`,
+		);
+	}
 
 	return {
-		content: [
-			{
-				type: "text",
-				text:
-					`Applied ${appliedFixes.length} automatic fixes to ${filename}:\n\n${
-						appliedFixes.join("\n")
-					}`,
-			},
-		],
+		content: [{ type: "text", text: sections.join("\n\n") }],
+		// Surface unfixable conflicts as an error so they aren't missed
+		isError: remainingIssues.length > 0,
 	};
 }
 
 export const autofixConfigTool: ToolHandler<AutofixConfigArgs> = {
 	name: TOOL_NAME,
-	description: "Automatically fix ESLint errors in a configuration file",
+	description:
+		"Automatically fix a device config file: apply ESLint fixes, remove "
+		+ "unnecessary overrides of imported template properties, and report any "
+		+ "remaining import-override conflicts (allowed vs. minValue/maxValue) "
+		+ "that must be resolved manually.",
 	inputSchema: {
 		type: "object",
 		properties: {

--- a/packages/mcp-server-dev/src/tools/findTemplateDefinition.ts
+++ b/packages/mcp-server-dev/src/tools/findTemplateDefinition.ts
@@ -1,0 +1,142 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { clearTemplateCache, resolveImportPath } from "@zwave-js/config";
+import { tryParseParamNumber } from "@zwave-js/core";
+import { parse as parseJsonC } from "jsonc-parser";
+import { readFile } from "node:fs/promises";
+import { parseSymbols } from "../configDoc/configDocument.js";
+import { DEVICES_DIR, fs } from "../configEnv.js";
+import type { ToolHandler } from "../types.js";
+import { errorResult, textResult } from "./results.js";
+
+export const TOOL_NAME = "find_template_definition";
+
+interface FindTemplateDefinitionArgs {
+	filename: string;
+	specifier?: string;
+	parameter?: number;
+}
+
+/** Reads the raw `$import` specifier of a parameter (first matching variant) */
+async function findParamImport(
+	filename: string,
+	parameter: number,
+): Promise<string | undefined> {
+	const text = await readFile(filename, "utf8");
+	const json = parseJsonC(text);
+	const params = json?.paramInformation;
+	if (!Array.isArray(params)) return undefined;
+
+	for (const p of params) {
+		if (typeof p !== "object" || p === null) continue;
+		const key = (p as Record<string, unknown>)["#"];
+		if (typeof key !== "string") continue;
+		if (tryParseParamNumber(key)?.parameter !== parameter) continue;
+		const imp = (p as Record<string, unknown>)["$import"];
+		if (typeof imp === "string") return imp;
+	}
+	return undefined;
+}
+
+async function handleFindTemplateDefinition(
+	args: FindTemplateDefinitionArgs,
+): Promise<CallToolResult> {
+	const { filename, parameter } = args;
+	let { specifier } = args;
+
+	if (!filename) return errorResult("Error: filename argument is required");
+
+	clearTemplateCache();
+
+	try {
+		if (!specifier && parameter != undefined) {
+			specifier = await findParamImport(filename, parameter);
+			if (!specifier) {
+				return errorResult(
+					`Parameter #${parameter} in ${filename} has no $import to navigate to.`,
+				);
+			}
+		}
+		if (!specifier) {
+			return errorResult(
+				"Error: provide either a specifier or a parameter that uses $import",
+			);
+		}
+
+		const targetFile = await resolveImportPath(
+			fs,
+			filename,
+			specifier,
+			DEVICES_DIR,
+		);
+		if (!targetFile) {
+			return errorResult(
+				`Could not locate the file referenced by "${specifier}".`,
+			);
+		}
+
+		const hashIndex = specifier.indexOf("#");
+		const templateKey = hashIndex >= 0
+			? specifier.slice(hashIndex + 1)
+			: undefined;
+
+		if (!templateKey) {
+			return textResult(
+				`${targetFile}:1:1\n(specifier has no #key, points at the whole file)`,
+			);
+		}
+
+		const text = await readFile(targetFile, "utf8");
+		const { symbols } = parseSymbols(targetFile, text);
+		const symbol = symbols.find((s) => s.name === templateKey);
+
+		if (!symbol) {
+			return textResult(
+				`${targetFile}:1:1\n(file resolved, but template "${templateKey}" was not found in it)`,
+			);
+		}
+
+		const { line, character } = symbol.location.range.start;
+		return textResult(
+			`${targetFile}:${line + 1}:${character + 1}\n`
+				+ `Definition of "${templateKey}"`,
+		);
+	} catch (error: any) {
+		return errorResult(
+			`Failed to find template definition: ${String(error)}`,
+		);
+	}
+}
+
+export const findTemplateDefinitionTool: ToolHandler<
+	FindTemplateDefinitionArgs
+> = {
+	name: TOOL_NAME,
+	description:
+		"Navigate to where an imported template is defined. Given a config file "
+		+ "and either an $import specifier or a parameter number that uses "
+		+ "$import, returns the target file and the line/column of the "
+		+ "definition (file start if the specifier has no #key).",
+	inputSchema: {
+		type: "object",
+		properties: {
+			filename: {
+				type: "string",
+				description:
+					"Absolute path to the config file the import appears in",
+			},
+			specifier: {
+				type: "string",
+				description: "The $import specifier to resolve, e.g. "
+					+ "\"~/templates/master_template.json#base_enable_disable\"",
+			},
+			parameter: {
+				type: "number",
+				description:
+					"Alternatively, a parameter number whose $import should be "
+					+ "resolved (used when specifier is omitted)",
+			},
+		},
+		required: ["filename"],
+	},
+	handler: handleFindTemplateDefinition,
+};

--- a/packages/mcp-server-dev/src/tools/findTemplateReferences.ts
+++ b/packages/mcp-server-dev/src/tools/findTemplateReferences.ts
@@ -1,0 +1,136 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { clearTemplateCache, resolveImportPath } from "@zwave-js/config";
+import { readFile, readdir } from "node:fs/promises";
+import { join, normalize, resolve } from "node:path";
+import PQueue from "p-queue";
+import {
+	getPropertyValueFromNode,
+	nodeIsPropertyNameOrValue,
+} from "../configDoc/astUtils.js";
+import { parseSymbols } from "../configDoc/configDocument.js";
+import { DEVICES_DIR, fs } from "../configEnv.js";
+import type { ToolHandler } from "../types.js";
+import { errorResult, textResult } from "./results.js";
+
+export const TOOL_NAME = "find_template_references";
+
+interface FindTemplateReferencesArgs {
+	templateFile: string;
+	templateName: string;
+}
+
+/** Lists all `.json` files below the devices directory */
+async function listConfigFiles(): Promise<string[]> {
+	const relative = await readdir(DEVICES_DIR, { recursive: true });
+	return relative
+		.filter((f) => f.endsWith(".json"))
+		.map((f) => join(DEVICES_DIR, f));
+}
+
+async function handleFindTemplateReferences(
+	args: FindTemplateReferencesArgs,
+): Promise<CallToolResult> {
+	const { templateName } = args;
+	if (!args.templateFile) {
+		return errorResult("Error: templateFile argument is required");
+	}
+	if (!templateName) {
+		return errorResult("Error: templateName argument is required");
+	}
+	const templateFile = normalize(resolve(args.templateFile));
+
+	clearTemplateCache();
+
+	try {
+		const files = await listConfigFiles();
+		const refs: { file: string; line: number; column: number }[] = [];
+
+		// Reading and parsing the whole device corpus dominates the runtime,
+		// so process the files concurrently
+		const queue = new PQueue({ concurrency: 32 });
+		await queue.addAll(files.map((file) => async () => {
+			const text = await readFile(file, "utf8");
+			// Cheap pre-filter: skip files that can't reference the template
+			if (!text.includes(templateName)) return;
+
+			const { document, json, symbols } = parseSymbols(file, text);
+			for (const s of symbols) {
+				if (s.name !== "$import") continue;
+
+				const node = json.getNodeFromOffset(
+					document.offsetAt(s.location.range.start),
+				);
+				if (!nodeIsPropertyNameOrValue(node)) continue;
+				const value = getPropertyValueFromNode(node);
+				if (typeof value !== "string") continue;
+
+				// The selector must match the template name we're looking for
+				const hashIndex = value.indexOf("#");
+				if (hashIndex < 0) continue;
+				if (value.slice(hashIndex + 1) !== templateName) continue;
+
+				// ...and the import must resolve to the template file
+				const target = await resolveImportPath(
+					fs,
+					file,
+					value,
+					DEVICES_DIR,
+				);
+				if (!target || normalize(target) !== templateFile) continue;
+
+				refs.push({
+					file,
+					line: s.location.range.start.line + 1,
+					column: s.location.range.start.character + 1,
+				});
+			}
+		}));
+
+		if (refs.length === 0) {
+			return textResult(
+				`No references to "${templateName}" (${templateFile}) found.`,
+			);
+		}
+
+		refs.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+		return textResult(
+			`${refs.length} reference${
+				refs.length === 1 ? "" : "s"
+			} to "${templateName}":\n\n`
+				+ refs
+					.map((r) => `${r.file}:${r.line}:${r.column}`)
+					.join("\n"),
+		);
+	} catch (error: any) {
+		return errorResult(`Failed to find references: ${String(error)}`);
+	}
+}
+
+export const findTemplateReferencesTool: ToolHandler<
+	FindTemplateReferencesArgs
+> = {
+	name: TOOL_NAME,
+	description:
+		"Find all $import references to a template across every device config "
+		+ "file. Given the template file and the top-level template name, "
+		+ "returns each importing file with its line/column.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			templateFile: {
+				type: "string",
+				description:
+					"Absolute path to the template file defining the template, "
+					+ "e.g. .../config/devices/templates/master_template.json",
+			},
+			templateName: {
+				type: "string",
+				description:
+					"The top-level template key to find references to, e.g. "
+					+ "\"base_enable_disable\"",
+			},
+		},
+		required: ["templateFile", "templateName"],
+	},
+	handler: handleFindTemplateReferences,
+};

--- a/packages/mcp-server-dev/src/tools/format.ts
+++ b/packages/mcp-server-dev/src/tools/format.ts
@@ -1,14 +1,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import spawn from "nano-spawn";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { REPO_ROOT } from "../configEnv.js";
 import type { ToolHandler } from "../types.js";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-// Get the repository root (go up from packages/mcp-server-dev/build/tools to root)
-const REPO_ROOT = resolve(__dirname, "../../../..");
 
 export const TOOL_NAME = "format";
 

--- a/packages/mcp-server-dev/src/tools/index.ts
+++ b/packages/mcp-server-dev/src/tools/index.ts
@@ -1,3 +1,7 @@
 export { autofixConfigTool } from "./autofixConfig.js";
+export { findTemplateDefinitionTool } from "./findTemplateDefinition.js";
+export { findTemplateReferencesTool } from "./findTemplateReferences.js";
 export { formatTool } from "./format.js";
 export { lintConfigTool } from "./lintConfig.js";
+export { resolveImportTool } from "./resolveImport.js";
+export { resolveParamTool } from "./resolveParam.js";

--- a/packages/mcp-server-dev/src/tools/lintConfig.ts
+++ b/packages/mcp-server-dev/src/tools/lintConfig.ts
@@ -1,15 +1,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import spawn from "nano-spawn";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { REPO_ROOT } from "../configEnv.js";
 import type { ToolHandler } from "../types.js";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-// Get the repository root (go up from packages/mcp-server-dev/build/tools to root)
-const REPO_ROOT = resolve(__dirname, "../../../..");
-// const CONFIG_PACKAGE_DIR = resolve(REPO_ROOT, "packages/config");
 
 export const TOOL_NAME = "lint_config";
 

--- a/packages/mcp-server-dev/src/tools/resolveImport.ts
+++ b/packages/mcp-server-dev/src/tools/resolveImport.ts
@@ -1,0 +1,62 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { clearTemplateCache, resolveTemplateImport } from "@zwave-js/config";
+import { DEVICES_DIR, fs } from "../configEnv.js";
+import type { ToolHandler } from "../types.js";
+import { errorResult, jsonResult } from "./results.js";
+
+export const TOOL_NAME = "resolve_config_import";
+
+interface ResolveConfigImportArgs {
+	filename: string;
+	specifier: string;
+}
+
+async function handleResolveConfigImport(
+	args: ResolveConfigImportArgs,
+): Promise<CallToolResult> {
+	const { filename, specifier } = args;
+
+	if (!filename) return errorResult("Error: filename argument is required");
+	if (!specifier) return errorResult("Error: specifier argument is required");
+
+	// Read files fresh so edits between calls are not served from the cache
+	clearTemplateCache();
+
+	try {
+		const resolved = await resolveTemplateImport(
+			fs,
+			filename,
+			specifier,
+			DEVICES_DIR,
+		);
+		return jsonResult(resolved);
+	} catch (error: any) {
+		return errorResult(`Failed to resolve import: ${String(error)}`);
+	}
+}
+
+export const resolveImportTool: ToolHandler<ResolveConfigImportArgs> = {
+	name: TOOL_NAME,
+	description:
+		"Resolve an $import specifier to the JSON it pulls in, with the "
+		+ "imported file's own $imports resolved recursively. Mirrors the config "
+		+ "editor's import hover preview.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			filename: {
+				type: "string",
+				description:
+					"Absolute path to the config file the $import appears in "
+					+ "(used to resolve relative and same-file imports)",
+			},
+			specifier: {
+				type: "string",
+				description: "The $import specifier, e.g. "
+					+ "\"~/templates/master_template.json#base_enable_disable\"",
+			},
+		},
+		required: ["filename", "specifier"],
+	},
+	handler: handleResolveConfigImport,
+};

--- a/packages/mcp-server-dev/src/tools/resolveParam.ts
+++ b/packages/mcp-server-dev/src/tools/resolveParam.ts
@@ -1,0 +1,141 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+	DeviceConfig,
+	clearTemplateCache,
+	readJsonWithTemplate,
+} from "@zwave-js/config";
+import { tryParseParamNumber } from "@zwave-js/core";
+import { num2hex } from "@zwave-js/shared";
+import { parse as parseJsonC } from "jsonc-parser";
+import { readFile } from "node:fs/promises";
+import { DEVICES_DIR, fs } from "../configEnv.js";
+import type { ToolHandler } from "../types.js";
+import { errorResult, jsonResult } from "./results.js";
+
+export const TOOL_NAME = "resolve_config_param";
+
+interface ResolveConfigParamArgs {
+	filename: string;
+	parameter: number;
+	valueBitMask?: number;
+	firmwareVersion?: string;
+}
+
+function paramLabel(parameter: number, valueBitMask?: number): string {
+	return `#${parameter}${
+		valueBitMask != undefined ? ` [${num2hex(valueBitMask)}]` : ""
+	}`;
+}
+
+async function handleResolveConfigParam(
+	args: ResolveConfigParamArgs,
+): Promise<CallToolResult> {
+	const { filename, parameter, valueBitMask, firmwareVersion } = args;
+
+	if (!filename) return errorResult("Error: filename argument is required");
+	if (typeof parameter !== "number") {
+		return errorResult("Error: parameter (number) argument is required");
+	}
+
+	// Read files fresh so edits between calls are not served from the cache
+	clearTemplateCache();
+
+	try {
+		if (firmwareVersion != undefined) {
+			// Resolve templates AND evaluate $if conditionals for the given firmware.
+			// The device IDs are plain top-level fields, so read them from the raw
+			// JSON instead of resolving templates a second time before DeviceConfig.from
+			const raw = parseJsonC(await readFile(filename, "utf8"));
+			const firstDevice = (raw?.devices as any[] | undefined)?.[0];
+			const deviceId = {
+				manufacturerId: Number(raw?.manufacturerId),
+				productType: Number(firstDevice?.productType),
+				productId: Number(firstDevice?.productId),
+				firmwareVersion,
+			};
+			const config = await DeviceConfig.from(fs, filename, true, {
+				rootDir: DEVICES_DIR,
+				deviceId,
+			});
+			const matches = [...(config.paramInformation?.values() ?? [])]
+				.filter((p) =>
+					p.parameterNumber === parameter
+					&& (valueBitMask == undefined
+						|| p.valueBitMask === valueBitMask)
+				);
+			if (matches.length === 0) {
+				return errorResult(
+					`No parameter ${
+						paramLabel(parameter, valueBitMask)
+					} found in ${filename} for firmware ${firmwareVersion}.`,
+				);
+			}
+			return jsonResult(matches.length === 1 ? matches[0] : matches);
+		} else {
+			// Templates only, conditionals preserved (matches the editor preview)
+			const json = await readJsonWithTemplate(fs, filename, DEVICES_DIR);
+			const params = json.paramInformation;
+			if (!Array.isArray(params)) {
+				return errorResult(
+					`${filename} has no paramInformation array.`,
+				);
+			}
+			const matches = params.filter((p) => {
+				if (typeof p !== "object" || p === null) return false;
+				const key = (p as Record<string, unknown>)["#"];
+				if (typeof key !== "string") return false;
+				const parsed = tryParseParamNumber(key);
+				return parsed?.parameter === parameter
+					&& (valueBitMask == undefined
+						|| parsed.valueBitMask === valueBitMask);
+			});
+			if (matches.length === 0) {
+				return errorResult(
+					`No parameter ${
+						paramLabel(parameter, valueBitMask)
+					} found in ${filename}.`,
+				);
+			}
+			return jsonResult(matches.length === 1 ? matches[0] : matches);
+		}
+	} catch (error: any) {
+		return errorResult(`Failed to resolve parameter: ${String(error)}`);
+	}
+}
+
+export const resolveParamTool: ToolHandler<ResolveConfigParamArgs> = {
+	name: TOOL_NAME,
+	description:
+		"Resolve a device config parameter to its canonical JSON, with all "
+		+ "$import templates applied. By default conditionals ($if) are kept "
+		+ "as-is (matching the config editor preview); pass firmwareVersion to "
+		+ "fully evaluate conditionals for a specific firmware. Returns all "
+		+ "matching parameter variants when more than one exists.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			filename: {
+				type: "string",
+				description: "Absolute path to the device config file",
+			},
+			parameter: {
+				type: "number",
+				description: "The parameter number to resolve",
+			},
+			valueBitMask: {
+				type: "number",
+				description:
+					"Optional value bitmask for partial parameters (as a number, "
+					+ "e.g. 255 for 0xff)",
+			},
+			firmwareVersion: {
+				type: "string",
+				description:
+					"Optional firmware version (e.g. \"1.5\") to fully evaluate "
+					+ "$if conditionals instead of preserving them",
+			},
+		},
+		required: ["filename", "parameter"],
+	},
+	handler: handleResolveConfigParam,
+};

--- a/packages/mcp-server-dev/src/tools/results.ts
+++ b/packages/mcp-server-dev/src/tools/results.ts
@@ -1,0 +1,15 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export function errorResult(text: string): CallToolResult {
+	return { content: [{ type: "text", text }], isError: true };
+}
+
+export function textResult(text: string): CallToolResult {
+	return { content: [{ type: "text", text }] };
+}
+
+export function jsonResult(value: unknown): CallToolResult {
+	return {
+		content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+	};
+}

--- a/packages/mcp-server-dev/tsconfig.json
+++ b/packages/mcp-server-dev/tsconfig.json
@@ -4,6 +4,17 @@
 		"outDir": "./build",
 		"rootDir": "./src"
 	},
+	"references": [
+		{
+			"path": "../config/tsconfig.build.json"
+		},
+		{
+			"path": "../core/tsconfig.build.json"
+		},
+		{
+			"path": "../shared/tsconfig.build.json"
+		}
+	],
 	"include": [
 		"src/**/*"
 	],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,6 +2952,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vscode/l10n@npm:^0.0.18":
+  version: 0.0.18
+  resolution: "@vscode/l10n@npm:0.0.18"
+  checksum: 10/82e2d02ab28d1733340c3c8829ee39dfb40a7a6637bf3fc71b0d1a74f2d46cf35f551dacd18c34832d377fe8717ecc2f3d196e3d1c64fca1e55751ce67273daf
+  languageName: node
+  linkType: hard
+
 "@zwave-js/bindings-browser@workspace:*, @zwave-js/bindings-browser@workspace:^, @zwave-js/bindings-browser@workspace:packages/bindings-browser":
   version: 0.0.0-use.local
   resolution: "@zwave-js/bindings-browser@workspace:packages/bindings-browser"
@@ -3166,7 +3173,14 @@ __metadata:
     "@modelcontextprotocol/sdk": "npm:^1.29.0"
     "@types/node": "npm:^20.19.35"
     "@typescript/native-preview": "npm:7.0.0-dev.20260423.1"
+    "@zwave-js/config": "workspace:*"
+    "@zwave-js/core": "workspace:*"
+    "@zwave-js/shared": "workspace:*"
+    jsonc-parser: "npm:^3.2.0"
     nano-spawn: "npm:^2.1.0"
+    p-queue: "npm:^9.1.0"
+    vscode-json-languageservice: "npm:^5.1.3"
+    vscode-languageserver-textdocument: "npm:^1.0.13"
   bin:
     zwave-dev-mcp: ./build/index.js
   languageName: unknown
@@ -6399,7 +6413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:^3.3.1":
+"jsonc-parser@npm:^3.2.0, jsonc-parser@npm:^3.3.1":
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
@@ -9610,6 +9624,40 @@ __metadata:
   bin:
     vitest: vitest.mjs
   checksum: 10/6c6464ebcf3af83546862896fd1b5f10cb6607261bffce39df60033a288b8c1687ae1dd20002b6e4997a7a05303376d1eb58ce20afe63be052529a4378a8c165
+  languageName: node
+  linkType: hard
+
+"vscode-json-languageservice@npm:^5.1.3":
+  version: 5.7.2
+  resolution: "vscode-json-languageservice@npm:5.7.2"
+  dependencies:
+    "@vscode/l10n": "npm:^0.0.18"
+    jsonc-parser: "npm:^3.3.1"
+    vscode-languageserver-textdocument: "npm:^1.0.12"
+    vscode-languageserver-types: "npm:^3.17.5"
+    vscode-uri: "npm:^3.1.0"
+  checksum: 10/547ed5173a43dba0b75e24d66f3e7a956776be7f4f4b04b793659b4cda5ec13d8bff23efa1e762eba854ef77d5c0ec005f519e18d86eafa32db843ea60661316
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-textdocument@npm:^1.0.12, vscode-languageserver-textdocument@npm:^1.0.13":
+  version: 1.0.13
+  resolution: "vscode-languageserver-textdocument@npm:1.0.13"
+  checksum: 10/0962cd125e932d81f18667eb5048da34b93f9060c3f7bc808138ead7741d1672bcebe638e4dd3634398b0ab0175c1d1e58ad5c418ee7afed30717c20c788354b
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-types@npm:^3.17.5":
+  version: 3.18.0
+  resolution: "vscode-languageserver-types@npm:3.18.0"
+  checksum: 10/7a0c61005e863b291cca864a96c81dd4281468ae88c0d60048b7c1445ed7842f9ad627a05d14adc6c4f8fa221b1f803184e6be81e6d50bb4692320f549ed973a
+  languageName: node
+  linkType: hard
+
+"vscode-uri@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "vscode-uri@npm:3.1.0"
+  checksum: 10/80c2a2421f44b64008ef1f91dfa52a2d68105cbb4dcea197dbf5b00c65ccaccf218b615e93ec587f26fc3ba04796898f3631a9406e3b04cda970c3ca8eadf646
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR ports some tools from the VSCode extension to the local MCP server, giving AI agents a better understanding of templates and templated config parameters.