### PR TITLE
fix: treat S2 command with next  expected sequence number as delivery verification

### DIFF
--- a/packages/core/src/security/Manager2.ts
+++ b/packages/core/src/security/Manager2.ts
@@ -309,6 +309,18 @@ export class SecurityManager2 {
 		);
 	}
 
+	/**
+	 * Returns the sequence number that is expected for the next message received from the given peer node ID,
+	 * or `undefined` if no message has been received yet.
+	 */
+	public getNextPeerSequenceNumber(peerNodeId: number): number | undefined {
+		const lastSequenceNumber = this.peerSequenceNumbers
+			.get(peerNodeId)
+			?.at(-1);
+		if (lastSequenceNumber == undefined) return undefined;
+		return (lastSequenceNumber + 1) & 0xff;
+	}
+
 	/** Stores the latest sequence number for the given peer node ID and returns the previous one */
 	public storeSequenceNumber(
 		peerNodeId: number,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -667,18 +667,30 @@ interface AwaitedThing<T> {
 	timeout?: Timer;
 	predicate: (msg: T) => boolean;
 	refreshPredicate?: (msg: T) => boolean;
+	/** Whether a matching thing is consumed (default) or only observed. */
+	consume?: boolean;
 }
 
 type AwaitedMessageHeader = AwaitedThing<MessageHeaders>;
 type AwaitedMessageEntry = AwaitedThing<Message>;
 type AwaitedCommandEntry = AwaitedThing<CCId>;
-type AwaitedS2MessageEntry = AwaitedThing<Security2CCMessageEncapsulation>;
 type AwaitedCLIChunkEntry = AwaitedThing<CLIChunk>;
 export type AwaitedBootloaderChunkEntry = AwaitedThing<BootloaderChunk>;
+
 type AwaitedIdleEntry = Omit<
 	AwaitedThing<void>,
 	"predicate" | "refreshPredicate"
 >;
+
+interface WaitForCommandOptions {
+	/**
+	 * Whether a matching command is consumed (default) or only observed.
+	 * When `false`, the predicate is additionally tested against the command
+	 * before encapsulation is unwrapped (so it can inspect e.g. the S2 sequence
+	 * number), and the command is still handled normally afterwards.
+	 */
+	consume?: boolean;
+}
 
 interface TransportServiceSession {
 	machine: TransportServiceRXMachine;
@@ -1077,11 +1089,6 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 	private awaitedMessages: AwaitedMessageEntry[] = [];
 	/** A list of awaited commands */
 	private awaitedCommands: AwaitedCommandEntry[] = [];
-	/**
-	 * A list of awaited S2-encapsulated messages. Unlike {@link awaitedCommands},
-	 * these are tested against the still-encapsulated command and do not consume it.
-	 */
-	private awaitedS2Messages: AwaitedS2MessageEntry[] = [];
 	/** A list of awaited chunks from the bootloader */
 	private awaitedBootloaderChunks: AwaitedBootloaderChunkEntry[] = [];
 	/** A list of awaited chunks from the end device CLI */
@@ -5885,14 +5892,13 @@ ${handlers.length} left`,
 				return;
 			}
 
-			// Notify observers waiting for a specific S2-encapsulated message before
-			// we unwrap it. This is used to verify successful delivery of a previous
-			// command without consuming the message, so it is still handled normally.
-			if (msg.command instanceof Security2CCMessageEncapsulation) {
-				for (const entry of this.awaitedS2Messages) {
-					if (entry.predicate(msg.command)) {
-						entry.handler(msg.command);
-					}
+			// Notify non-consuming observers before unwrapping, so their predicate can
+			// inspect the command as received (e.g. encapsulation details like the S2
+			// sequence number). These do not consume the command, so it is still
+			// handled normally afterwards.
+			for (const entry of this.awaitedCommands) {
+				if (entry.consume === false && entry.predicate(msg.command)) {
+					entry.handler(msg.command);
 				}
 			}
 
@@ -6058,6 +6064,10 @@ ${handlers.length} left`,
 				if (entry.predicate(msg.command)) {
 					// there is!
 					entry.handler(msg.command);
+
+					// Non-consuming observers only inspect the command, so we
+					// continue handling it normally.
+					if (entry.consume === false) continue;
 
 					// and possibly reply to a supervised command
 					await reply(SupervisionStatus.Success);
@@ -7952,23 +7962,27 @@ ${handlers.length} left`,
 		predicate: (cc: CCId) => cc is U,
 		timeout?: number,
 		abortSignal?: AbortSignal,
+		options?: WaitForCommandOptions,
 	): Promise<U>;
 
 	public waitForCommand<T extends CCId>(
 		predicate: (cc: CCId) => boolean,
 		timeout?: number,
 		abortSignal?: AbortSignal,
+		options?: WaitForCommandOptions,
 	): Promise<T>;
 
 	/**
 	 * Waits until a CommandClass is received or an optional timeout has elapsed. Returns the received command.
-	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
 	 * @param predicate A predicate function to test all incoming command classes
+	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
+	 * @param abortSignal An optional abort signal to cancel the wait
 	 */
 	public waitForCommand<T extends CCId>(
 		predicate: (cc: CCId) => boolean,
 		timeout?: number,
 		abortSignal?: AbortSignal,
+		options?: WaitForCommandOptions,
 	): Promise<T> {
 		return new Promise<T>((resolve, reject) => {
 			const promise = createDeferredPromise<CCId>();
@@ -7976,6 +7990,7 @@ ${handlers.length} left`,
 				predicate,
 				handler: (cc) => promise.resolve(cc),
 				timeout: undefined,
+				consume: options?.consume,
 			};
 			this.awaitedCommands.push(entry);
 			const removeEntry = () => {
@@ -8004,59 +8019,6 @@ ${handlers.length} left`,
 			// When the abort signal is used, silently remove the wait entry
 			abortSignal?.addEventListener("abort", removeEntry);
 		});
-	}
-
-	/**
-	 * Waits until an S2-encapsulated message matching the given predicate is received, or an optional timeout has elapsed.
-	 * Unlike {@link waitForCommand}, the predicate is tested against the still-encapsulated command, and a match does
-	 * not consume the message, so it is still handled normally afterwards.
-	 * @param predicate A predicate function to test all incoming S2-encapsulated messages
-	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
-	 * @param abortSignal An optional abort signal to cancel the wait
-	 */
-	public waitForS2MessageEncapsulation(
-		predicate: (cc: Security2CCMessageEncapsulation) => boolean,
-		timeout?: number,
-		abortSignal?: AbortSignal,
-	): Promise<Security2CCMessageEncapsulation> {
-		return new Promise<Security2CCMessageEncapsulation>(
-			(resolve, reject) => {
-				const promise = createDeferredPromise<
-					Security2CCMessageEncapsulation
-				>();
-				const entry: AwaitedS2MessageEntry = {
-					predicate,
-					handler: (cc) => promise.resolve(cc),
-					timeout: undefined,
-				};
-				this.awaitedS2Messages.push(entry);
-				const removeEntry = () => {
-					entry.timeout?.clear();
-					abortSignal?.removeEventListener("abort", removeEntry);
-					const index = this.awaitedS2Messages.indexOf(entry);
-					if (index !== -1) this.awaitedS2Messages.splice(index, 1);
-				};
-				// When the timeout elapses, remove the wait entry and reject the returned Promise
-				if (timeout) {
-					entry.timeout = setTimer(() => {
-						removeEntry();
-						reject(
-							new ZWaveError(
-								`Received no matching S2 message within the provided timeout!`,
-								ZWaveErrorCodes.Controller_NodeTimeout,
-							),
-						);
-					}, timeout);
-				}
-				// When the promise is resolved, remove the wait entry and resolve the returned Promise
-				void promise.then((cc) => {
-					removeEntry();
-					resolve(cc);
-				});
-				// When the abort signal is used, silently remove the wait entry
-				abortSignal?.addEventListener("abort", removeEntry);
-			},
-		);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -676,7 +676,6 @@ type AwaitedMessageEntry = AwaitedThing<Message>;
 type AwaitedCommandEntry = AwaitedThing<CCId>;
 type AwaitedCLIChunkEntry = AwaitedThing<CLIChunk>;
 export type AwaitedBootloaderChunkEntry = AwaitedThing<BootloaderChunk>;
-
 type AwaitedIdleEntry = Omit<
 	AwaitedThing<void>,
 	"predicate" | "refreshPredicate"

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -672,6 +672,7 @@ interface AwaitedThing<T> {
 type AwaitedMessageHeader = AwaitedThing<MessageHeaders>;
 type AwaitedMessageEntry = AwaitedThing<Message>;
 type AwaitedCommandEntry = AwaitedThing<CCId>;
+type AwaitedS2MessageEntry = AwaitedThing<Security2CCMessageEncapsulation>;
 type AwaitedCLIChunkEntry = AwaitedThing<CLIChunk>;
 export type AwaitedBootloaderChunkEntry = AwaitedThing<BootloaderChunk>;
 type AwaitedIdleEntry = Omit<
@@ -1076,6 +1077,11 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 	private awaitedMessages: AwaitedMessageEntry[] = [];
 	/** A list of awaited commands */
 	private awaitedCommands: AwaitedCommandEntry[] = [];
+	/**
+	 * A list of awaited S2-encapsulated messages. Unlike {@link awaitedCommands},
+	 * these are tested against the still-encapsulated command and do not consume it.
+	 */
+	private awaitedS2Messages: AwaitedS2MessageEntry[] = [];
 	/** A list of awaited chunks from the bootloader */
 	private awaitedBootloaderChunks: AwaitedBootloaderChunkEntry[] = [];
 	/** A list of awaited chunks from the end device CLI */
@@ -5879,6 +5885,17 @@ ${handlers.length} left`,
 				return;
 			}
 
+			// Notify observers waiting for a specific S2-encapsulated message before
+			// we unwrap it. This is used to verify successful delivery of a previous
+			// command without consuming the message, so it is still handled normally.
+			if (msg.command instanceof Security2CCMessageEncapsulation) {
+				for (const entry of this.awaitedS2Messages) {
+					if (entry.predicate(msg.command)) {
+						entry.handler(msg.command);
+					}
+				}
+			}
+
 			// For further actions, we are only interested in the innermost CC
 			this.unwrapCommands(msg);
 
@@ -7987,6 +8004,59 @@ ${handlers.length} left`,
 			// When the abort signal is used, silently remove the wait entry
 			abortSignal?.addEventListener("abort", removeEntry);
 		});
+	}
+
+	/**
+	 * Waits until an S2-encapsulated message matching the given predicate is received, or an optional timeout has elapsed.
+	 * Unlike {@link waitForCommand}, the predicate is tested against the still-encapsulated command, and a match does
+	 * not consume the message, so it is still handled normally afterwards.
+	 * @param predicate A predicate function to test all incoming S2-encapsulated messages
+	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
+	 * @param abortSignal An optional abort signal to cancel the wait
+	 */
+	public waitForS2MessageEncapsulation(
+		predicate: (cc: Security2CCMessageEncapsulation) => boolean,
+		timeout?: number,
+		abortSignal?: AbortSignal,
+	): Promise<Security2CCMessageEncapsulation> {
+		return new Promise<Security2CCMessageEncapsulation>(
+			(resolve, reject) => {
+				const promise = createDeferredPromise<
+					Security2CCMessageEncapsulation
+				>();
+				const entry: AwaitedS2MessageEntry = {
+					predicate,
+					handler: (cc) => promise.resolve(cc),
+					timeout: undefined,
+				};
+				this.awaitedS2Messages.push(entry);
+				const removeEntry = () => {
+					entry.timeout?.clear();
+					abortSignal?.removeEventListener("abort", removeEntry);
+					const index = this.awaitedS2Messages.indexOf(entry);
+					if (index !== -1) this.awaitedS2Messages.splice(index, 1);
+				};
+				// When the timeout elapses, remove the wait entry and reject the returned Promise
+				if (timeout) {
+					entry.timeout = setTimer(() => {
+						removeEntry();
+						reject(
+							new ZWaveError(
+								`Received no matching S2 message within the provided timeout!`,
+								ZWaveErrorCodes.Controller_NodeTimeout,
+							),
+						);
+					}, timeout);
+				}
+				// When the promise is resolved, remove the wait entry and resolve the returned Promise
+				void promise.then((cc) => {
+					removeEntry();
+					resolve(cc);
+				});
+				// When the abort signal is used, silently remove the wait entry
+				abortSignal?.addEventListener("abort", removeEntry);
+			},
+		);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -670,14 +670,45 @@ export const secureMessageGeneratorS2: MessageGeneratorImplementation<
 			SupervisionCommand.Get,
 		)
 	) {
-		nonceReport = await driver
-			.waitForCommand<Security2CCNonceReport>(
-				(cc) =>
-					cc.nodeId === nodeId
-					&& cc instanceof Security2CCNonceReport,
-				500,
-			)
-			.catch(() => undefined);
+		// Wait for a possible Nonce Report, which would indicate that the node could
+		// not decrypt our command. Receiving the node's next encrypted command (i.e.
+		// with the next sequence number) instead proves a successful delivery, so we
+		// stop waiting early in that case to avoid artificially delaying command sequences.
+		const verifyAbort = new AbortController();
+		const expectedSequenceNumber = secMan.getNextPeerSequenceNumber(nodeId);
+		const verifications: Promise<
+			Security2CCNonceReport | Security2CCMessageEncapsulation | undefined
+		>[] = [
+			driver
+				.waitForCommand<Security2CCNonceReport>(
+					(cc) =>
+						cc.nodeId === nodeId
+						&& cc instanceof Security2CCNonceReport,
+					500,
+					verifyAbort.signal,
+				)
+				.catch(() => undefined),
+		];
+		if (expectedSequenceNumber != undefined) {
+			verifications.push(
+				driver
+					.waitForS2MessageEncapsulation(
+						(cc) =>
+							cc.nodeId === nodeId
+							&& cc.sequenceNumber === expectedSequenceNumber,
+						500,
+						verifyAbort.signal,
+					)
+					.catch(() => undefined),
+			);
+		}
+		const verification = await Promise.race(verifications);
+		// Clean up the remaining wait(s)
+		verifyAbort.abort();
+
+		if (verification instanceof Security2CCNonceReport) {
+			nonceReport = verification;
+		}
 	} else if (
 		containsCC(response)
 		&& response.command instanceof Security2CCNonceReport

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -692,12 +692,16 @@ export const secureMessageGeneratorS2: MessageGeneratorImplementation<
 		if (expectedSequenceNumber != undefined) {
 			verifications.push(
 				driver
-					.waitForS2MessageEncapsulation(
+					.waitForCommand<Security2CCMessageEncapsulation>(
 						(cc) =>
 							cc.nodeId === nodeId
+							&& cc instanceof Security2CCMessageEncapsulation
 							&& cc.sequenceNumber === expectedSequenceNumber,
 						500,
 						verifyAbort.signal,
+						// Receiving the node's next command must not consume it,
+						// so it is still handled (and answered) normally.
+						{ consume: false },
 					)
 					.catch(() => undefined),
 			);

--- a/packages/zwave-js/src/lib/test/driver/s2VerifyDeliveryNextSequenceNumber.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2VerifyDeliveryNextSequenceNumber.test.ts
@@ -15,7 +15,7 @@ import { integrationTest } from "../integrationTestSuite.js";
 integrationTest(
 	"S2: The node's next encrypted command counts as verified delivery and does not delay subsequent responses",
 	{
-		debug: true,
+		// debug: true,
 
 		nodeCapabilities: {
 			commandClasses: [

--- a/packages/zwave-js/src/lib/test/driver/s2VerifyDeliveryNextSequenceNumber.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2VerifyDeliveryNextSequenceNumber.test.ts
@@ -1,0 +1,100 @@
+import {
+	Security2CC,
+	Security2CCMessageEncapsulation,
+	VersionCCCommandClassGet,
+	VersionCCCommandClassReport,
+} from "@zwave-js/cc";
+import { CommandClasses, SecurityClass } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"S2: The node's next encrypted command counts as verified delivery and does not delay subsequent responses",
+	{
+		debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				CommandClasses["Security 2"],
+				{
+					ccId: CommandClasses.Basic,
+					secure: true,
+				},
+			],
+			securityClasses: new Set([SecurityClass.S2_Unauthenticated]),
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// The interview has established a shared SPAN, so the node can send
+			// encrypted commands the controller can decrypt.
+
+			// Build an S2-encapsulated Version CC Command Class Get from the node.
+			// Each call uses the next sequence number automatically.
+			const makeVersionGet = (requestedCC: CommandClasses) =>
+				Security2CC.encapsulate(
+					new VersionCCCommandClassGet({
+						nodeId: mockController.ownNodeId,
+						requestedCC,
+					}),
+					mockNode.id,
+					mockNode.securityManagers,
+				);
+
+			// 1. The node queries the version of a CC.
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(
+					makeVersionGet(CommandClasses.Supervision),
+					{ ackRequested: true },
+				),
+			);
+
+			// 2. zwave-js answers with a secure, unsupervised Report. Since the report
+			//    is not supervised and does not expect a response, zwave-js then enters
+			//    the 500ms "verify delivery" window, waiting for a possible Nonce Report.
+			await mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof Security2CCMessageEncapsulation
+					&& frame.payload.encapsulated
+						instanceof VersionCCCommandClassReport
+					&& frame.payload.encapsulated.requestedCC
+						=== CommandClasses.Supervision,
+				{ timeout: 1000 },
+			);
+
+			// 3. While zwave-js is still inside the verify-delivery window, the node
+			//    sends its next encrypted command (with the next sequence number).
+			//    Receiving it proves the previous command was delivered, so the
+			//    response to this second query must NOT be delayed by the full
+			//    verify-delivery timeout.
+			const secondReport = mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof Security2CCMessageEncapsulation
+					&& frame.payload.encapsulated
+						instanceof VersionCCCommandClassReport
+					&& frame.payload.encapsulated.requestedCC
+						=== CommandClasses["Humidity Control Mode"],
+				{
+					timeout: 250,
+					errorMessage:
+						"The response to the second query was delayed by the S2 verify-delivery timeout",
+				},
+			);
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(
+					makeVersionGet(CommandClasses["Humidity Control Mode"]),
+					{ ackRequested: true },
+				),
+			);
+
+			await secondReport;
+		},
+	},
+);


### PR DESCRIPTION
When the `s2VerifyDelivery` option is enabled, we would always wait 500ms for a potential NonceReport, even when the next command by the peer was already received.

With this PR, we now treat the receipt of an S2 encapsulated command with the next expected sequence number as successful delivery.