### PR TITLE
fix(config): override supported thermostat modes for Fibaro FGT-001

### DIFF
--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -199,24 +199,17 @@
 		"overrideQueries": {
 			"Thermostat Mode": [
 				{
-					// Override the getSupportedModes query for endpoint 1, because the device
-					// reports incorrect supported modes via the Z-Wave protocol.
+					// The device does not report "Manufacturer specific" as a supported thermostat mode
 					"endpoint": 1,
 					"method": "getSupportedModes",
-
-					// The device natively reports only [Off, Heat], but also supports
-					// "Fully Open" (mode 31 / 0x1F, manufacturer-specific).
 					"result": [0, 1, 31],
 
-					// Persist the corrected supported modes so ZWaveJS does not overwrite
-					// them with the incorrect values reported by the device.
+					// Prevent overwriting the supported modes with the values reported by the device.
 					"persistValues": {
 						"supportedModes": [0, 1, 31]
 					},
 
-					// Extend the metadata with human-readable labels for each mode,
-					// since mode 31 is manufacturer-specific and has no standard label.
-					// Without this, ZWaveJS would display it as "Manufacturer specific".
+					// Extend the metadata since mode 31 is manufacturer-specific and has no standard label.
 					"extendMetadata": {
 						"thermostatMode": {
 							"states": {

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -22,7 +22,7 @@
 		"max": "255.255"
 	},
 	"metadata": {
-		"manual": "https://manuals.fibaro.com/heat-controller/"
+		"manual": "https://manuals.fibaro.com/content/manuals/en/FGT-001/FGT-001-EN-T-v1.6.pdf"
 	},
 	"paramInformation": [
 		{

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -21,6 +21,9 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
+	"metadata": {
+		"manual": "https://manuals.fibaro.com/heat-controller/"
+	},
 	"paramInformation": [
 		{
 			"#": "1",
@@ -143,11 +146,58 @@
 		"mapRootReportsToEndpoint": 1,
 		// Hide CCs from root endpoint that are duplicated on the manually preserved endpoint 1
 		"commandClasses": {
+			"add": {
+				"Multilevel Sensor": {
+					"endpoints": {
+						"2": {
+							"isSupported": true
+						}
+					}
+				},
+				"Battery": {
+					"endpoints": {
+						"2": {
+							"isSupported": true
+						}
+					}
+				},
+				"Notification": {
+					"endpoints": {
+						"1": {
+							"isSupported": true
+						},
+						"2": {
+							"isSupported": true
+						}
+					}
+				}
+			},
 			"remove": {
 				"Battery": {
 					"endpoints": [0]
 				}
 			}
+		},
+		"overrideQueries": {
+			"Thermostat Mode": [
+				{
+					"endpoint": 1,
+					"method": "getSupportedModes",
+					"result": [0, 1, 31],
+					"persistValues": {
+						"supportedModes": [0, 1, 31]
+					},
+					"extendMetadata": {
+						"thermostatMode": {
+							"states": {
+								"0": "Off",
+								"1": "Heat",
+								"31": "Manufacturer specific"
+							}
+						}
+					}
+				}
+			]
 		}
 	}
 }

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -148,7 +148,7 @@
 					"endpoints": [0]
 				}
 			}
-		}
+		},
 		"overrideQueries": {
 			"Thermostat Mode": [
 				{

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -141,6 +141,14 @@
 		"preserveEndpoints": [1, 2],
 		// Not sure if necessary, but this can prevent missing updates on endpoint 1
 		"mapRootReportsToEndpoint": 1,
+		// Hide CCs from root endpoint that are duplicated on the manually preserved endpoint 1
+		"commandClasses": {
+			"remove": {
+				"Battery": {
+					"endpoints": [0]
+				}
+			}
+		}
 		"overrideQueries": {
 			"Thermostat Mode": [
 				{

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -144,8 +144,16 @@
 		// Hide CCs from root endpoint that are duplicated on the manually preserved endpoint 1
 		"commandClasses": {
 			"add": {
+				// The following command classes are added manually because the device
+				// does not correctly advertise them in its NIF (Node Information Frame).
+				// Without these entries, ZWaveJS would not interview these CCs on the
+				// respective endpoints, even though the device fully supports them.
+
 				"Multilevel Sensor": {
 					"endpoints": {
+						// Add Multilevel Sensor to endpoint 2 (external temperature sensor).
+						// This allows ZWaveJS to read the temperature from the external
+						// sensor connected to the device.
 						"2": {
 							"isSupported": true
 						}
@@ -153,6 +161,11 @@
 				},
 				"Battery": {
 					"endpoints": {
+						// Add Battery to endpoint 2 (external temperature sensor).
+						// The FGT001 has two separate battery sets: endpoint 1 for the
+						// thermostat valve and endpoint 2 for the external temperature
+						// sensor. Without this entry, only the battery of endpoint 1
+						// would be queried.
 						"2": {
 							"isSupported": true
 						}
@@ -160,6 +173,9 @@
 				},
 				"Notification": {
 					"endpoints": {
+						// Add Notification to endpoints 1 and 2, as both endpoints send
+						// notifications (e.g. battery status, hardware alerts) that are
+						// not declared in their NIF.
 						"1": {
 							"isSupported": true
 						},
@@ -171,6 +187,11 @@
 			},
 			"remove": {
 				"Battery": {
+					// Remove Battery from the root endpoint (endpoint 0), as the device
+					// correctly reports battery information on endpoint 1 and 2 only.
+					// Without this entry, ZWaveJS would also query the battery on the
+					// root endpoint, resulting in a duplicate and potentially incorrect
+					// battery value.
 					"endpoints": [0]
 				}
 			}

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -178,12 +178,24 @@
 		"overrideQueries": {
 			"Thermostat Mode": [
 				{
+					// Override the getSupportedModes query for endpoint 1, because the device
+					// reports incorrect supported modes via the Z-Wave protocol.
 					"endpoint": 1,
 					"method": "getSupportedModes",
+
+					// The device natively reports only [Off, Heat], but also supports
+					// "Fully Open" (mode 31 / 0x1F, manufacturer-specific).
 					"result": [0, 1, 31],
+
+					// Persist the corrected supported modes so ZWaveJS does not overwrite
+					// them with the incorrect values reported by the device.
 					"persistValues": {
 						"supportedModes": [0, 1, 31]
 					},
+
+					// Extend the metadata with human-readable labels for each mode,
+					// since mode 31 is manufacturer-specific and has no standard label.
+					// Without this, ZWaveJS would display it as "Manufacturer specific".
 					"extendMetadata": {
 						"thermostatMode": {
 							"states": {

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -21,9 +21,6 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"metadata": {
-		"manual": "https://manuals.fibaro.com/heat-controller/"
-	},
 	"paramInformation": [
 		{
 			"#": "1",
@@ -199,5 +196,8 @@
 				}
 			]
 		}
+	},
+	"metadata": {
+		"manual": "https://manuals.fibaro.com/heat-controller/"
 	}
 }

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -141,61 +141,6 @@
 		"preserveEndpoints": [1, 2],
 		// Not sure if necessary, but this can prevent missing updates on endpoint 1
 		"mapRootReportsToEndpoint": 1,
-		// Hide CCs from root endpoint that are duplicated on the manually preserved endpoint 1
-		"commandClasses": {
-			"add": {
-				// The following command classes are added manually because the device
-				// does not correctly advertise them in its NIF (Node Information Frame).
-				// Without these entries, ZWaveJS would not interview these CCs on the
-				// respective endpoints, even though the device fully supports them.
-
-				"Multilevel Sensor": {
-					"endpoints": {
-						// Add Multilevel Sensor to endpoint 2 (external temperature sensor).
-						// This allows ZWaveJS to read the temperature from the external
-						// sensor connected to the device.
-						"2": {
-							"isSupported": true
-						}
-					}
-				},
-				"Battery": {
-					"endpoints": {
-						// Add Battery to endpoint 2 (external temperature sensor).
-						// The FGT001 has two separate battery sets: endpoint 1 for the
-						// thermostat valve and endpoint 2 for the external temperature
-						// sensor. Without this entry, only the battery of endpoint 1
-						// would be queried.
-						"2": {
-							"isSupported": true
-						}
-					}
-				},
-				"Notification": {
-					"endpoints": {
-						// Add Notification to endpoints 1 and 2, as both endpoints send
-						// notifications (e.g. battery status, hardware alerts) that are
-						// not declared in their NIF.
-						"1": {
-							"isSupported": true
-						},
-						"2": {
-							"isSupported": true
-						}
-					}
-				}
-			},
-			"remove": {
-				"Battery": {
-					// Remove Battery from the root endpoint (endpoint 0), as the device
-					// correctly reports battery information on endpoint 1 and 2 only.
-					// Without this entry, ZWaveJS would also query the battery on the
-					// root endpoint, resulting in a duplicate and potentially incorrect
-					// battery value.
-					"endpoints": [0]
-				}
-			}
-		},
 		"overrideQueries": {
 			"Thermostat Mode": [
 				{

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -22,7 +22,7 @@
 		"max": "255.255"
 	},
 	"metadata": {
-		"manual": "https://manuals.fibaro.com/content/manuals/en/FGT-001/FGT-001-EN-T-v1.6.pdf"
+		"manual": "https://manuals.fibaro.com/heat-controller/"
 	},
 	"paramInformation": [
 		{
@@ -192,7 +192,7 @@
 							"states": {
 								"0": "Off",
 								"1": "Heat",
-								"31": "Manufacturer specific"
+								"31": "Fully Open"
 							}
 						}
 					}


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

Add manual link for Fibaro FGT-001, expose Multilevel Sensor/Battery/Notification CCs on endpoint 2 and Notification on endpoint 1, and override the Thermostat Mode supported modes query. The entry "Fully Open" (Manufacturer specific) was missing.

Issue with the missing Thermostat Mode was discussed in https://github.com/zwave-js/zwave-js-ui/issues/972.
