### PR TITLE
fix: cache devices not known to the firmware update service

### DIFF
--- a/packages/zwave-js/src/lib/controller/FirmwareUpdateService.test.ts
+++ b/packages/zwave-js/src/lib/controller/FirmwareUpdateService.test.ts
@@ -1,0 +1,155 @@
+import { type AddressInfo } from "node:net";
+import { afterAll, beforeAll, beforeEach, test } from "vitest";
+import { getAvailableFirmwareUpdatesBulk } from "./FirmwareUpdateService.js";
+import type {
+	FirmwareUpdateBulkInfo,
+	FirmwareUpdateDeviceID,
+} from "./_Types.js";
+
+// Mock update service. Devices with productId 0x0001 are known and have one
+// update, all others are unknown and get omitted from the response
+let requestCount = 0;
+let requestedDevices: any[][] = [];
+let server: import("node:http").Server;
+
+beforeAll(async () => {
+	const { createServer } = await import("node:http");
+	server = createServer((req, res) => {
+		let body = "";
+		req.on("data", (chunk) => (body += chunk));
+		req.on("end", () => {
+			requestCount++;
+			const { devices } = JSON.parse(body);
+			requestedDevices.push(devices);
+
+			const response: FirmwareUpdateBulkInfo[] = devices
+				.filter((d: any) => d.productId === "0x0001")
+				.map((d: any) => ({
+					manufacturerId: d.manufacturerId,
+					productType: d.productType,
+					productId: d.productId,
+					firmwareVersion: d.firmwareVersion + ".0",
+					updates: [
+						{
+							version: "2.0.0",
+							changelog: "Fixes everything",
+							channel: "stable",
+							files: [
+								{
+									target: 0,
+									url: "https://example.com/firmware.gbl",
+									integrity: "sha256:abcd",
+								},
+							],
+							downgrade: false,
+							normalizedVersion: "2.0.0",
+						},
+					],
+				}));
+
+			res.setHeader("content-type", "application/json");
+			res.end(JSON.stringify(response));
+		});
+	});
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	process.env.ZWAVEJS_FW_SERVICE_URL = `http://127.0.0.1:${
+		(server.address() as AddressInfo).port
+	}`;
+});
+
+afterAll(async () => {
+	delete process.env.ZWAVEJS_FW_SERVICE_URL;
+	await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+	requestCount = 0;
+	requestedDevices = [];
+});
+
+const options = { userAgent: "test" };
+
+// The device cache is module state and persists across tests,
+// so each test must use a unique manufacturerId
+function testDevices(manufacturerId: number): {
+	known: FirmwareUpdateDeviceID;
+	unknown: FirmwareUpdateDeviceID;
+} {
+	return {
+		known: {
+			manufacturerId,
+			productType: 0x0001,
+			productId: 0x0001,
+			firmwareVersion: "1.0",
+		},
+		unknown: {
+			manufacturerId,
+			productType: 0x0001,
+			productId: 0x0002,
+			firmwareVersion: "1.0",
+		},
+	};
+}
+
+test("updates for known devices are returned and cached", async (t) => {
+	const { known } = testDevices(0x0001);
+
+	const result1 = await getAvailableFirmwareUpdatesBulk([known], options);
+	t.expect(result1.get(known)?.map((u) => u.version)).toStrictEqual([
+		"2.0.0",
+	]);
+
+	// The second call must be answered from the cache
+	const result2 = await getAvailableFirmwareUpdatesBulk([known], options);
+	t.expect(result2.get(known)?.map((u) => u.version)).toStrictEqual([
+		"2.0.0",
+	]);
+	t.expect(requestCount).toBe(1);
+});
+
+test("devices unknown to the service are not re-requested", async (t) => {
+	const { known, unknown } = testDevices(0x0002);
+
+	const result1 = await getAvailableFirmwareUpdatesBulk(
+		[known, unknown],
+		options,
+	);
+	t.expect(result1.has(known)).toBe(true);
+	t.expect(result1.has(unknown)).toBe(false);
+	t.expect(requestCount).toBe(1);
+
+	// The unknown device was omitted from the response, but must still be
+	// cached, so subsequent calls do not cause another request
+	const result2 = await getAvailableFirmwareUpdatesBulk(
+		[known, unknown],
+		options,
+	);
+	t.expect(result2.has(known)).toBe(true);
+	t.expect(result2.has(unknown)).toBe(false);
+	t.expect(requestCount).toBe(1);
+});
+
+test("concurrent calls for the same devices share a single request", async (t) => {
+	const { known, unknown } = testDevices(0x0003);
+
+	const [result1, result2] = await Promise.all([
+		getAvailableFirmwareUpdatesBulk([known, unknown], options),
+		getAvailableFirmwareUpdatesBulk([known, unknown], options),
+	]);
+	t.expect(result1.has(known)).toBe(true);
+	t.expect(result2.has(known)).toBe(true);
+	t.expect(requestCount).toBe(1);
+});
+
+test("only stale devices are re-requested", async (t) => {
+	const { known, unknown } = testDevices(0x0004);
+
+	await getAvailableFirmwareUpdatesBulk([known], options);
+	t.expect(requestedDevices[0]).toHaveLength(1);
+
+	// The known device is cached, so only the unknown one may be requested
+	await getAvailableFirmwareUpdatesBulk([known, unknown], options);
+	t.expect(requestCount).toBe(2);
+	t.expect(requestedDevices[1]).toHaveLength(1);
+	t.expect(requestedDevices[1][0].productId).toBe("0x0002");
+});

--- a/packages/zwave-js/src/lib/controller/FirmwareUpdateService.ts
+++ b/packages/zwave-js/src/lib/controller/FirmwareUpdateService.ts
@@ -41,11 +41,13 @@ const deviceFirmwareCache = new ObjectKeyMap<
 	CachedDeviceResponse
 >();
 interface CachedDeviceResponse {
-	updates: FirmwareUpdateInfo[];
+	/** The available updates, or `undefined` if the device is unknown to the update service */
+	updates?: FirmwareUpdateInfo[];
 	staleDate: number;
 }
 
-// Queue requests to the firmware update service. Only allow few parallel requests so we can make some use of the cache.
+// Queue requests to the firmware update service, so requests made while
+// another one is in flight can be answered from the cache
 let requestQueue: PQueue | undefined;
 
 let cleanCacheTimeout: Timer | undefined;
@@ -181,22 +183,16 @@ export async function getAvailableFirmwareUpdatesBulk(
 				),
 	);
 
-	const now = Date.now();
-	const freshDevices: FirmwareUpdateDeviceID[] = [];
-	const staleDevices: FirmwareUpdateDeviceID[] = [];
+	// Determine which devices need a request inside the queued task, so calls
+	// waiting in the queue can use the cache entries of previous requests
+	const checkStaleDevices = async () => {
+		const now = Date.now();
+		const staleDevices = uniqueDeviceIds.filter((device) => {
+			const cached = deviceFirmwareCache.get(device);
+			return !cached || cached.staleDate <= now;
+		});
+		if (staleDevices.length === 0) return;
 
-	// Split devices into those with fresh cache and those needing updates
-	for (const device of uniqueDeviceIds) {
-		const cached = deviceFirmwareCache.get(device);
-		if (cached && cached.staleDate > now) {
-			freshDevices.push(device);
-		} else {
-			staleDevices.push(device);
-		}
-	}
-
-	// If we have devices with stale cache, make a request for them
-	if (staleDevices.length > 0) {
 		const headers = new Headers({
 			"User-Agent": options.userAgent,
 			"Content-Type": "application/json",
@@ -227,15 +223,11 @@ export async function getAvailableFirmwareUpdatesBulk(
 			timeout: CHECK_TIMEOUT,
 		};
 
-		if (!requestQueue) {
-			// I just love ESM
-			const PQueue = (await import("p-queue")).default;
-			requestQueue = new PQueue({ concurrency: 2 });
-		}
+		const { data: result, expiry } = await makeRequest<
+			FirmwareUpdateBulkInfo[]
+		>(url, config);
 
-		const { data: result, expiry } = await requestQueue.add(() =>
-			makeRequest<FirmwareUpdateBulkInfo[]>(url, config)
-		);
+		const foundDevices = new Set<FirmwareUpdateDeviceID>();
 
 		for (const deviceResponse of result) {
 			// Find the original device info to get the RF region
@@ -251,6 +243,8 @@ export async function getAvailableFirmwareUpdatesBulk(
 			);
 
 			if (originalDevice) {
+				foundDevices.add(originalDevice);
+
 				const updates: FirmwareUpdateInfo[] = deviceResponse.updates
 					.map(
 						(update) => ({
@@ -266,7 +260,27 @@ export async function getAvailableFirmwareUpdatesBulk(
 				});
 			}
 		}
+
+		// The update service omits devices it does not know. Cache those too,
+		// so they are not re-requested before the cache entry becomes stale
+		for (const device of staleDevices) {
+			if (!foundDevices.has(device)) {
+				deviceFirmwareCache.set(device, {
+					updates: undefined,
+					staleDate: expiry,
+				});
+			}
+		}
+	};
+
+	if (!requestQueue) {
+		// I just love ESM
+		const PQueue = (await import("p-queue")).default;
+		// Concurrent calls can reach this point simultaneously. Make sure they share one queue
+		requestQueue ??= new PQueue({ concurrency: 1 });
 	}
+
+	await requestQueue.add(checkStaleDevices);
 
 	// Build the final result map with all requested devices that have updates
 	const ret = new ObjectKeyMap<


### PR DESCRIPTION
Request statistics of the firmware update service seemed to be pretty high compared to expectations. The problem was that the `v4` endpoint encoded unknown devices by omitting them from the response, but Z-Wave JS's internal cache would only cache devices that are present.

As a result, networks with several unknown devices would still cause multiple requests with the same payload, instead of serving the results from cache.

This PR fixes that behavior and pins it down with a unit test.