### PR TITLE
fix: export `AssociationGroupInfo`, `UserCode` and `EndpointCapability` types

### DIFF
--- a/packages/cc/src/cc/AssociationGroupInfoCC.ts
+++ b/packages/cc/src/cc/AssociationGroupInfoCC.ts
@@ -594,6 +594,7 @@ export class AssociationGroupInfoCCNameGet extends AssociationGroupInfoCC {
 	}
 }
 
+// @publicAPI
 export interface AssociationGroupInfo {
 	groupId: number;
 	mode: number;

--- a/packages/cc/src/cc/MultiChannelCC.ts
+++ b/packages/cc/src/cc/MultiChannelCC.ts
@@ -375,6 +375,7 @@ export class MultiChannelCCAPI extends CCAPI {
 	}
 }
 
+// @publicAPI
 export interface EndpointCapability {
 	generic: GenericDeviceClass;
 	specific: SpecificDeviceClass;

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -2232,6 +2232,7 @@ export interface UserCodeCCExtendedUserCodeSetOptions {
 	userCodes: UserCodeCCSetOptions[];
 }
 
+// @publicAPI
 export interface UserCode {
 	userId: number;
 	userIdStatus: UserIDStatus;

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -69,6 +69,7 @@ export {
 	AssociationCCValues,
 };
 export type {
+	AssociationGroupInfo,
 	AssociationGroupInfoCCCommandListGetOptions,
 	AssociationGroupInfoCCCommandListReportOptions,
 	AssociationGroupInfoCCInfoGetOptions,
@@ -779,6 +780,7 @@ export {
 	MultiChannelAssociationCCValues,
 };
 export type {
+	EndpointCapability,
 	MultiChannelCCAggregatedMembersGetOptions,
 	MultiChannelCCAggregatedMembersReportOptions,
 	MultiChannelCCCapabilityGetOptions,
@@ -1444,6 +1446,7 @@ export {
 	isTransportServiceEncapsulation,
 };
 export type {
+	UserCode,
 	UserCodeCCAdminCodeReportOptions,
 	UserCodeCCAdminCodeSetOptions,
 	UserCodeCCCapabilitiesReportOptions,


### PR DESCRIPTION
These interfaces appear in public CC API method signatures (`AssociationGroupInfoCCAPI.getGroupInfo`, `UserCodeCCAPI.get`, `MultiChannelCCAPI.getEndpointCapabilities`) but were not exported from `@zwave-js/cc`, so consumers could not name them.

Adds the `// @publicAPI` marker to each interface; the `cc/index.ts` barrel changes are generated. A sweep over all CC files found no other types used in public CC API signatures that are missing from the package exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)