### PR TITLE
fix: distinguish between actuator and non-actuator CCs when optimistically updating values on slow devices

### DIFF
--- a/packages/core/src/registries/DeviceClasses.test.ts
+++ b/packages/core/src/registries/DeviceClasses.test.ts
@@ -1,58 +1,58 @@
 import { getGenericDeviceClass, getSpecificDeviceClass } from "@zwave-js/core";
 import { test } from "vitest";
 
-test("device classes marked as slow should not support optimistic value updates", (t) => {
+test("device classes with slow actuators should be marked as such", (t) => {
 	// Test Window Covering (0x09)
 	const windowCoveringGeneric = getGenericDeviceClass(0x09);
-	t.expect(windowCoveringGeneric.supportsOptimisticValueUpdate).toBe(false);
+	t.expect(windowCoveringGeneric.isSlowActuator).toBe(true);
 
 	const windowCoveringSpecific = getSpecificDeviceClass(0x09, 0x01);
-	t.expect(windowCoveringSpecific.supportsOptimisticValueUpdate).toBe(false);
+	t.expect(windowCoveringSpecific.isSlowActuator).toBe(true);
 
 	// Test Multilevel Switch Motor Control classes
 	const multilevelSwitchGeneric = getGenericDeviceClass(0x11);
-	t.expect(multilevelSwitchGeneric.supportsOptimisticValueUpdate).toBe(true); // Generic should be true
+	t.expect(multilevelSwitchGeneric.isSlowActuator).toBe(false); // Generic should be false
 
 	// Multiposition Motor (0x11:0x03)
 	const multipositionMotor = getSpecificDeviceClass(0x11, 0x03);
-	t.expect(multipositionMotor.supportsOptimisticValueUpdate).toBe(false);
+	t.expect(multipositionMotor.isSlowActuator).toBe(true);
 
 	// Motor Control Class A (0x11:0x05)
 	const motorControlA = getSpecificDeviceClass(0x11, 0x05);
-	t.expect(motorControlA.supportsOptimisticValueUpdate).toBe(false);
+	t.expect(motorControlA.isSlowActuator).toBe(true);
 
 	// Motor Control Class B (0x11:0x06)
 	const motorControlB = getSpecificDeviceClass(0x11, 0x06);
-	t.expect(motorControlB.supportsOptimisticValueUpdate).toBe(false);
+	t.expect(motorControlB.isSlowActuator).toBe(true);
 
 	// Motor Control Class C (0x11:0x07)
 	const motorControlC = getSpecificDeviceClass(0x11, 0x07);
-	t.expect(motorControlC.supportsOptimisticValueUpdate).toBe(false);
+	t.expect(motorControlC.isSlowActuator).toBe(true);
 });
 
-test("device classes marked as fast should support optimistic value updates", (t) => {
+test("device classes without slow actuators should not be marked as such", (t) => {
 	// Test Binary Switch (0x10)
 	const binarySwitchGeneric = getGenericDeviceClass(0x10);
-	t.expect(binarySwitchGeneric.supportsOptimisticValueUpdate).toBe(true);
+	t.expect(binarySwitchGeneric.isSlowActuator).toBe(false);
 
 	const binaryPowerSwitch = getSpecificDeviceClass(0x10, 0x01);
-	t.expect(binaryPowerSwitch.supportsOptimisticValueUpdate).toBe(true);
+	t.expect(binaryPowerSwitch.isSlowActuator).toBe(false);
 
 	// Test Multilevel Switch - Light Dimmer (0x11:0x01)
 	const lightDimmer = getSpecificDeviceClass(0x11, 0x01);
-	t.expect(lightDimmer.supportsOptimisticValueUpdate).toBe(true);
+	t.expect(lightDimmer.isSlowActuator).toBe(false);
 
 	// Test Fan Switch (0x11:0x08)
 	const fanSwitch = getSpecificDeviceClass(0x11, 0x08);
-	t.expect(fanSwitch.supportsOptimisticValueUpdate).toBe(true);
+	t.expect(fanSwitch.isSlowActuator).toBe(false);
 });
 
-test("unknown device classes should default to supporting optimistic value updates", (t) => {
+test("unknown device classes should default to not being slow actuators", (t) => {
 	// Test unknown generic class
 	const unknownGeneric = getGenericDeviceClass(0xFF);
-	t.expect(unknownGeneric.supportsOptimisticValueUpdate).toBe(true);
+	t.expect(unknownGeneric.isSlowActuator).toBe(false);
 
 	// Test unknown specific class
 	const unknownSpecific = getSpecificDeviceClass(0x10, 0xFF);
-	t.expect(unknownSpecific.supportsOptimisticValueUpdate).toBe(true);
+	t.expect(unknownSpecific.isSlowActuator).toBe(false);
 });

--- a/packages/core/src/registries/DeviceClasses.ts
+++ b/packages/core/src/registries/DeviceClasses.ts
@@ -11,7 +11,7 @@ interface DeviceClassProperties {
 	readonly zwavePlusDeviceType?: string;
 	readonly requiresSecurity?: boolean;
 	readonly maySupportBasicCC?: boolean;
-	readonly supportsOptimisticValueUpdate?: boolean;
+	readonly isSlowActuator?: boolean;
 }
 
 interface GenericDeviceClassDefinition extends DeviceClassProperties {
@@ -29,7 +29,7 @@ export interface GenericDeviceClass {
 	readonly zwavePlusDeviceType?: string;
 	readonly requiresSecurity: boolean;
 	readonly maySupportBasicCC: boolean;
-	readonly supportsOptimisticValueUpdate: boolean;
+	readonly isSlowActuator: boolean;
 }
 
 export interface GenericDeviceClassWithSpecific extends GenericDeviceClass {
@@ -185,7 +185,7 @@ const deviceClasses: Record<number, GenericDeviceClassDefinition> = Object
 			},
 			[0x09]: {
 				label: "Window Covering",
-				supportsOptimisticValueUpdate: false,
+				isSlowActuator: true,
 				specific: {
 					[0x01]: {
 						label: "Simple Window Covering Control",
@@ -252,7 +252,7 @@ const deviceClasses: Record<number, GenericDeviceClassDefinition> = Object
 					},
 					[0x03]: {
 						label: "Multiposition Motor",
-						supportsOptimisticValueUpdate: false,
+						isSlowActuator: true,
 					},
 					[0x04]: {
 						label: "Multilevel Scene Switch",
@@ -261,18 +261,18 @@ const deviceClasses: Record<number, GenericDeviceClassDefinition> = Object
 						label: "Motor Control Class A",
 						zwavePlusDeviceType:
 							"Window Covering - No Position/Endpoint",
-						supportsOptimisticValueUpdate: false,
+						isSlowActuator: true,
 					},
 					[0x06]: {
 						label: "Motor Control Class B",
 						zwavePlusDeviceType: "Window Covering - Endpoint Aware",
-						supportsOptimisticValueUpdate: false,
+						isSlowActuator: true,
 					},
 					[0x07]: {
 						label: "Motor Control Class C",
 						zwavePlusDeviceType:
 							"Window Covering - Position/Endpoint Aware",
-						supportsOptimisticValueUpdate: false,
+						isSlowActuator: true,
 					},
 					[0x08]: {
 						label: "Fan Switch",
@@ -498,8 +498,7 @@ export function getGenericDeviceClass(generic: number): GenericDeviceClass {
 		zwavePlusDeviceType: genericClass.zwavePlusDeviceType,
 		requiresSecurity: genericClass.requiresSecurity ?? false,
 		maySupportBasicCC: genericClass.maySupportBasicCC ?? true,
-		supportsOptimisticValueUpdate:
-			genericClass.supportsOptimisticValueUpdate ?? true,
+		isSlowActuator: genericClass.isSlowActuator ?? false,
 	};
 }
 
@@ -535,7 +534,7 @@ function getUnknownGenericDeviceClass(key: number): GenericDeviceClass {
 		label: `UNKNOWN (${num2hex(key)})`,
 		requiresSecurity: false,
 		maySupportBasicCC: true,
-		supportsOptimisticValueUpdate: true,
+		isSlowActuator: false,
 	};
 }
 
@@ -573,10 +572,9 @@ export function getSpecificDeviceClass(
 		maySupportBasicCC: specificClass.maySupportBasicCC
 			?? genericClass.maySupportBasicCC
 			?? true,
-		supportsOptimisticValueUpdate:
-			specificClass.supportsOptimisticValueUpdate
-				?? genericClass.supportsOptimisticValueUpdate
-				?? true,
+		isSlowActuator: specificClass.isSlowActuator
+			?? genericClass.isSlowActuator
+			?? false,
 	};
 }
 
@@ -591,8 +589,7 @@ function getUnknownSpecificDeviceClass(
 			zwavePlusDeviceType: genericClass.zwavePlusDeviceType,
 			requiresSecurity: genericClass.requiresSecurity ?? false,
 			maySupportBasicCC: genericClass.maySupportBasicCC ?? true,
-			supportsOptimisticValueUpdate:
-				genericClass.supportsOptimisticValueUpdate ?? true,
+			isSlowActuator: genericClass.isSlowActuator ?? false,
 		};
 	} else {
 		return {
@@ -601,8 +598,7 @@ function getUnknownSpecificDeviceClass(
 			zwavePlusDeviceType: genericClass.zwavePlusDeviceType,
 			requiresSecurity: genericClass.requiresSecurity ?? false,
 			maySupportBasicCC: genericClass.maySupportBasicCC ?? true,
-			supportsOptimisticValueUpdate:
-				genericClass.supportsOptimisticValueUpdate ?? true,
+			isSlowActuator: genericClass.isSlowActuator ?? false,
 		};
 	}
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -122,6 +122,7 @@ import {
 	getCCName,
 	getDSTInfo,
 	getNotification,
+	isActuatorCC,
 	isRssiError,
 	isSupervisionResult,
 	isTransmissionError,
@@ -616,9 +617,10 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			// and related values, should be performed:
 			const isAPIOptimistic = api.isSetValueOptimistic(valueId);
 
-			// Whether the device class is slow (e.g. motors, window coverings)
-			const isSlowDeviceClass = endpointInstance.deviceClass?.specific
-				.supportsOptimisticValueUpdate === false;
+			// Whether the device class has slow actuators (e.g. motors, window coverings)
+			const isSlowActuator = isActuatorCC(valueId.commandClass)
+				&& !!endpointInstance.deviceClass?.specific
+					.isSlowActuator;
 			// Whether the device has at least started executing the command
 			const supervisedAndAccepted = supervisedCommandSucceeded(result);
 			// Whether the device has completed the command successfully
@@ -633,15 +635,15 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 
 			// The actual value may be updated optimistically once the command has started.
 			const shouldUpdateActualValueOptimistically = isAPIOptimistic
-				// For slow device classes, this is only allowed when the value is a
+				// For slow actuators, this is only allowed when the value is a
 				// target value that is distinct from the current physical state.
-				&& (!isSlowDeviceClass || hooks?.isSplitStateTargetValue)
+				&& (!isSlowActuator || hooks?.isSplitStateTargetValue)
 				&& (supervisedAndAccepted
 					|| unsupervisedAndOptimisticValueUpdateEnabled);
 			// Related values may only be updated optimistically once the command has completed successfully
 			const shouldUpdateRelatedValuesOptimistically = isAPIOptimistic
-				// And only for fast device classes
-				&& !isSlowDeviceClass
+				// And only for fast actuators or non-actuators
+				&& !isSlowActuator
 				&& (supervisedAndCompletedSuccessfully
 					|| unsupervisedAndOptimisticValueUpdateEnabled);
 
@@ -692,13 +694,12 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 					);
 				}
 
-				// Verify the current value after a delay, unless...
-				// ...the command was supervised and successful
-				//    ... and this is not a slow device class
-				// ...and the CC API decides not to verify anyways
+				// Verify the current value after a delay when the command
+				// hasn't already completed successfully, the device is a slow
+				// actuator, or the CC API forces verification.
 				if (
 					!supervisedCommandSucceeded(result)
-					|| isSlowDeviceClass
+					|| isSlowActuator
 					|| hooks.forceVerifyChanges?.()
 				) {
 					// Let the CC API implementation handle the verification.

--- a/packages/zwave-js/src/lib/test/driver/fixtures/configurationPartialParamSupervision/deviceConfig.json
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/configurationPartialParamSupervision/deviceConfig.json
@@ -1,0 +1,54 @@
+{
+	"manufacturer": "Test Corp",
+	"manufacturerId": "0xdead",
+	"label": "Test Motor Controller",
+	"description": "Test device with partial config params",
+	"devices": [
+		{
+			"productType": "0xbeef",
+			"productId": "0xcafe"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1[0x01]",
+			"label": "Bit 0",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "1[0x02]",
+			"label": "Bit 1",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "1[0x04]",
+			"label": "Bit 2",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "1[0x08]",
+			"label": "Bit 3",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true
+		}
+	]
+}

--- a/packages/zwave-js/src/lib/test/driver/setValueConfigPartialParamSupervision.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueConfigPartialParamSupervision.test.ts
@@ -1,0 +1,117 @@
+import {
+	ConfigurationCCSet,
+	ConfigurationCCValues,
+	SupervisionCommand,
+} from "@zwave-js/cc";
+import {
+	BasicDeviceClass,
+	CommandClasses,
+	ConfigValueFormat,
+} from "@zwave-js/core";
+import { type MockNodeBehavior, ccCaps } from "@zwave-js/testing";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"setValue with supervised partial config parameter on a slow device class updates cached value",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			manufacturerId: 0xdead,
+			productType: 0xbeef,
+			productId: 0xcafe,
+
+			basicDeviceClass: BasicDeviceClass["End Node"],
+			genericDeviceClass: 0x11, // Multilevel Switch
+			specificDeviceClass: 0x06, // Motor Control Class B
+
+			commandClasses: [
+				CommandClasses.Supervision,
+				CommandClasses.Version,
+				CommandClasses["Manufacturer Specific"],
+				ccCaps({
+					ccId: CommandClasses.Configuration,
+					isSupported: true,
+					version: 1,
+					parameters: [
+						{
+							"#": 1,
+							valueSize: 1,
+							name: "Partial Params",
+							format: ConfigValueFormat.UnsignedInteger,
+							minValue: 0,
+							maxValue: 255,
+							defaultValue: 0,
+						},
+					],
+				}),
+			],
+		},
+
+		additionalDriverOptions: {
+			storage: {
+				deviceConfigPriorityDir: path.join(
+					__dirname,
+					"fixtures/configurationPartialParamSupervision",
+				),
+			},
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Track the current value for parameter 1
+			let paramValue = 0;
+
+			const respondToConfigSet: MockNodeBehavior = {
+				handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC.isEncapsulatedWith(
+							CommandClasses.Supervision,
+							SupervisionCommand.Get,
+						)
+						&& receivedCC instanceof ConfigurationCCSet
+					) {
+						paramValue = receivedCC.value!;
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToConfigSet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			// Read the initial value for all partial params (should be 0)
+			const bit0Id = ConfigurationCCValues.paramInformation(1, 0x01).id;
+			const bit1Id = ConfigurationCCValues.paramInformation(1, 0x02).id;
+			const bit2Id = ConfigurationCCValues.paramInformation(1, 0x04).id;
+			const bit3Id = ConfigurationCCValues.paramInformation(1, 0x08).id;
+
+			t.expect(node.getValue(bit0Id)).toBe(0);
+			t.expect(node.getValue(bit1Id)).toBe(0);
+			t.expect(node.getValue(bit2Id)).toBe(0);
+			t.expect(node.getValue(bit3Id)).toBe(0);
+
+			// Set bit 2 to 1 via supervised command
+			await node.setValue(bit2Id, 1);
+
+			// The value should be updated in the cache
+			t.expect(
+				node.getValue(bit2Id),
+				"Partial param bit 2 should be updated to 1",
+			).toBe(1);
+
+			// Other bits should remain unchanged
+			t.expect(
+				node.getValue(bit0Id),
+				"Partial param bit 0 should remain 0",
+			).toBe(0);
+			t.expect(
+				node.getValue(bit1Id),
+				"Partial param bit 1 should remain 0",
+			).toBe(0);
+			t.expect(
+				node.getValue(bit3Id),
+				"Partial param bit 3 should remain 0",
+			).toBe(0);
+		},
+	},
+);


### PR DESCRIPTION
fixes: #8910