### PR TITLE
fix: keep User Code CC cache in sync after supervised unified-API writes

### DIFF
--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -665,6 +665,15 @@ export class AccessControlAPI extends FeatureAPI {
 					);
 			} else {
 				succeeded = supervisedCommandSucceeded(result);
+				if (succeeded) {
+					// Supervision replaces the verification GET, so persist
+					// the written slot state to the value DB ourselves
+					this.#persistCachedUserCode(userId, status, codeData);
+				} else {
+					// Re-read the slot so the cache reflects the device's
+					// actual state
+					await api.get(userId);
+				}
 			}
 
 			if (succeeded) {
@@ -798,6 +807,15 @@ export class AccessControlAPI extends FeatureAPI {
 					&& verifiedStatus !== UserIDStatus.Available;
 			} else {
 				succeeded = supervisedCommandSucceeded(result);
+				if (succeeded) {
+					// Supervision replaces the verification GET, so persist
+					// the written slot state to the value DB ourselves
+					this.#persistCachedUserCode(userId, status, existingCode);
+				} else {
+					// Re-read the slot so the cache reflects the device's
+					// actual state
+					await api.get(userId);
+				}
 			}
 			if (succeeded) {
 				const node = this.endpoint.tryGetNode();
@@ -849,6 +867,11 @@ export class AccessControlAPI extends FeatureAPI {
 				succeeded = verified?.userIdStatus === UserIDStatus.Available;
 			} else {
 				succeeded = supervisedCommandSucceeded(result);
+				if (!succeeded) {
+					// Re-read the slot so the cache reflects the device's
+					// actual state
+					await api.get(userId);
+				}
 			}
 			if (succeeded) {
 				this.#clearCachedUserCodes(userId);
@@ -1158,6 +1181,15 @@ export class AccessControlAPI extends FeatureAPI {
 					);
 			} else {
 				succeeded = supervisedCommandSucceeded(result);
+				if (succeeded) {
+					// Supervision replaces the verification GET, so persist
+					// the written slot state to the value DB ourselves
+					this.#persistCachedUserCode(userId, status, codeData);
+				} else {
+					// Re-read the slot so the cache reflects the device's
+					// actual state
+					await api.get(userId);
+				}
 			}
 			if (succeeded) {
 				const node = this.endpoint.tryGetNode();
@@ -1256,6 +1288,11 @@ export class AccessControlAPI extends FeatureAPI {
 				succeeded = verified?.userIdStatus === UserIDStatus.Available;
 			} else {
 				succeeded = supervisedCommandSucceeded(result);
+				if (!succeeded) {
+					// Re-read the slot so the cache reflects the device's
+					// actual state
+					await api.get(targetUserId);
+				}
 			}
 			if (succeeded) {
 				this.#clearCachedUserCodes(targetUserId);
@@ -1342,6 +1379,11 @@ export class AccessControlAPI extends FeatureAPI {
 				// assume it worked when the command was not supervised.
 				succeeded = result == undefined
 					|| supervisedCommandSucceeded(result);
+				if (!succeeded && userId !== 0) {
+					// Re-read the slot so the cache reflects the device's
+					// actual state
+					await api.get(userId);
+				}
 			}
 			if (succeeded) {
 				this.#clearCachedUserCodes(userId);
@@ -1654,6 +1696,28 @@ export class AccessControlAPI extends FeatureAPI {
 		for (const vid of credentialValues) {
 			valueDB.removeValue(vid);
 		}
+	}
+
+	/**
+	 * Persists a User Code CC slot's status and code in the value DB after a
+	 * successful supervised write, which does not trigger a verification GET.
+	 */
+	#persistCachedUserCode(
+		userId: number,
+		status: UserIDStatus,
+		code: string | Uint8Array,
+	): void {
+		const valueDB = this.endpoint.tryGetNode()?.valueDB;
+		if (!valueDB) return;
+
+		valueDB.setValue(
+			UserCodeCCValues.userIdStatus(userId).endpoint(this.endpoint.index),
+			status,
+		);
+		valueDB.setValue(
+			UserCodeCCValues.userCode(userId).endpoint(this.endpoint.index),
+			code,
+		);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -675,14 +675,13 @@ export class AccessControlAPI extends FeatureAPI {
 			} else if (supervisedCommandSucceeded(result)) {
 				succeeded = true;
 				// Supervision replaces the verification GET, so persist
-				// the written slot state to the value DB ourselves
+				// the new state ourselves
 				this.#persistCachedUserCode(userId, status, codeData);
 			} else {
-				// Re-read the slot so the cache reflects the device's
-				// actual state. Treat devices that applied the change but
-				// reported failure as success. Require an exact readback match
-				// though, since the V1 obfuscation leniency would wrongly
-				// confirm a previous code after an explicit failure.
+				// The device reported failure
+				// Determine the actual state and treat an exact match as
+				// success. The obfuscation leniency does not apply here,
+				// since it would confirm the previous code.
 				const verified = await api.get(userId);
 				succeeded = verified?.userIdStatus === status
 					&& userCodeEquals(codeData, verified.userCode);
@@ -821,12 +820,12 @@ export class AccessControlAPI extends FeatureAPI {
 			} else if (supervisedCommandSucceeded(result)) {
 				succeeded = true;
 				// Supervision replaces the verification GET, so persist
-				// the written slot state to the value DB ourselves
+				// the new state ourselves
 				this.#persistCachedUserCode(userId, status, existingCode);
 			} else {
-				// Re-read the slot so the cache reflects the device's actual
-				// state. Treat devices that applied the change but reported
-				// failure as success.
+				// The device reported failure
+				// Determine the actual state and treat a matching status as
+				// success.
 				const verified = await api.get(userId);
 				succeeded = verified?.userIdStatus === status;
 				if (
@@ -884,10 +883,9 @@ export class AccessControlAPI extends FeatureAPI {
 			if (result != undefined && supervisedCommandSucceeded(result)) {
 				succeeded = true;
 			} else {
-				// Unsupervised, or the device reported failure - verify by
-				// readback, which also reconciles the cache after a failure.
-				// An Available slot is the desired end state, even if the
-				// device rejected clearing an already-empty slot.
+				// Unsupervised, or the device reported failure
+				// Determine the actual state and treat an empty slot as
+				// success in any case.
 				const verified = await api.get(userId);
 				succeeded = verified?.userIdStatus === UserIDStatus.Available;
 			}
@@ -1201,14 +1199,13 @@ export class AccessControlAPI extends FeatureAPI {
 			} else if (supervisedCommandSucceeded(result)) {
 				succeeded = true;
 				// Supervision replaces the verification GET, so persist
-				// the written slot state to the value DB ourselves
+				// the new state ourselves
 				this.#persistCachedUserCode(userId, status, codeData);
 			} else {
-				// Re-read the slot so the cache reflects the device's
-				// actual state. Treat devices that applied the change but
-				// reported failure as success. Require an exact readback match
-				// though, since the V1 obfuscation leniency would wrongly
-				// confirm a previous code after an explicit failure.
+				// The device reported failure
+				// Determine the actual state and treat an exact match as
+				// success. The obfuscation leniency does not apply here,
+				// since it would confirm the previous code.
 				const verified = await api.get(userId);
 				succeeded = verified?.userIdStatus === status
 					&& userCodeEquals(codeData, verified.userCode);
@@ -1317,10 +1314,9 @@ export class AccessControlAPI extends FeatureAPI {
 			if (result != undefined && supervisedCommandSucceeded(result)) {
 				succeeded = true;
 			} else {
-				// Unsupervised, or the device reported failure - verify by
-				// readback, which also reconciles the cache after a failure.
-				// An Available slot is the desired end state, even if the
-				// device rejected clearing an already-empty slot.
+				// Unsupervised, or the device reported failure
+				// Determine the actual state and treat an empty slot as
+				// success in any case.
 				const verified = await api.get(targetUserId);
 				succeeded = verified?.userIdStatus === UserIDStatus.Available;
 			}
@@ -1403,10 +1399,9 @@ export class AccessControlAPI extends FeatureAPI {
 			if (result != undefined && supervisedCommandSucceeded(result)) {
 				succeeded = true;
 			} else if (userId !== 0) {
-				// Unsupervised, or the device reported failure - verify by
-				// readback, which also reconciles the cache after a failure.
-				// An Available slot is the desired end state, even if the
-				// device rejected clearing an already-empty slot.
+				// Unsupervised, or the device reported failure
+				// Determine the actual state and treat an empty slot as
+				// success in any case.
 				const verified = await api.get(userId);
 				succeeded = verified?.userIdStatus === UserIDStatus.Available;
 			} else {

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -215,6 +215,22 @@ function supportsNonPINChars(supportedASCIIChars: string | undefined): boolean {
 // Characters known to be used by nodes that obfuscate user codes in reports
 const USER_CODE_OBFUSCATION_CHARS = ["*"];
 
+/** Compares two user codes, which may be given as strings or binary */
+function userCodeEquals(
+	expected: string | Uint8Array,
+	actual: string | Uint8Array | undefined,
+): boolean {
+	if (actual == undefined) return false;
+
+	// Compare byte-wise unless both codes are strings
+	if (typeof expected !== "string" || typeof actual !== "string") {
+		const toBytes = (v: string | Uint8Array) =>
+			typeof v === "string" ? Bytes.from(v, "ascii") : Bytes.view(v);
+		return toBytes(actual).equals(toBytes(expected));
+	}
+	return actual === expected;
+}
+
 /**
  * Some version 1 nodes obfuscate codes in the report (e.g. "******"), so
  * we need to be a bit lenient when verifying that a code was set correctly.
@@ -226,14 +242,7 @@ function userCodeReadBackConfirmsSet(
 ): boolean {
 	if (actual == undefined) return false;
 
-	// Compare byte-wise unless both codes are strings
-	if (typeof expected !== "string" || typeof actual !== "string") {
-		const toBytes = (v: string | Uint8Array) =>
-			typeof v === "string" ? Bytes.from(v, "ascii") : Bytes.view(v);
-		if (toBytes(actual).equals(toBytes(expected))) return true;
-	} else if (actual === expected) {
-		return true;
-	}
+	if (userCodeEquals(expected, actual)) return true;
 
 	// It has been found that some version 1 nodes wrongfully report obfuscated
 	// User Codes in the User Code Report (e.g. "******").
@@ -663,17 +672,20 @@ export class AccessControlAPI extends FeatureAPI {
 						verified?.userCode,
 						api.version,
 					);
+			} else if (supervisedCommandSucceeded(result)) {
+				succeeded = true;
+				// Supervision replaces the verification GET, so persist
+				// the written slot state to the value DB ourselves
+				this.#persistCachedUserCode(userId, status, codeData);
 			} else {
-				succeeded = supervisedCommandSucceeded(result);
-				if (succeeded) {
-					// Supervision replaces the verification GET, so persist
-					// the written slot state to the value DB ourselves
-					this.#persistCachedUserCode(userId, status, codeData);
-				} else {
-					// Re-read the slot so the cache reflects the device's
-					// actual state
-					await api.get(userId);
-				}
+				// Re-read the slot so the cache reflects the device's
+				// actual state. Treat devices that applied the change but
+				// reported failure as success. Require an exact readback match
+				// though, since the V1 obfuscation leniency would wrongly
+				// confirm a previous code after an explicit failure.
+				const verified = await api.get(userId);
+				succeeded = verified?.userIdStatus === status
+					&& userCodeEquals(codeData, verified.userCode);
 			}
 
 			if (succeeded) {
@@ -798,6 +810,7 @@ export class AccessControlAPI extends FeatureAPI {
 				existingCode,
 			);
 			let succeeded: boolean;
+			let failure = SetUserResult.Error_Unknown;
 			if (result == undefined) {
 				// Unsupervised - verify the change
 				const verified = await api.get(userId);
@@ -805,16 +818,23 @@ export class AccessControlAPI extends FeatureAPI {
 				succeeded = verifiedStatus != undefined
 					&& verifiedStatus !== existingStatus
 					&& verifiedStatus !== UserIDStatus.Available;
+			} else if (supervisedCommandSucceeded(result)) {
+				succeeded = true;
+				// Supervision replaces the verification GET, so persist
+				// the written slot state to the value DB ourselves
+				this.#persistCachedUserCode(userId, status, existingCode);
 			} else {
-				succeeded = supervisedCommandSucceeded(result);
-				if (succeeded) {
-					// Supervision replaces the verification GET, so persist
-					// the written slot state to the value DB ourselves
-					this.#persistCachedUserCode(userId, status, existingCode);
-				} else {
-					// Re-read the slot so the cache reflects the device's
-					// actual state
-					await api.get(userId);
+				// Re-read the slot so the cache reflects the device's actual
+				// state. Treat devices that applied the change but reported
+				// failure as success.
+				const verified = await api.get(userId);
+				succeeded = verified?.userIdStatus === status;
+				if (
+					!succeeded
+					&& verified?.userIdStatus === UserIDStatus.Available
+				) {
+					// There is no user to modify on the device
+					failure = SetUserResult.Error_ModifyRejectedLocationEmpty;
 				}
 			}
 			if (succeeded) {
@@ -828,7 +848,7 @@ export class AccessControlAPI extends FeatureAPI {
 					);
 				}
 			}
-			return succeeded ? SetUserResult.OK : SetUserResult.Error_Unknown;
+			return succeeded ? SetUserResult.OK : failure;
 		}
 	}
 
@@ -861,17 +881,15 @@ export class AccessControlAPI extends FeatureAPI {
 			const api = this.#ucAPI();
 			const result = await api.clear(userId);
 			let succeeded: boolean;
-			if (result == undefined) {
-				// Unsupervised - verify the change
+			if (result != undefined && supervisedCommandSucceeded(result)) {
+				succeeded = true;
+			} else {
+				// Unsupervised, or the device reported failure - verify by
+				// readback, which also reconciles the cache after a failure.
+				// An Available slot is the desired end state, even if the
+				// device rejected clearing an already-empty slot.
 				const verified = await api.get(userId);
 				succeeded = verified?.userIdStatus === UserIDStatus.Available;
-			} else {
-				succeeded = supervisedCommandSucceeded(result);
-				if (!succeeded) {
-					// Re-read the slot so the cache reflects the device's
-					// actual state
-					await api.get(userId);
-				}
 			}
 			if (succeeded) {
 				this.#clearCachedUserCodes(userId);
@@ -1171,6 +1189,7 @@ export class AccessControlAPI extends FeatureAPI {
 				codeData,
 			);
 			let succeeded: boolean;
+			let failure = SetCredentialResult.Error_Unknown;
 			if (result == undefined) {
 				const verified = await api.get(userId);
 				succeeded = verified?.userIdStatus === status
@@ -1179,16 +1198,28 @@ export class AccessControlAPI extends FeatureAPI {
 						verified?.userCode,
 						api.version,
 					);
+			} else if (supervisedCommandSucceeded(result)) {
+				succeeded = true;
+				// Supervision replaces the verification GET, so persist
+				// the written slot state to the value DB ourselves
+				this.#persistCachedUserCode(userId, status, codeData);
 			} else {
-				succeeded = supervisedCommandSucceeded(result);
-				if (succeeded) {
-					// Supervision replaces the verification GET, so persist
-					// the written slot state to the value DB ourselves
-					this.#persistCachedUserCode(userId, status, codeData);
-				} else {
-					// Re-read the slot so the cache reflects the device's
-					// actual state
-					await api.get(userId);
+				// Re-read the slot so the cache reflects the device's
+				// actual state. Treat devices that applied the change but
+				// reported failure as success. Require an exact readback match
+				// though, since the V1 obfuscation leniency would wrongly
+				// confirm a previous code after an explicit failure.
+				const verified = await api.get(userId);
+				succeeded = verified?.userIdStatus === status
+					&& userCodeEquals(codeData, verified.userCode);
+				if (
+					!succeeded
+					&& existingCred
+					&& verified?.userIdStatus === UserIDStatus.Available
+				) {
+					// There is no credential to modify on the device
+					failure = SetCredentialResult
+						.Error_ModifyRejectedLocationEmpty;
 				}
 			}
 			if (succeeded) {
@@ -1210,7 +1241,7 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 			return succeeded
 				? SetCredentialResult.OK
-				: SetCredentialResult.Error_Unknown;
+				: failure;
 		}
 	}
 
@@ -1283,16 +1314,15 @@ export class AccessControlAPI extends FeatureAPI {
 			const api = this.#ucAPI();
 			const result = await api.clear(targetUserId);
 			let succeeded: boolean;
-			if (result == undefined) {
+			if (result != undefined && supervisedCommandSucceeded(result)) {
+				succeeded = true;
+			} else {
+				// Unsupervised, or the device reported failure - verify by
+				// readback, which also reconciles the cache after a failure.
+				// An Available slot is the desired end state, even if the
+				// device rejected clearing an already-empty slot.
 				const verified = await api.get(targetUserId);
 				succeeded = verified?.userIdStatus === UserIDStatus.Available;
-			} else {
-				succeeded = supervisedCommandSucceeded(result);
-				if (!succeeded) {
-					// Re-read the slot so the cache reflects the device's
-					// actual state
-					await api.get(targetUserId);
-				}
 			}
 			if (succeeded) {
 				this.#clearCachedUserCodes(targetUserId);
@@ -1370,20 +1400,20 @@ export class AccessControlAPI extends FeatureAPI {
 			const api = this.#ucAPI();
 			const result = await api.clear(userId);
 			let succeeded: boolean;
-			if (userId !== 0 && result == undefined) {
+			if (result != undefined && supervisedCommandSucceeded(result)) {
+				succeeded = true;
+			} else if (userId !== 0) {
+				// Unsupervised, or the device reported failure - verify by
+				// readback, which also reconciles the cache after a failure.
+				// An Available slot is the desired end state, even if the
+				// device rejected clearing an already-empty slot.
 				const verified = await api.get(userId);
 				succeeded = verified?.userIdStatus === UserIDStatus.Available;
 			} else {
 				// Verifying all users being deleted is unrealistic
 				// since there can be up to 65535 users. So we just
 				// assume it worked when the command was not supervised.
-				succeeded = result == undefined
-					|| supervisedCommandSucceeded(result);
-				if (!succeeded && userId !== 0) {
-					// Re-read the slot so the cache reflects the device's
-					// actual state
-					await api.get(userId);
-				}
+				succeeded = result == undefined;
 			}
 			if (succeeded) {
 				this.#clearCachedUserCodes(userId);

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -1701,7 +1701,10 @@ integrationTest(
 //
 // Supervision replaces the verification GET, so a successful supervised write
 // must persist the written slot state directly, and a failed one must re-read
-// the slot to reconcile the cache with the device's actual state.
+// the slot to reconcile the cache with the device's actual state. The readback
+// after a failure is also used to infer a more specific result than
+// Error_Unknown: a slot that already matches the desired end state means
+// success, an empty slot on a modify/delete means there was nothing to change.
 // =============================================================================
 
 const supervisedUserCodeCapabilities = {
@@ -1863,7 +1866,11 @@ integrationTest(
 				2,
 				"1234",
 			);
-			t.expect(result).toBe(SetCredentialResult.Error_Unknown);
+			// The cache claimed an existing credential, so this was a modify,
+			// and the readback shows there is nothing to modify
+			t.expect(result).toBe(
+				SetCredentialResult.Error_ModifyRejectedLocationEmpty,
+			);
 
 			t.expect(node.valueDB.getValue(statusVid)).toBe(
 				UserIDStatus.Available,
@@ -1880,7 +1887,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteUser reconciles the cache on supervised failure (UC)",
+	"deleteUser returns OK when the device fails clearing an already-empty slot (UC)",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1896,7 +1903,8 @@ integrationTest(
 			node.valueDB.setValue(codeVid, "1234");
 
 			const result = await node.accessControl!.deleteUser(1);
-			t.expect(result).toBe(SetUserResult.Error_Unknown);
+			// The readback shows the desired end state, so this is a success
+			t.expect(result).toBe(SetUserResult.OK);
 
 			t.expect(node.valueDB.getValue(statusVid)).toBe(
 				UserIDStatus.Available,
@@ -1907,7 +1915,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteCredential reconciles the cache on supervised failure (UC)",
+	"deleteCredential returns OK when the device fails clearing an already-empty slot (UC)",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1927,7 +1935,8 @@ integrationTest(
 				UserCredentialType.PINCode,
 				2,
 			);
-			t.expect(result).toBe(SetCredentialResult.Error_Unknown);
+			// The readback shows the desired end state, so this is a success
+			t.expect(result).toBe(SetCredentialResult.OK);
 
 			t.expect(node.valueDB.getValue(statusVid)).toBe(
 				UserIDStatus.Available,
@@ -1938,7 +1947,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteCredentials reconciles the cache on supervised failure (UC)",
+	"deleteCredentials returns OK when the device fails clearing an already-empty slot (UC)",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1956,7 +1965,177 @@ integrationTest(
 			const result = await node.accessControl!.deleteCredentials({
 				userId: 4,
 			});
+			// The readback shows the desired end state, so this is a success
+			t.expect(result).toBe(SetCredentialResult.OK);
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("");
+		},
+	},
+);
+
+integrationTest(
+	"setCredential returns OK when the device applies the change but reports failure (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		customSetup: async (driver, controller, mockNode) => {
+			mockNode.defineBehavior(failSupervisedUserCodeSet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Quirky device: the code was actually applied despite the
+			// supervision failure. Defined here instead of customSetup so the
+			// interview does not already see the code.
+			mockNode.defineBehavior(
+				{
+					handleCC(controller, self, receivedCC) {
+						if (
+							receivedCC instanceof UserCodeCCGet
+							&& receivedCC.userId === 1
+						) {
+							const cc = new UserCodeCCReport({
+								nodeId: controller.ownNodeId,
+								userId: 1,
+								userIdStatus: UserIDStatus.Enabled,
+								userCode: "1234",
+							});
+							return { action: "sendCC", cc };
+						}
+					},
+				} satisfies MockNodeBehavior,
+			);
+
+			const result = await node.accessControl!.setCredential(
+				1,
+				UserCredentialType.PINCode,
+				1,
+				"1234",
+			);
+			t.expect(result).toBe(SetCredentialResult.OK);
+
+			t.expect(
+				node.valueDB.getValue(UserCodeCCValues.userIdStatus(1).id),
+			).toBe(UserIDStatus.Enabled);
+			t.expect(
+				node.valueDB.getValue(UserCodeCCValues.userCode(1).id),
+			).toBe("1234");
+		},
+	},
+);
+
+integrationTest(
+	"setCredential does not accept an obfuscated readback after a supervised failure (V1)",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				CommandClasses.Supervision,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 1,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportedUserIDStatuses: [
+						UserIDStatus.Available,
+						UserIDStatus.Enabled,
+					],
+				}),
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			mockNode.defineBehavior(failSupervisedUserCodeSet);
+			mockNode.defineBehavior(obfuscateUserCodeReadBack("******"));
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// After an explicit supervision failure, an obfuscated readback
+			// must not be treated as confirmation like it is on the
+			// unsupervised path
+			const result = await node.accessControl!.setCredential(
+				1,
+				UserCredentialType.PINCode,
+				1,
+				"1234",
+			);
 			t.expect(result).toBe(SetCredentialResult.Error_Unknown);
+		},
+	},
+);
+
+integrationTest(
+	"deleteUser reconciles the cache when the device fails and keeps the code (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		customSetup: async (driver, controller, mockNode) => {
+			mockNode.defineBehavior(failSupervisedUserCodeSet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// The device refuses the deletion and still has a code that
+			// differs from the cached one. Defined here instead of customSetup
+			// so the interview does not already see the code.
+			mockNode.defineBehavior(
+				{
+					handleCC(controller, self, receivedCC) {
+						if (
+							receivedCC instanceof UserCodeCCGet
+							&& receivedCC.userId === 1
+						) {
+							const cc = new UserCodeCCReport({
+								nodeId: controller.ownNodeId,
+								userId: 1,
+								userIdStatus: UserIDStatus.Enabled,
+								userCode: "5678",
+							});
+							return { action: "sendCC", cc };
+						}
+					},
+				} satisfies MockNodeBehavior,
+			);
+
+			const statusVid = UserCodeCCValues.userIdStatus(1).id;
+			const codeVid = UserCodeCCValues.userCode(1).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "1234");
+
+			const result = await node.accessControl!.deleteUser(1);
+			t.expect(result).toBe(SetUserResult.Error_Unknown);
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Enabled,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("5678");
+		},
+	},
+);
+
+integrationTest(
+	"setUser returns ModifyRejectedLocationEmpty on supervised failure for a missing user (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		customSetup: async (driver, controller, mockNode) => {
+			mockNode.defineBehavior(failSupervisedUserCodeSet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// The cache is wrong: the device's slot is actually empty
+			const statusVid = UserCodeCCValues.userIdStatus(1).id;
+			const codeVid = UserCodeCCValues.userCode(1).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "1234");
+
+			const result = await node.accessControl!.setUser(1, {
+				active: false,
+			});
+			t.expect(result).toBe(
+				SetUserResult.Error_ModifyRejectedLocationEmpty,
+			);
 
 			t.expect(node.valueDB.getValue(statusVid)).toBe(
 				UserIDStatus.Available,

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -1742,7 +1742,7 @@ const failSupervisedUserCodeSet: MockNodeBehavior = {
 };
 
 integrationTest(
-	"setCredential persists status and code on supervised success (UC)",
+	"setCredential persists status and code on supervised success",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1794,7 +1794,7 @@ integrationTest(
 );
 
 integrationTest(
-	"setUser persists status on supervised success (UC)",
+	"setUser persists status on supervised success",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1821,7 +1821,7 @@ integrationTest(
 );
 
 integrationTest(
-	"addUser persists user and code on supervised success (UC)",
+	"addUser persists user and code on supervised success",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1845,7 +1845,7 @@ integrationTest(
 );
 
 integrationTest(
-	"setCredential reconciles the cache on supervised failure (UC)",
+	"setCredential reconciles the cache on supervised failure",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1887,7 +1887,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteUser returns OK when the device fails clearing an already-empty slot (UC)",
+	"deleteUser returns OK when the device fails clearing an already-empty slot",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1915,7 +1915,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteCredential returns OK when the device fails clearing an already-empty slot (UC)",
+	"deleteCredential returns OK when the device fails clearing an already-empty slot",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1947,7 +1947,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteCredentials returns OK when the device fails clearing an already-empty slot (UC)",
+	"deleteCredentials returns OK when the device fails clearing an already-empty slot",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -1977,7 +1977,7 @@ integrationTest(
 );
 
 integrationTest(
-	"setCredential returns OK when the device applies the change but reports failure (UC)",
+	"setCredential returns OK when the device applies the change but reports failure",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -2067,7 +2067,7 @@ integrationTest(
 );
 
 integrationTest(
-	"deleteUser reconciles the cache when the device fails and keeps the code (UC)",
+	"deleteUser reconciles the cache when the device fails and keeps the code",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 
@@ -2115,7 +2115,7 @@ integrationTest(
 );
 
 integrationTest(
-	"setUser returns ModifyRejectedLocationEmpty on supervised failure for a missing user (UC)",
+	"setUser returns ModifyRejectedLocationEmpty on supervised failure for a missing user",
 	{
 		nodeCapabilities: supervisedUserCodeCapabilities,
 

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -1,4 +1,6 @@
 import {
+	SupervisionCCGet,
+	SupervisionCommand,
 	UserCredentialRule,
 	UserCredentialType,
 	UserCredentialUserType,
@@ -1690,6 +1692,276 @@ integrationTest(
 				"1234",
 			);
 			t.expect(result).toBe(SetCredentialResult.Error_Unknown);
+		},
+	},
+);
+
+// =============================================================================
+// Supervised writes and the value DB
+//
+// Supervision replaces the verification GET, so a successful supervised write
+// must persist the written slot state directly, and a failed one must re-read
+// the slot to reconcile the cache with the device's actual state.
+// =============================================================================
+
+const supervisedUserCodeCapabilities = {
+	commandClasses: [
+		CommandClasses.Version,
+		CommandClasses.Supervision,
+		ccCaps({
+			ccId: CommandClasses["User Code"],
+			version: 2,
+			numUsers: 10,
+			supportedASCIIChars: "0123456789",
+			supportedUserIDStatuses: [
+				UserIDStatus.Available,
+				UserIDStatus.Enabled,
+				UserIDStatus.Disabled,
+			],
+		}),
+	],
+};
+
+// Have the node respond to all supervised User Code sets negatively
+const failSupervisedUserCodeSet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (
+			(receivedCC instanceof UserCodeCCSet
+				|| receivedCC instanceof UserCodeCCExtendedUserCodeSet)
+			&& receivedCC.isEncapsulatedWith(
+				CommandClasses.Supervision,
+				SupervisionCommand.Get,
+			)
+		) {
+			return { action: "fail" };
+		}
+	},
+};
+
+integrationTest(
+	"setCredential persists status and code on supervised success (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			mockNode.clearReceivedControllerFrames();
+
+			const result = await node.accessControl!.setCredential(
+				3,
+				UserCredentialType.PINCode,
+				3,
+				"1234",
+			);
+			t.expect(result).toBe(SetCredentialResult.OK);
+
+			// The write must have used Supervision...
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof SupervisionCCGet
+					&& frame.payload.encapsulated
+						instanceof UserCodeCCExtendedUserCodeSet,
+				{
+					errorMessage:
+						"Node should have received a supervised User Code set",
+				},
+			);
+			// ...without a verification GET
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof UserCodeCCGet,
+				{ noMatch: true },
+			);
+
+			t.expect(
+				node.valueDB.getValue(UserCodeCCValues.userIdStatus(3).id),
+			).toBe(UserIDStatus.Enabled);
+			t.expect(
+				node.valueDB.getValue(UserCodeCCValues.userCode(3).id),
+			).toBe("1234");
+
+			const cached = node.accessControl!.getCredentialCached(
+				UserCredentialType.PINCode,
+				3,
+			);
+			t.expect(cached?.data).toBe("1234");
+		},
+	},
+);
+
+integrationTest(
+	"setUser persists status on supervised success (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const statusVid = UserCodeCCValues.userIdStatus(1).id;
+			const codeVid = UserCodeCCValues.userCode(1).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "1234");
+
+			const result = await node.accessControl!.setUser(1, {
+				active: false,
+			});
+			t.expect(result).toBe(SetUserResult.OK);
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Disabled,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("1234");
+
+			const cached = node.accessControl!.getUserCached(1);
+			t.expect(cached?.active).toBe(false);
+		},
+	},
+);
+
+integrationTest(
+	"addUser persists user and code on supervised success (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const result = await node.accessControl!.addUser(2, {}, {
+				type: UserCredentialType.PINCode,
+				slot: 2,
+				data: "5678",
+			});
+			t.expect(result.user).toBe(SetUserResult.OK);
+			t.expect(result.credential).toBe(SetCredentialResult.OK);
+
+			t.expect(
+				node.valueDB.getValue(UserCodeCCValues.userIdStatus(2).id),
+			).toBe(UserIDStatus.Enabled);
+			t.expect(
+				node.valueDB.getValue(UserCodeCCValues.userCode(2).id),
+			).toBe("5678");
+		},
+	},
+);
+
+integrationTest(
+	"setCredential reconciles the cache on supervised failure (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		customSetup: async (driver, controller, mockNode) => {
+			mockNode.defineBehavior(failSupervisedUserCodeSet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// The cache is wrong: the device's slot is actually empty
+			const statusVid = UserCodeCCValues.userIdStatus(2).id;
+			const codeVid = UserCodeCCValues.userCode(2).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "9999");
+
+			const result = await node.accessControl!.setCredential(
+				2,
+				UserCredentialType.PINCode,
+				2,
+				"1234",
+			);
+			t.expect(result).toBe(SetCredentialResult.Error_Unknown);
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("");
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.PINCode,
+					2,
+				),
+			).toBeUndefined();
+		},
+	},
+);
+
+integrationTest(
+	"deleteUser reconciles the cache on supervised failure (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		customSetup: async (driver, controller, mockNode) => {
+			mockNode.defineBehavior(failSupervisedUserCodeSet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// The cache is wrong: the device's slot is actually empty
+			const statusVid = UserCodeCCValues.userIdStatus(1).id;
+			const codeVid = UserCodeCCValues.userCode(1).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "1234");
+
+			const result = await node.accessControl!.deleteUser(1);
+			t.expect(result).toBe(SetUserResult.Error_Unknown);
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("");
+		},
+	},
+);
+
+integrationTest(
+	"deleteCredential reconciles the cache on supervised failure (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		customSetup: async (driver, controller, mockNode) => {
+			mockNode.defineBehavior(failSupervisedUserCodeSet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// The cache is wrong: the device's slot is actually empty
+			const statusVid = UserCodeCCValues.userIdStatus(2).id;
+			const codeVid = UserCodeCCValues.userCode(2).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "1234");
+
+			const result = await node.accessControl!.deleteCredential(
+				2,
+				UserCredentialType.PINCode,
+				2,
+			);
+			t.expect(result).toBe(SetCredentialResult.Error_Unknown);
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("");
+		},
+	},
+);
+
+integrationTest(
+	"deleteCredentials reconciles the cache on supervised failure (UC)",
+	{
+		nodeCapabilities: supervisedUserCodeCapabilities,
+
+		customSetup: async (driver, controller, mockNode) => {
+			mockNode.defineBehavior(failSupervisedUserCodeSet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// The cache is wrong: the device's slot is actually empty
+			const statusVid = UserCodeCCValues.userIdStatus(4).id;
+			const codeVid = UserCodeCCValues.userCode(4).id;
+			node.valueDB.setValue(statusVid, UserIDStatus.Enabled);
+			node.valueDB.setValue(codeVid, "1111");
+
+			const result = await node.accessControl!.deleteCredentials({
+				userId: 4,
+			});
+			t.expect(result).toBe(SetCredentialResult.Error_Unknown);
+
+			t.expect(node.valueDB.getValue(statusVid)).toBe(
+				UserIDStatus.Available,
+			);
+			t.expect(node.valueDB.getValue(codeVid)).toBe("");
 		},
 	},
 );


### PR DESCRIPTION
Supervised User Code CC writes through the unified access control API previously never updated the value DB, so cached getters served stale data on S2 locks.

Successful supervised writes in `setCredential` / `addUser` / `setUser` now persist the written slot state, mirroring #8866's fix for the delete side.

Failed supervised commands now re-read the affected slot, so the cache reconciles with the device's actual state. The readback also determines the returned result: a slot that already matches the desired end state counts as success, and an empty slot on a modify returns `Error_ModifyRejectedLocationEmpty`.