### PR TITLE
refactor: make AccessControl API the source of truth for User Code CC

### DIFF
--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -40,9 +40,7 @@ import {
 	SET_VALUE_HOOKS,
 	type SetValueImplementation,
 	type SetValueImplementationHooksFactory,
-	throwMissingPropertyKey,
 	throwUnsupportedProperty,
-	throwUnsupportedPropertyKey,
 	throwWrongValueType,
 } from "../lib/API.js";
 import {
@@ -130,17 +128,9 @@ export const UserCodeCCValues = V.defineCCValues(CommandClasses["User Code"], {
 			maxLength: 10,
 		},
 		{
+			internal: true,
 			minVersion: 2,
 			secret: true,
-		},
-	),
-	...V.staticPropertyWithName(
-		"_deprecated_masterCode",
-		"masterCode",
-		undefined,
-		{
-			internal: true,
-			autoCreate: false,
 		},
 	),
 	...V.dynamicPropertyAndKeyWithName(
@@ -153,6 +143,7 @@ export const UserCodeCCValues = V.defineCCValues(CommandClasses["User Code"], {
 			...ValueMetadata.Number,
 			label: `User ID status (${userId})`,
 		}),
+		{ internal: true },
 	),
 	...V.dynamicPropertyAndKeyWithName(
 		"userCode",
@@ -162,7 +153,7 @@ export const UserCodeCCValues = V.defineCCValues(CommandClasses["User Code"], {
 			property === "userCode" && typeof propertyKey === "number",
 		// The user code metadata is dynamically created
 		undefined,
-		{ secret: true },
+		{ internal: true, secret: true },
 	),
 });
 
@@ -262,8 +253,59 @@ function persistUserCode(
 		this.setValue(ctx, statusValue, userIdStatus);
 		this.setValue(ctx, codeValue, userCode);
 	}
+}
 
-	return true;
+function persistAdminCode(
+	this: UserCodeCC,
+	ctx: GetValueDB,
+	adminCode: string,
+) {
+	this.ensureMetadata(ctx, UserCodeCCValues.adminCode);
+	this.setValue(ctx, UserCodeCCValues.adminCode, adminCode);
+}
+
+/**
+ * Updates the cache with the state contained in the report. This does not
+ * happen automatically, so the receiver can diff the report against the cache
+ * before updating it.
+ */
+export function persistUserCodeReport(
+	report: UserCodeCCReport,
+	ctx: GetValueDB & GetSupportedCCVersion,
+): void {
+	persistUserCode.call(
+		report,
+		ctx,
+		report.userId,
+		report.userIdStatus,
+		report.userCode,
+	);
+}
+
+/**
+ * Updates the cache with the state contained in the report. This does not
+ * happen automatically, so the receiver can diff the report against the cache
+ * before updating it.
+ */
+export function persistExtendedUserCodeReport(
+	report: UserCodeCCExtendedUserCodeReport,
+	ctx: GetValueDB & GetSupportedCCVersion,
+): void {
+	for (const { userId, userIdStatus, userCode } of report.userCodes) {
+		persistUserCode.call(report, ctx, userId, userIdStatus, userCode);
+	}
+}
+
+/**
+ * Updates the cache with the state contained in the report. This does not
+ * happen automatically, so the receiver can diff the report against the cache
+ * before updating it.
+ */
+export function persistAdminCodeReport(
+	report: UserCodeCCAdminCodeReport,
+	ctx: GetValueDB,
+): void {
+	persistAdminCode.call(report, ctx, report.adminCode);
 }
 
 /** Formats a user code in a way that's safe to print in public logs */
@@ -313,10 +355,9 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 	protected override get [SET_VALUE](): SetValueImplementation {
 		return async function(
 			this: UserCodeCCAPI,
-			{ property, propertyKey },
+			{ property },
 			value,
 		) {
-			let result: SupervisionResult | undefined;
 			if (property === "keypadMode") {
 				if (typeof value !== "number") {
 					throwWrongValueType(
@@ -326,93 +367,10 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 						typeof value,
 					);
 				}
-				result = await this.setKeypadMode(value);
-			} else if (
-				property === "adminCode"
-				// Support devices that were interviewed before the rename to adminCode
-				|| property === "masterCode"
-			) {
-				if (typeof value !== "string") {
-					throwWrongValueType(
-						this.ccId,
-						property,
-						"string",
-						typeof value,
-					);
-				}
-				result = await this.setAdminCode(value);
-			} else if (property === "userIdStatus") {
-				if (propertyKey == undefined) {
-					throwMissingPropertyKey(this.ccId, property);
-				} else if (typeof propertyKey !== "number") {
-					throwUnsupportedPropertyKey(
-						this.ccId,
-						property,
-						propertyKey,
-					);
-				}
-				if (typeof value !== "number") {
-					throwWrongValueType(
-						this.ccId,
-						property,
-						"number",
-						typeof value,
-					);
-				}
-
-				if (value === UserIDStatus.Available) {
-					// Clear Code
-					result = await this.clear(propertyKey);
-				} else {
-					// We need to set the user code along with the status
-					const userCode = this.getValueDB().getValue<string>(
-						UserCodeCCValues.userCode(propertyKey).endpoint(
-							this.endpoint.index,
-						),
-					);
-					result = await this.set(propertyKey, value, userCode!);
-				}
-			} else if (property === "userCode") {
-				if (propertyKey == undefined) {
-					throwMissingPropertyKey(this.ccId, property);
-				} else if (typeof propertyKey !== "number") {
-					throwUnsupportedPropertyKey(
-						this.ccId,
-						property,
-						propertyKey,
-					);
-				}
-				if (typeof value !== "string" && !isUint8Array(value)) {
-					throwWrongValueType(
-						this.ccId,
-						property,
-						"string or Buffer",
-						typeof value,
-					);
-				}
-
-				// We need to set the user id status along with the code
-				let userIdStatus = this.getValueDB().getValue<UserIDStatus>(
-					UserCodeCCValues.userIdStatus(propertyKey).endpoint(
-						this.endpoint.index,
-					),
-				);
-				if (
-					userIdStatus === UserIDStatus.Available
-					|| userIdStatus == undefined
-				) {
-					userIdStatus = UserIDStatus.Enabled;
-				}
-				result = await this.set(
-					propertyKey,
-					userIdStatus as any,
-					value,
-				);
+				return this.setKeypadMode(value);
 			} else {
 				throwUnsupportedProperty(this.ccId, property);
 			}
-
-			return result;
 		};
 	}
 
@@ -427,36 +385,15 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			propertyKey,
 		};
 
-		if (
-			UserCodeCCValues.keypadMode.is(valueId)
-			|| UserCodeCCValues.adminCode.is(valueId)
-			// Support devices that were interviewed before the rename to adminCode
-			|| UserCodeCCValues._deprecated_masterCode.is(valueId)
-		) {
-			// Keypad mode, admin/master code should update immediately.
+		if (UserCodeCCValues.keypadMode.is(valueId)) {
+			// The keypad mode should update immediately.
 			// Optimistically update when supervised successfully, otherwise verify
-			// For the deprecated masterCode, the canonical target is adminCode
 			return {
 				forceVerifyChanges: () => true,
 				verifyChanges: (result) => {
 					if (supervisedCommandSucceeded(result)) {
 						this.tryGetValueDB()?.setValue(valueId, value);
 					} else if (this.isSinglecast()) {
-						this.schedulePoll(valueId, value, {
-							transition: "fast",
-						});
-					}
-				},
-			};
-		} else if (
-			UserCodeCCValues.userCode.is(valueId)
-			|| UserCodeCCValues.userIdStatus.is(valueId)
-		) {
-			// Simply verify the change in any case
-			return {
-				forceVerifyChanges: () => true,
-				verifyChanges: (_result) => {
-					if (this.isSinglecast()) {
 						this.schedulePoll(valueId, value, {
 							transition: "fast",
 						});
@@ -471,25 +408,10 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 	}
 
 	protected get [POLL_VALUE](): PollValueImplementation {
-		return async function(this: UserCodeCCAPI, { property, propertyKey }) {
+		return async function(this: UserCodeCCAPI, { property }) {
 			switch (property) {
 				case "keypadMode":
 					return this.getKeypadMode();
-				case "adminCode":
-					return this.getAdminCode();
-				case "userIdStatus":
-				case "userCode": {
-					if (propertyKey == undefined) {
-						throwMissingPropertyKey(this.ccId, property);
-					} else if (typeof propertyKey !== "number") {
-						throwUnsupportedPropertyKey(
-							this.ccId,
-							property,
-							propertyKey,
-						);
-					}
-					return (await this.get(propertyKey))?.[property];
-				}
 				default:
 					throwUnsupportedProperty(this.ccId, property);
 			}
@@ -549,7 +471,13 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			);
 			if (!response) {
 				return;
-			} else if (multiple) {
+			}
+			// Reports are not persisted automatically, so their contents can be
+			// diffed against the cache elsewhere. Solicited responses are
+			// persisted here instead.
+			persistExtendedUserCodeReport(response, this.host);
+
+			if (multiple) {
 				return pick(response, ["userCodes", "nextUserId"]);
 			} else {
 				return pick(response.userCodes[0], [
@@ -569,7 +497,13 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				cc,
 				this.commandOptions,
 			);
-			if (response) return pick(response, ["userIdStatus", "userCode"]);
+			if (response) {
+				// Reports are not persisted automatically, so their contents can
+				// be diffed against the cache elsewhere. Solicited responses are
+				// persisted here instead.
+				persistUserCodeReport(response, this.host);
+				return pick(response, ["userIdStatus", "userCode"]);
+			}
 		}
 	}
 
@@ -866,6 +800,12 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			cc,
 			this.commandOptions,
 		);
+		if (response) {
+			// Reports are not persisted automatically, so their contents can be
+			// diffed against the cache elsewhere. Solicited responses are
+			// persisted here instead.
+			persistAdminCodeReport(response, this.host);
+		}
 		return response?.adminCode;
 	}
 
@@ -1607,19 +1547,6 @@ export class UserCodeCCReport extends UserCodeCC
 	public readonly userIdStatus: UserIDStatus;
 	public readonly userCode: string | Bytes;
 
-	public persistValues(ctx: PersistValuesContext): boolean {
-		if (!super.persistValues(ctx)) return false;
-
-		persistUserCode.call(
-			this,
-			ctx,
-			this.userId,
-			this.userIdStatus,
-			this.userCode,
-		);
-		return true;
-	}
-
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		let userCodeBuffer: Bytes;
 		if (typeof this.userCode === "string") {
@@ -2131,7 +2058,6 @@ export interface UserCodeCCAdminCodeReportOptions {
 }
 
 @CCCommand(UserCodeCommand.AdminCodeReport)
-@ccValueProperty("adminCode", UserCodeCCValues.adminCode)
 export class UserCodeCCAdminCodeReport extends UserCodeCC {
 	public constructor(
 		options: WithAddress<UserCodeCCAdminCodeReportOptions>,
@@ -2382,23 +2308,32 @@ export class UserCodeCCExtendedUserCodeReport extends UserCodeCC {
 		});
 	}
 
-	public persistValues(ctx: PersistValuesContext): boolean {
-		if (!super.persistValues(ctx)) return false;
-
-		for (const { userId, userIdStatus, userCode } of this.userCodes) {
-			persistUserCode.call(
-				this,
-				ctx,
-				userId,
-				userIdStatus,
-				userCode,
-			);
-		}
-		return true;
-	}
-
 	public readonly userCodes: readonly UserCode[];
 	public readonly nextUserId: number;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const userCodeBuffers = this.userCodes.map((code) => {
+			const ret = Bytes.concat([
+				[
+					0,
+					0,
+					code.userIdStatus,
+					code.userCode.length,
+				],
+				Bytes.from(code.userCode, "ascii"),
+			]);
+			ret.writeUInt16BE(code.userId, 0);
+			return ret;
+		});
+		const nextUserIdBuffer = new Bytes(2);
+		nextUserIdBuffer.writeUInt16BE(this.nextUserId, 0);
+		this.payload = Bytes.concat([
+			[this.userCodes.length],
+			...userCodeBuffers,
+			nextUserIdBuffer,
+		]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {};

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -8897,39 +8897,12 @@ export const UserCodeCCValues = Object.freeze({
 			} as const;
 		},
 		options: {
-			internal: false,
+			internal: true,
 			minVersion: 2,
 			secret: true,
 			stateful: true,
 			supportsEndpoints: true,
 			autoCreate: true,
-		} as const satisfies CCValueOptions,
-	},
-	_deprecated_masterCode: {
-		id: {
-			commandClass: CommandClasses["User Code"],
-			property: "masterCode",
-		} as const,
-		endpoint: (endpoint: number = 0) => ({
-			commandClass: CommandClasses["User Code"],
-			endpoint,
-			property: "masterCode",
-		} as const),
-		is: (valueId: ValueID): boolean => {
-			return valueId.commandClass === CommandClasses["User Code"]
-				&& valueId.property === "masterCode"
-				&& valueId.propertyKey == undefined;
-		},
-		get meta() {
-			return ValueMetadata.Any;
-		},
-		options: {
-			internal: true,
-			minVersion: 1,
-			secret: false,
-			stateful: true,
-			supportsEndpoints: true,
-			autoCreate: false,
 		} as const satisfies CCValueOptions,
 	},
 	userIdStatus: Object.assign(
@@ -8965,7 +8938,7 @@ export const UserCodeCCValues = Object.freeze({
 						&& typeof propertyKey === "number")(valueId);
 			},
 			options: {
-				internal: false,
+				internal: true,
 				minVersion: 1,
 				secret: false,
 				stateful: true,
@@ -9004,7 +8977,7 @@ export const UserCodeCCValues = Object.freeze({
 						&& typeof propertyKey === "number")(valueId);
 			},
 			options: {
-				internal: false,
+				internal: true,
 				minVersion: 1,
 				secret: true,
 				stateful: true,

--- a/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
@@ -42,6 +42,7 @@ import type { ZWaveNode } from "../Node.js";
 import type {
 	ZWaveNotificationCallbackArgs_NotificationCC,
 } from "../_Types.js";
+import { getUserCodeCredentialType } from "../feature-apis/AccessControl.js";
 import type { NodeValues } from "../mixins/40_Values.js";
 
 export interface NotificationHandlerStore {
@@ -564,6 +565,18 @@ function handleKnownNotification(
 			);
 			UserCodeCC.setUserCodeCached(ctx, endpoint, userId, "");
 		}
+
+		// Notify applications with wildcard events, matching the unified
+		// bulk-delete semantics where user ID 0 addresses all users
+		const eventTarget = node.getEndpoint(command.endpointIndex) ?? node;
+		node.emit("user deleted", eventTarget, { userId: 0 });
+		node.emit("credential deleted", eventTarget, {
+			userId: 0,
+			credentialType: getUserCodeCredentialType(
+				UserCodeCC.getSupportedASCIICharsCached(ctx, endpoint),
+			),
+			credentialSlot: 0,
+		});
 	}
 }
 

--- a/packages/zwave-js/src/lib/node/CCHandlers/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/UserCodeCC.ts
@@ -1,0 +1,166 @@
+import { type UserIDStatus } from "@zwave-js/cc";
+import {
+	UserCodeCC,
+	type UserCodeCCAdminCodeReport,
+	type UserCodeCCExtendedUserCodeReport,
+	type UserCodeCCReport,
+	persistAdminCodeReport,
+	persistExtendedUserCodeReport,
+	persistUserCodeReport,
+} from "@zwave-js/cc/UserCodeCC";
+import type {
+	EndpointId,
+	GetSupportedCCVersion,
+	GetValueDB,
+} from "@zwave-js/core";
+import { Bytes, type BytesView } from "@zwave-js/shared";
+import type { ZWaveNode } from "../Node.js";
+import {
+	getUserCodeCredentialType,
+	mapUserCodeStatusToUserData,
+} from "../feature-apis/AccessControl.js";
+
+function codeEquals(
+	a: string | BytesView | undefined,
+	b: string | BytesView | undefined,
+): boolean {
+	if (a == undefined || b == undefined) return a === b;
+	if (typeof a === "string" && typeof b === "string") return a === b;
+	const toBytes = (v: string | BytesView) =>
+		typeof v === "string" ? Bytes.from(v, "ascii") : Bytes.view(v);
+	return toBytes(a).equals(toBytes(b));
+}
+
+function nodeEndpointId(node: ZWaveNode, endpointIndex: number): EndpointId {
+	return {
+		nodeId: node.id,
+		index: endpointIndex,
+		virtual: false,
+	};
+}
+
+// User Code CC reports are snapshots of a slot's state, so the kind of
+// change is determined by diffing against the previously cached state
+function emitUserCodeChangeEvents(
+	ctx: GetValueDB,
+	node: ZWaveNode,
+	endpointIndex: number,
+	userId: number,
+	prevStatus: UserIDStatus | undefined,
+	prevCode: string | BytesView | undefined,
+	userIdStatus: UserIDStatus,
+	userCode: string | BytesView,
+): void {
+	const prevUser = mapUserCodeStatusToUserData(userId, prevStatus);
+	const newUser = mapUserCodeStatusToUserData(userId, userIdStatus);
+	if (!prevUser && !newUser) return;
+
+	const endpoint = node.getEndpoint(endpointIndex) ?? node;
+	const credentialType = getUserCodeCredentialType(
+		UserCodeCC.getSupportedASCIICharsCached(
+			ctx,
+			nodeEndpointId(node, endpointIndex),
+		),
+	);
+
+	if (!prevUser && newUser) {
+		node.emit("user added", endpoint, newUser);
+		node.emit("credential added", endpoint, {
+			userId,
+			credentialType,
+			// For User Code CC, credential slots and users are identical
+			credentialSlot: userId,
+			data: userCode,
+		});
+	} else if (prevUser && !newUser) {
+		node.emit("user deleted", endpoint, { userId });
+		node.emit("credential deleted", endpoint, {
+			userId,
+			credentialType,
+			credentialSlot: userId,
+		});
+	} else if (prevUser && newUser) {
+		if (
+			prevUser.active !== newUser.active
+			|| prevUser.userType !== newUser.userType
+		) {
+			node.emit("user modified", endpoint, newUser);
+		}
+		if (!codeEquals(prevCode, userCode)) {
+			node.emit("credential modified", endpoint, {
+				userId,
+				credentialType,
+				credentialSlot: userId,
+				data: userCode,
+			});
+		}
+	}
+}
+
+export function handleUserCodeReport(
+	ctx: GetValueDB & GetSupportedCCVersion,
+	node: ZWaveNode,
+	report: UserCodeCCReport,
+): void {
+	const endpointId = nodeEndpointId(node, report.endpointIndex);
+	const prevStatus = UserCodeCC.getUserIdStatusCached(
+		ctx,
+		endpointId,
+		report.userId,
+	);
+	const prevCode = UserCodeCC.getUserCodeCached(
+		ctx,
+		endpointId,
+		report.userId,
+	);
+
+	persistUserCodeReport(report, ctx);
+
+	emitUserCodeChangeEvents(
+		ctx,
+		node,
+		report.endpointIndex,
+		report.userId,
+		prevStatus,
+		prevCode,
+		report.userIdStatus,
+		report.userCode,
+	);
+}
+
+export function handleExtendedUserCodeReport(
+	ctx: GetValueDB & GetSupportedCCVersion,
+	node: ZWaveNode,
+	report: UserCodeCCExtendedUserCodeReport,
+): void {
+	const endpointId = nodeEndpointId(node, report.endpointIndex);
+	const prevStates = report.userCodes.map(({ userId }) => ({
+		status: UserCodeCC.getUserIdStatusCached(ctx, endpointId, userId),
+		code: UserCodeCC.getUserCodeCached(ctx, endpointId, userId),
+	}));
+
+	persistExtendedUserCodeReport(report, ctx);
+
+	for (let i = 0; i < report.userCodes.length; i++) {
+		const { userId, userIdStatus, userCode } = report.userCodes[i];
+		emitUserCodeChangeEvents(
+			ctx,
+			node,
+			report.endpointIndex,
+			userId,
+			prevStates[i].status,
+			prevStates[i].code,
+			userIdStatus,
+			userCode,
+		);
+	}
+}
+
+export function handleAdminCodeReport(
+	ctx: GetValueDB,
+	report: UserCodeCCAdminCodeReport,
+): void {
+	// There is no unified event for admin code changes, so only the cache
+	// needs to be updated
+	persistAdminCodeReport(report, ctx);
+}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -74,6 +74,11 @@ import { Security2CCNonceGet } from "@zwave-js/cc/Security2CC";
 import { SecurityCCNonceGet } from "@zwave-js/cc/SecurityCC";
 import { ThermostatModeCCSet } from "@zwave-js/cc/ThermostatModeCC";
 import {
+	UserCodeCCAdminCodeReport,
+	UserCodeCCExtendedUserCodeReport,
+	UserCodeCCReport,
+} from "@zwave-js/cc/UserCodeCC";
+import {
 	UserCredentialCCAssociationReport,
 	UserCredentialCCCredentialLearnReport,
 	UserCredentialCCCredentialReport,
@@ -239,6 +244,11 @@ import {
 	handleTimeGet,
 	handleTimeOffsetGet,
 } from "./CCHandlers/TimeCC.js";
+import {
+	handleAdminCodeReport,
+	handleExtendedUserCodeReport,
+	handleUserCodeReport,
+} from "./CCHandlers/UserCodeCC.js";
 import {
 	handleUserCredentialAssociationReport,
 	handleUserCredentialCredentialLearnReport,
@@ -2868,6 +2878,12 @@ protocol version:      ${this.protocolVersion}`;
 				command,
 				this.entryControlHandlerStore,
 			);
+		} else if (command instanceof UserCodeCCReport) {
+			return handleUserCodeReport(this.driver, this, command);
+		} else if (command instanceof UserCodeCCExtendedUserCodeReport) {
+			return handleExtendedUserCodeReport(this.driver, this, command);
+		} else if (command instanceof UserCodeCCAdminCodeReport) {
+			return handleAdminCodeReport(this.driver, command);
 		} else if (command instanceof UserCredentialCCUserReport) {
 			return handleUserCredentialUserReport(this, command);
 		} else if (command instanceof UserCredentialCCCredentialReport) {

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -212,6 +212,63 @@ function supportsNonPINChars(supportedASCIIChars: string | undefined): boolean {
 		&& NON_PIN_CHARS.test(supportedASCIIChars);
 }
 
+/**
+ * Returns the unified credential type used to represent User Code CC
+ * credentials, based on the ASCII characters the node accepts in user codes.
+ * @internal
+ */
+export function getUserCodeCredentialType(
+	supportedASCIIChars: string | undefined,
+): UserCredentialType {
+	return supportsNonPINChars(supportedASCIIChars)
+		? UserCredentialType.Password
+		: UserCredentialType.PINCode;
+}
+
+/**
+ * Maps User Code CC's UserIDStatus to the unified active/userType model.
+ * Returns `undefined` for statuses that indicate no configured user.
+ * @internal
+ */
+export function mapUserCodeStatusToUserData(
+	userId: number,
+	status: UserIDStatus | undefined,
+): UserData | undefined {
+	// These statuses indicate no user is configured for this slot
+	if (
+		status == undefined
+		|| status === UserIDStatus.Available
+		|| status === UserIDStatus.StatusNotAvailable
+		|| status === UserIDStatus.PassageMode
+	) {
+		return undefined;
+	}
+
+	let active: boolean;
+	let userType: UserCredentialUserType;
+	switch (status) {
+		case UserIDStatus.Enabled:
+			active = true;
+			userType = UserCredentialUserType.General;
+			break;
+		case UserIDStatus.Disabled:
+			active = false;
+			userType = UserCredentialUserType.General;
+			break;
+		// Messaging is the closest User Code CC equivalent to NonAccess
+		case UserIDStatus.Messaging:
+			active = true;
+			userType = UserCredentialUserType.NonAccess;
+			break;
+		default:
+			active = true;
+			userType = UserCredentialUserType.General;
+			break;
+	}
+
+	return { userId, active, userType };
+}
+
 // Characters known to be used by nodes that obfuscate user codes in reports
 const USER_CODE_OBFUSCATION_CHARS = ["*"];
 
@@ -434,7 +491,7 @@ export class AccessControlAPI extends FeatureAPI {
 			const api = this.#ucAPI();
 			const result = await api.get(userId);
 			if (!result) return undefined;
-			return this.#mapUserCodeStatusToUserData(
+			return mapUserCodeStatusToUserData(
 				userId,
 				result.userIdStatus,
 			);
@@ -502,7 +559,7 @@ export class AccessControlAPI extends FeatureAPI {
 					users.push(
 						...response.userCodes
 							.map((entry) =>
-								this.#mapUserCodeStatusToUserData(
+								mapUserCodeStatusToUserData(
 									entry.userId,
 									entry.userIdStatus,
 								)
@@ -515,7 +572,7 @@ export class AccessControlAPI extends FeatureAPI {
 				for (let userId = 1; userId <= maxUsers; userId++) {
 					const result = await api.get(userId);
 					if (!result) continue;
-					const user = this.#mapUserCodeStatusToUserData(
+					const user = mapUserCodeStatusToUserData(
 						userId,
 						result.userIdStatus,
 					);
@@ -1528,48 +1585,7 @@ export class AccessControlAPI extends FeatureAPI {
 
 	/** Returns the credential type to use for User Code CC based on supported characters */
 	get #ucCredentialType(): UserCredentialType {
-		return supportsNonPINChars(this.#supportedASCIIChars)
-			? UserCredentialType.Password
-			: UserCredentialType.PINCode;
-	}
-
-	/** Maps User Code CC's UserIDStatus to the unified active/userType model */
-	#mapUserCodeStatusToUserData(
-		userId: number,
-		status: UserIDStatus,
-	): UserData | undefined {
-		// These statuses indicate no user is configured for this slot
-		if (
-			status === UserIDStatus.Available
-			|| status === UserIDStatus.StatusNotAvailable
-			|| status === UserIDStatus.PassageMode
-		) {
-			return undefined;
-		}
-
-		let active: boolean;
-		let userType: UserCredentialUserType;
-		switch (status) {
-			case UserIDStatus.Enabled:
-				active = true;
-				userType = UserCredentialUserType.General;
-				break;
-			case UserIDStatus.Disabled:
-				active = false;
-				userType = UserCredentialUserType.General;
-				break;
-			// Messaging is the closest User Code CC equivalent to NonAccess
-			case UserIDStatus.Messaging:
-				active = true;
-				userType = UserCredentialUserType.NonAccess;
-				break;
-			default:
-				active = true;
-				userType = UserCredentialUserType.General;
-				break;
-		}
-
-		return { userId, active, userType };
+		return getUserCodeCredentialType(this.#supportedASCIIChars);
 	}
 
 	/**
@@ -1981,7 +1997,7 @@ export class AccessControlAPI extends FeatureAPI {
 			),
 		);
 		if (status == undefined) return undefined;
-		return this.#mapUserCodeStatusToUserData(userId, status);
+		return mapUserCodeStatusToUserData(userId, status);
 	}
 
 	#getCredentialCached_UC(

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -1,12 +1,15 @@
 import {
+	SetValueStatus,
 	UserCredentialRule,
 	UserCredentialType,
 	UserCredentialUserType,
 	UserIDStatus,
 } from "@zwave-js/cc";
+import { NotificationCCReport } from "@zwave-js/cc/NotificationCC";
 import {
 	UserCodeCCAdminCodeGet,
 	UserCodeCCAdminCodeSet,
+	UserCodeCCExtendedUserCodeReport,
 	UserCodeCCExtendedUserCodeSet,
 	UserCodeCCGet,
 	UserCodeCCReport,
@@ -14,8 +17,13 @@ import {
 	UserCodeCCValues,
 } from "@zwave-js/cc/UserCodeCC";
 import { CommandClasses } from "@zwave-js/core";
-import { MockZWaveFrameType, ccCaps } from "@zwave-js/testing";
+import {
+	MockZWaveFrameType,
+	ccCaps,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
 import type { MockNodeBehavior } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
 import {
 	SetCredentialResult,
 	SetUserResult,
@@ -1208,8 +1216,8 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			const userEvent = createDeferredPromise<unknown>();
-			const credEvent = createDeferredPromise<unknown>();
+			const userEvent = Promise.withResolvers<unknown>();
+			const credEvent = Promise.withResolvers<unknown>();
 			node.on("user added", (_node, args) => userEvent.resolve(args));
 			node.on(
 				"credential added",
@@ -1234,12 +1242,12 @@ integrationTest(
 				credential: SetCredentialResult.OK,
 			});
 
-			t.expect(await userEvent).toMatchObject({
+			t.expect(await userEvent.promise).toMatchObject({
 				userId: 3,
 				active: true,
 				userType: UserCredentialUserType.General,
 			});
-			t.expect(await credEvent).toMatchObject({
+			t.expect(await credEvent.promise).toMatchObject({
 				userId: 3,
 				credentialType: UserCredentialType.PINCode,
 				credentialSlot: 3,
@@ -1689,6 +1697,528 @@ integrationTest(
 				"1234",
 			);
 			t.expect(result).toBe(SetCredentialResult.Error_Unknown);
+		},
+	},
+);
+const userCodeCapabilities = ccCaps({
+	ccId: CommandClasses["User Code"],
+	version: 1,
+	numUsers: 10,
+	supportedASCIIChars: "0123456789",
+});
+
+// =============================================================================
+// Unsolicited User Code Reports
+// =============================================================================
+
+integrationTest(
+	"Unsolicited report for a new slot emits user added and credential added",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCapabilities,
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const userEvent = Promise.withResolvers<unknown>();
+			node.on("user added", (_node, args) => userEvent.resolve(args));
+			const credEvent = Promise.withResolvers<unknown>();
+			node.on(
+				"credential added",
+				(_node, args) => credEvent.resolve(args),
+			);
+
+			const cc = new UserCodeCCReport({
+				nodeId: mockController.ownNodeId,
+				userId: 1,
+				userIdStatus: UserIDStatus.Enabled,
+				userCode: "1234",
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, { ackRequested: false }),
+			);
+
+			t.expect(await userEvent.promise).toMatchObject({
+				userId: 1,
+				active: true,
+			});
+			t.expect(await credEvent.promise).toMatchObject({
+				userId: 1,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 1,
+				data: "1234",
+			});
+
+			// The cache must reflect the reported state
+			t.expect(
+				node.getValue(UserCodeCCValues.userIdStatus(1).id),
+			).toBe(UserIDStatus.Enabled);
+			t.expect(node.getValue(UserCodeCCValues.userCode(1).id)).toBe(
+				"1234",
+			);
+		},
+	},
+);
+
+integrationTest(
+	"Unsolicited report with a changed code emits only credential modified",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCapabilities,
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(2).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "1111");
+
+			const events: string[] = [];
+			const credEvent = Promise.withResolvers<unknown>();
+			node.on("user added", () => void events.push("user added"));
+			node.on("user modified", () => void events.push("user modified"));
+			node.on("user deleted", () => void events.push("user deleted"));
+			node.on("credential modified", (_node, args) => {
+				events.push("credential modified");
+				credEvent.resolve(args);
+			});
+
+			const cc = new UserCodeCCReport({
+				nodeId: mockController.ownNodeId,
+				userId: 2,
+				userIdStatus: UserIDStatus.Enabled,
+				userCode: "2222",
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, { ackRequested: false }),
+			);
+
+			t.expect(await credEvent.promise).toMatchObject({
+				userId: 2,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 2,
+				data: "2222",
+			});
+			await wait(50);
+			t.expect(events).toStrictEqual(["credential modified"]);
+		},
+	},
+);
+
+integrationTest(
+	"Unsolicited report with a changed status emits only user modified",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCapabilities,
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(2).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "1111");
+
+			const events: string[] = [];
+			const userEvent = Promise.withResolvers<unknown>();
+			node.on("user added", () => void events.push("user added"));
+			node.on("user deleted", () => void events.push("user deleted"));
+			node.on(
+				"credential modified",
+				() => void events.push("credential modified"),
+			);
+			node.on("user modified", (_node, args) => {
+				events.push("user modified");
+				userEvent.resolve(args);
+			});
+
+			const cc = new UserCodeCCReport({
+				nodeId: mockController.ownNodeId,
+				userId: 2,
+				userIdStatus: UserIDStatus.Disabled,
+				userCode: "1111",
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, { ackRequested: false }),
+			);
+
+			t.expect(await userEvent.promise).toMatchObject({
+				userId: 2,
+				active: false,
+			});
+			await wait(50);
+			t.expect(events).toStrictEqual(["user modified"]);
+		},
+	},
+);
+
+integrationTest(
+	"Unsolicited report clearing a slot emits user deleted and credential deleted",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCapabilities,
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(3).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(3).id, "1234");
+
+			const userEvent = Promise.withResolvers<unknown>();
+			node.on("user deleted", (_node, args) => userEvent.resolve(args));
+			const credEvent = Promise.withResolvers<unknown>();
+			node.on(
+				"credential deleted",
+				(_node, args) => credEvent.resolve(args),
+			);
+
+			const cc = new UserCodeCCReport({
+				nodeId: mockController.ownNodeId,
+				userId: 3,
+				userIdStatus: UserIDStatus.Available,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, { ackRequested: false }),
+			);
+
+			t.expect(await userEvent.promise).toMatchObject({ userId: 3 });
+			t.expect(await credEvent.promise).toMatchObject({
+				userId: 3,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 3,
+			});
+		},
+	},
+);
+
+integrationTest(
+	"Unsolicited report matching the cached state emits no events",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCapabilities,
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(4).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(4).id, "4444");
+
+			const events: string[] = [];
+			for (
+				const event of [
+					"user added",
+					"user modified",
+					"user deleted",
+					"credential added",
+					"credential modified",
+					"credential deleted",
+				] as const
+			) {
+				node.on(event, () => void events.push(event));
+			}
+
+			const cc = new UserCodeCCReport({
+				nodeId: mockController.ownNodeId,
+				userId: 4,
+				userIdStatus: UserIDStatus.Enabled,
+				userCode: "4444",
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, { ackRequested: false }),
+			);
+
+			await wait(100);
+			t.expect(events).toStrictEqual([]);
+		},
+	},
+);
+
+integrationTest(
+	"Unsolicited extended report emits events for each changed slot",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Slot 1 is already known, slot 2 changes, slot 3 is new
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(1).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1111");
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(2).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(2).id, "2222");
+
+			const events: [string, any][] = [];
+			for (
+				const event of [
+					"user added",
+					"user modified",
+					"user deleted",
+					"credential added",
+					"credential modified",
+					"credential deleted",
+				] as const
+			) {
+				node.on(
+					event,
+					(_node: any, args: any) => void events.push([event, args]),
+				);
+			}
+
+			const cc = new UserCodeCCExtendedUserCodeReport({
+				nodeId: mockController.ownNodeId,
+				userCodes: [
+					{
+						userId: 1,
+						userIdStatus: UserIDStatus.Enabled,
+						userCode: "1111",
+					},
+					{
+						userId: 2,
+						userIdStatus: UserIDStatus.Enabled,
+						userCode: "9999",
+					},
+					{
+						userId: 3,
+						userIdStatus: UserIDStatus.Enabled,
+						userCode: "3333",
+					},
+				],
+				nextUserId: 0,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, { ackRequested: false }),
+			);
+
+			await wait(100);
+			t.expect(events).toStrictEqual([
+				["credential modified", {
+					userId: 2,
+					credentialType: UserCredentialType.PINCode,
+					credentialSlot: 2,
+					data: "9999",
+				}],
+				["user added", {
+					userId: 3,
+					active: true,
+					userType: UserCredentialUserType.General,
+				}],
+				["credential added", {
+					userId: 3,
+					credentialType: UserCredentialType.PINCode,
+					credentialSlot: 3,
+					data: "3333",
+				}],
+			]);
+		},
+	},
+);
+
+// =============================================================================
+// Value API removal
+// =============================================================================
+
+integrationTest(
+	"User code and admin code values are internal and not settable",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Code"],
+					version: 2,
+					numUsers: 10,
+					supportedASCIIChars: "0123456789",
+					supportsAdminCode: true,
+					supportedKeypadModes: [1, 2],
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(1).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
+			node.valueDB.setValue(UserCodeCCValues.adminCode.id, "5678");
+
+			const definedProperties = node
+				.getDefinedValueIDs()
+				.filter((v) => v.commandClass === CommandClasses["User Code"])
+				.map((v) => v.property);
+			t.expect(definedProperties).not.toContain("userIdStatus");
+			t.expect(definedProperties).not.toContain("userCode");
+			t.expect(definedProperties).not.toContain("adminCode");
+			t.expect(definedProperties).toContain("keypadMode");
+
+			for (
+				const [valueId, value] of [
+					[
+						UserCodeCCValues.userIdStatus(1).id,
+						UserIDStatus.Available,
+					],
+					[UserCodeCCValues.userCode(1).id, "4321"],
+					[UserCodeCCValues.adminCode.id, "8765"],
+				] as const
+			) {
+				const result = await node.setValue(valueId, value);
+				t.expect(result.status).toBe(SetValueStatus.InvalidValue);
+			}
+		},
+	},
+);
+
+// =============================================================================
+// Persistence of solicited reads
+// =============================================================================
+
+integrationTest(
+	"getUser() persists the queried state without emitting events",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCapabilities,
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			const respondToUserGet: MockNodeBehavior = {
+				handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof UserCodeCCGet) {
+						const cc = new UserCodeCCReport({
+							nodeId: controller.ownNodeId,
+							userId: receivedCC.userId,
+							userIdStatus: UserIDStatus.Enabled,
+							userCode: "1234",
+						});
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToUserGet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const events: string[] = [];
+			for (
+				const event of [
+					"user added",
+					"user modified",
+					"credential added",
+					"credential modified",
+				] as const
+			) {
+				node.on(event, () => void events.push(event));
+			}
+
+			const user = await node.accessControl!.getUser(1);
+			t.expect(user).toMatchObject({ userId: 1, active: true });
+
+			t.expect(
+				node.getValue(UserCodeCCValues.userIdStatus(1).id),
+			).toBe(UserIDStatus.Enabled);
+			t.expect(node.getValue(UserCodeCCValues.userCode(1).id)).toBe(
+				"1234",
+			);
+
+			// Solicited reads are discovery, not changes
+			await wait(100);
+			t.expect(events).toStrictEqual([]);
+		},
+	},
+);
+
+// =============================================================================
+// Notification-based wipe
+// =============================================================================
+
+integrationTest(
+	"The all user codes deleted notification emits wildcard deletion events",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				userCodeCapabilities,
+				ccCaps({
+					ccId: CommandClasses.Notification,
+					version: 2,
+					notificationTypesAndEvents: {
+						[0x06]: [], // Access Control
+					},
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.valueDB.setValue(
+				UserCodeCCValues.userIdStatus(1).id,
+				UserIDStatus.Enabled,
+			);
+			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
+
+			const userEvent = Promise.withResolvers<unknown>();
+			node.on("user deleted", (_node, args) => userEvent.resolve(args));
+			const credEvent = Promise.withResolvers<unknown>();
+			node.on(
+				"credential deleted",
+				(_node, args) => credEvent.resolve(args),
+			);
+
+			const cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x0c, // All user codes deleted
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, { ackRequested: false }),
+			);
+
+			t.expect(await userEvent.promise).toStrictEqual({ userId: 0 });
+			t.expect(await credEvent.promise).toStrictEqual({
+				userId: 0,
+				credentialType: UserCredentialType.PINCode,
+				credentialSlot: 0,
+			});
+
+			// The cache must be cleared as well
+			t.expect(
+				node.getValue(UserCodeCCValues.userIdStatus(1).id),
+			).toBe(UserIDStatus.Available);
+			t.expect(node.getValue(UserCodeCCValues.userCode(1).id)).toBe("");
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -1195,7 +1195,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			const userEvent = createDeferredPromise<unknown>();
+			const userEvent = Promise.withResolvers<unknown>();
 			node.on("user added", (_node, args) => userEvent.resolve(args));
 			let credEmitted = false;
 			node.on("credential added", () => {
@@ -1211,7 +1211,7 @@ integrationTest(
 			t.expect(result.user).toBe(SetUserResult.OK);
 			t.expect(result.credential).toBeUndefined();
 
-			t.expect(await userEvent).toMatchObject({
+			t.expect(await userEvent.promise).toMatchObject({
 				userId: 1,
 				active: true,
 				userType: UserCredentialUserType.General,
@@ -1269,8 +1269,8 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			const userEvent = createDeferredPromise<unknown>();
-			const credEvent = createDeferredPromise<unknown>();
+			const userEvent = Promise.withResolvers<unknown>();
+			const credEvent = Promise.withResolvers<unknown>();
 			node.on("user added", (_node, args) => userEvent.resolve(args));
 			node.on(
 				"credential added",
@@ -1294,13 +1294,13 @@ integrationTest(
 			t.expect(result.user).toBe(SetUserResult.OK);
 			t.expect(result.credential).toBe(SetCredentialResult.OK);
 
-			t.expect(await userEvent).toMatchObject({
+			t.expect(await userEvent.promise).toMatchObject({
 				userId: 2,
 				active: true,
 				userType: UserCredentialUserType.General,
 				userName: "Bob",
 			});
-			t.expect(await credEvent).toMatchObject({
+			t.expect(await credEvent.promise).toMatchObject({
 				userId: 2,
 				credentialType: UserCredentialType.PINCode,
 				credentialSlot: 2,
@@ -1654,7 +1654,7 @@ integrationTest(
 				1,
 			);
 
-			const cacheAtEvent = createDeferredPromise<number>();
+			const cacheAtEvent = Promise.withResolvers<number>();
 			node.once("credential deleted", () => {
 				cacheAtEvent.resolve(
 					node.accessControl!.getAllCredentialsCached().length,
@@ -1666,7 +1666,7 @@ integrationTest(
 			});
 			t.expect(result).toBe(SetCredentialResult.OK);
 
-			t.expect(await cacheAtEvent).toBe(0);
+			t.expect(await cacheAtEvent.promise).toBe(0);
 			t.expect(node.accessControl!.getAllCredentialsCached().length).toBe(
 				0,
 			);
@@ -1785,7 +1785,7 @@ integrationTest(
 				1,
 			);
 
-			const cacheAtEvent = createDeferredPromise<{
+			const cacheAtEvent = Promise.withResolvers<{
 				users: number;
 				credentials: number;
 			}>();
@@ -1801,7 +1801,7 @@ integrationTest(
 			const result = await node.accessControl!.deleteAllUsers();
 			t.expect(result).toBe(SetUserResult.OK);
 
-			t.expect(await cacheAtEvent).toStrictEqual({
+			t.expect(await cacheAtEvent.promise).toStrictEqual({
 				users: 0,
 				credentials: 0,
 			});


### PR DESCRIPTION
Previously, User Code CC changes reported by a device updated the cache without emitting any unified events. Users could also use the value API to modify user codes and there was no good way to reconcile them with the events emitted by the AccessControl API.

For the User Credential CC, the codes were already internal values, so this issue does not happen there.

This PR makes the unified Access Control API the only way to manage user codes: the User Code CC values for `userIdStatus`, `userCode`, and `adminCode` are now internal, the deprecated `masterCode` was removed, and their `setValue`/`pollValue` support is removed. Reports no longer persist their values automatically — solicited responses are persisted by the querying API methods, while unsolicited reports are handled in `Node.handleCommand`, which diffs them against the cache and emits the unified `user added/modified/deleted` and `credential added/modified/deleted` events.

In addition, the "all user codes deleted" notification now emits wildcard (`userId: 0`) deletion events after clearing the cache.