### PR TITLE
fix: correct Irrigation CC nominalCurrent metadata and low flow error label

### DIFF
--- a/packages/cc/src/cc/IrrigationCC.ts
+++ b/packages/cc/src/cc/IrrigationCC.ts
@@ -252,7 +252,7 @@ export const IrrigationCCValues = V.defineCCValues(CommandClasses.Irrigation, {
 			(typeof property === "number" || property === "master")
 			&& propertyKey === "nominalCurrent",
 		(valveId: ValveId) => ({
-			...ValueMetadata.ReadOnlyBoolean,
+			...ValueMetadata.ReadOnlyNumber,
 			label: `${
 				irrigationValveIdToMetadataPrefix(
 					valveId,
@@ -444,7 +444,7 @@ export const IrrigationCCValues = V.defineCCValues(CommandClasses.Irrigation, {
 				irrigationValveIdToMetadataPrefix(
 					valveId,
 				)
-			}: Error - Flow below high threshold`,
+			}: Error - Flow below low threshold`,
 		}),
 	),
 	...V.dynamicPropertyAndKeyWithName(

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -4617,7 +4617,7 @@ export const IrrigationCCValues = Object.freeze({
 				} as const),
 				get meta() {
 					return {
-						...ValueMetadata.ReadOnlyBoolean,
+						...ValueMetadata.ReadOnlyNumber,
 						label: `${
 							irrigationValveIdToMetadataPrefix(
 								valveId,
@@ -5143,7 +5143,7 @@ export const IrrigationCCValues = Object.freeze({
 							irrigationValveIdToMetadataPrefix(
 								valveId,
 							)
-						}: Error - Flow below high threshold`,
+						}: Error - Flow below low threshold`,
 					} as const;
 				},
 			};


### PR DESCRIPTION
The `nominalCurrent` dynamic CC value used `ValueMetadata.ReadOnlyBoolean`, but the value is numeric: the Valve Info Report stores `10 * raw.payload[2]` in mA, per CC:006B.01.09.11.008 ("This field MUST be expressed as a multiple of 10mA."). Changed to `ReadOnlyNumber`.

Also fixes a copy-paste typo: the `errorLowFlow` label read "Flow below high threshold", now "Flow below low threshold".

All other Irrigation value metadata match their stored types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)