### PR TITLE
feat(config): add fingerprint for Leviton VRCZ4-1LX

### DIFF
--- a/packages/config/config/devices/0x001d/vrcz4.json
+++ b/packages/config/config/devices/0x001d/vrcz4.json
@@ -13,6 +13,10 @@
 			"productId": "0x0261"
 		},
 		{
+			"productType": "0x0702",
+			"productId": "0x0243"
+		},
+		{
 			"productType": "0x0801",
 			"productId": "0x0206"
 		}


### PR DESCRIPTION
my VRCZ4 (supposedly VRCZ4-1LX) shows up as "Unknown" because its ID isn't listed

adding it to the existing VRCZ4 file. Behaves like the other VRCZ4s (4 groups, 8 scenes), so the `forceSceneControllerGroupCount` is correct (and what is needed for proper scene/button control)

(It shares the `0x0243` product ID with the MR variant, but has no load, so I think belongs in the the non-mr variant) 