### PR TITLE
fix: assert the correct command in Window Covering setValue API

### DIFF
--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -468,7 +468,7 @@ export class WindowCoveringCCAPI extends CCAPI {
 	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			WindowCoveringCommand,
-			WindowCoveringCommand.StartLevelChange,
+			WindowCoveringCommand.Set,
 		);
 
 		const cc = new WindowCoveringCCSet({


### PR DESCRIPTION
`WindowCoveringCCAPI.set()` asserted support for `StartLevelChange` instead of `Set`, likely a copy-paste mistake. Both commands are mandatory, so this had no practical effect. The other API methods assert their matching commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)