### PR TITLE
feat: unified covers API

### DIFF
--- a/packages/cc/src/cc/manufacturerProprietary/FibaroCC.ts
+++ b/packages/cc/src/cc/manufacturerProprietary/FibaroCC.ts
@@ -129,6 +129,18 @@ export class FibaroCCAPI extends ManufacturerProprietaryCCAPI {
 	}
 
 	@validateArgs()
+	public async fibaroVenetianBlindsSet(
+		options: FibaroVenetianBlindCCSetOptions,
+	): Promise<void> {
+		const cc = new FibaroVenetianBlindCCSet({
+			nodeId: this.endpoint.nodeId,
+			endpointIndex: this.endpoint.index,
+			...options,
+		});
+		await this.host.sendCommand(cc, this.commandOptions);
+	}
+
+	@validateArgs()
 	public async fibaroVenetianBlindsSetPosition(value: number): Promise<void> {
 		const cc = new FibaroVenetianBlindCCSet({
 			nodeId: this.endpoint.nodeId,
@@ -391,14 +403,23 @@ export class FibaroVenetianBlindCCSet extends FibaroVenetianBlindCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): FibaroVenetianBlindCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
+		validatePayload(raw.payload.length >= 3);
+		const controlByte = raw.payload[0];
+		const options = {} as FibaroVenetianBlindCCSetOptions;
+		if (!!(controlByte & 0b10)) {
+			(options as { position: number }).position = raw.payload[1];
+		}
+		if (!!(controlByte & 0b01)) {
+			(options as { tilt: number }).tilt = raw.payload[2];
+		}
+
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			...options,
+		});
 	}
 
 	public position: number | undefined;

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -304,6 +304,27 @@ compat option treatSetAsReport must be an array of strings`,
 			this.treatSetAsReport = new Set(definition.treatSetAsReport);
 		}
 
+		if (definition.treatAsCover != undefined) {
+			if (
+				definition.treatAsCover !== "*"
+				&& !(
+					isArray(definition.treatAsCover)
+					&& definition.treatAsCover.every(
+						(d: any) =>
+							typeof d === "number" && d % 1 === 0 && d >= 0,
+					)
+				)
+			) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+compat option treatAsCover must be "*" or an array of endpoint indices`,
+				);
+			}
+
+			this.treatAsCover = definition.treatAsCover;
+		}
+
 		if (definition.treatDestinationEndpointAsSource != undefined) {
 			if (definition.treatDestinationEndpointAsSource !== true) {
 				throwInvalidConfig(
@@ -651,6 +672,7 @@ compat option overrideQueries must be an object!`,
 	public readonly reportTimeout?: number;
 	public readonly skipConfigurationNameQuery?: boolean;
 	public readonly skipConfigurationInfoQuery?: boolean;
+	public readonly treatAsCover?: "*" | readonly number[];
 	public readonly treatMultilevelSwitchSetAsEvent?: boolean;
 	public readonly treatSetAsReport?: ReadonlySet<string>;
 	public readonly treatDestinationEndpointAsSource?: boolean;
@@ -694,6 +716,7 @@ compat option overrideQueries must be an object!`,
 			"removeEndpoints",
 			"skipConfigurationNameQuery",
 			"skipConfigurationInfoQuery",
+			"treatAsCover",
 			"treatMultilevelSwitchSetAsEvent",
 			"treatSetAsReport",
 			"treatDestinationEndpointAsSource",

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -34,4 +34,14 @@ export type {
 	UserCapabilities,
 	UserData,
 } from "./lib/node/feature-apis/AccessControl.js";
+export { CoverAspect, CoversAPI } from "./lib/node/feature-apis/Covers.js";
+export type {
+	CoverAspectCapabilities,
+	CoverAspectState,
+	CoverAspectType,
+	CoverCapabilities,
+	CoverControlOptions,
+	CoverMovement,
+	CoverValueReliability,
+} from "./lib/node/feature-apis/Covers.js";
 export { FeatureAPI } from "./lib/node/feature-apis/FeatureAPI.js";

--- a/packages/zwave-js/src/lib/node/CCHandlers/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/MultilevelSwitchCC.ts
@@ -48,6 +48,7 @@ export function handleMultilevelSwitchCommand(
 				direction: command.direction,
 			},
 		);
+		endpoint.covers?.handleUnsolicitedLevelChange(command.direction);
 	} else if (command instanceof MultilevelSwitchCCStopLevelChange) {
 		ctx.logNode(node.id, {
 			endpoint: command.endpointIndex,
@@ -63,5 +64,6 @@ export function handleMultilevelSwitchCommand(
 				eventTypeLabel: "Stop level change",
 			},
 		);
+		endpoint.covers?.handleUnsolicitedLevelChange("stop");
 	}
 }

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -26,6 +26,7 @@ import { ColorSwitchCCBehaviors } from "./mockCCBehaviors/ColorSwitch.js";
 import { ConfigurationCCBehaviors } from "./mockCCBehaviors/Configuration.js";
 import { DoorLockCCBehaviors } from "./mockCCBehaviors/DoorLock.js";
 import { EnergyProductionCCBehaviors } from "./mockCCBehaviors/EnergyProduction.js";
+import { FibaroCCBehaviors } from "./mockCCBehaviors/FibaroCC.js";
 import { IndicatorCCBehaviors } from "./mockCCBehaviors/Indicator.js";
 import { LockCCBehaviors } from "./mockCCBehaviors/Lock.js";
 import { ManufacturerSpecificCCBehaviors } from "./mockCCBehaviors/ManufacturerSpecific.js";
@@ -224,6 +225,7 @@ export function createDefaultBehaviors(): MockNodeBehavior[] {
 		...ConfigurationCCBehaviors,
 		...DoorLockCCBehaviors,
 		...EnergyProductionCCBehaviors,
+		...FibaroCCBehaviors,
 		...LockCCBehaviors,
 		...IndicatorCCBehaviors,
 		...ManufacturerSpecificCCBehaviors,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -325,6 +325,16 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 
 		// Add optional controlled CCs - endpoints don't have this
 		for (const cc of controlledCCs) this.addCC(cc, { isControlled: true });
+
+		this.on("ready", () => {
+			// Recreate feature APIs so they reflect the latest interview
+			// results, and instantiate event-emitting ones so applications
+			// receive their events without accessing the API first
+			for (const endpoint of this.getAllEndpoints()) {
+				endpoint.destroyFeatureAPIs();
+				void endpoint.covers;
+			}
+		});
 	}
 
 	/**
@@ -347,6 +357,11 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 
 		// Clear all scheduled polls that would interfere with the interview
 		this.cancelAllScheduledPolls();
+
+		// Release resources held by feature APIs
+		for (const endpoint of this.getAllEndpoints()) {
+			endpoint.destroyFeatureAPIs();
+		}
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -28,6 +28,7 @@ import type { Endpoint } from "./Endpoint.js";
 import type { ZWaveNode } from "./Node.js";
 import type { RouteStatistics } from "./NodeStatistics.js";
 import type { UserData } from "./feature-apis/AccessControl.js";
+import type { CoverAspectState } from "./feature-apis/Covers.js";
 
 export {
 	EntryControlDataTypes,
@@ -317,6 +318,10 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 		endpoint: Endpoint,
 		args: CredentialLearnCompletedArgs,
 	) => void;
+	"cover state changed": (
+		endpoint: Endpoint,
+		state: CoverAspectState,
+	) => void;
 }
 
 export type ZWaveNodeEvents = Extract<keyof ZWaveNodeEventCallbacks, string>;
@@ -348,6 +353,7 @@ export const zWaveNodeEvents = [
 	"credential deleted",
 	"credential learn progress",
 	"credential learn completed",
+	"cover state changed",
 ] as const satisfies readonly ZWaveNodeEvents[];
 
 /** Represents the result of one health check round of a node's lifeline */

--- a/packages/zwave-js/src/lib/node/endpoint-mixins/index.ts
+++ b/packages/zwave-js/src/lib/node/endpoint-mixins/index.ts
@@ -1,9 +1,11 @@
 import { CommandClasses } from "@zwave-js/core";
 import { AccessControlAPI } from "../feature-apis/AccessControl.js";
+import { CoversAPI, supportsCoversAPI } from "../feature-apis/Covers.js";
 import { EndpointBase } from "./00_Base.js";
 
 export class FeatureAPIsMixin extends EndpointBase {
 	private _accessControl?: AccessControlAPI;
+	private _covers?: CoversAPI;
 
 	/**
 	 * High-level API for managing users and credentials on access control
@@ -19,6 +21,29 @@ export class FeatureAPIsMixin extends EndpointBase {
 		}
 		this._accessControl ??= new AccessControlAPI(this);
 		return this._accessControl;
+	}
+
+	/**
+	 * High-level API for controlling covers (blinds, shades, curtains, ...).
+	 * Returns `undefined` if the endpoint does not support any cover-related
+	 * CC, or if its Multilevel Switch CC is not identified as a cover by the
+	 * device class.
+	 */
+	public get covers(): CoversAPI | undefined {
+		if (!supportsCoversAPI(this)) return undefined;
+		this._covers ??= new CoversAPI(this);
+		return this._covers;
+	}
+
+	/**
+	 * @internal
+	 * Releases resources held by instantiated feature APIs
+	 */
+	public destroyFeatureAPIs(): void {
+		this._accessControl?.destroy();
+		this._accessControl = undefined;
+		this._covers?.destroy();
+		this._covers = undefined;
 	}
 }
 

--- a/packages/zwave-js/src/lib/node/feature-apis/Covers.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/Covers.ts
@@ -1,0 +1,1126 @@
+import { type WindowCoveringParameter } from "@zwave-js/cc";
+import type { BasicWindowCoveringCCAPI } from "@zwave-js/cc/BasicWindowCoveringCC";
+import {
+	type MultilevelSwitchCCAPI,
+	MultilevelSwitchCCValues,
+} from "@zwave-js/cc/MultilevelSwitchCC";
+import {
+	type WindowCoveringCCAPI,
+	WindowCoveringCCValues,
+} from "@zwave-js/cc/WindowCoveringCC";
+import {
+	FibaroCCIDs,
+	getFibaroVenetianBlindPositionValueId,
+	getFibaroVenetianBlindTiltValueId,
+} from "@zwave-js/cc/manufacturerProprietary/FibaroCC";
+import type { FibaroCCAPI } from "@zwave-js/cc/manufacturerProprietary/FibaroCC";
+import {
+	CommandClasses,
+	Duration,
+	type SupervisionResult,
+	type ValueID,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import { isArray } from "alcalzone-shared/typeguards";
+import type { EndpointBase } from "../endpoint-mixins/00_Base.js";
+import {
+	type TransitionCommand,
+	type TransitionState,
+	TransitionTracker,
+} from "../transitions/TransitionTracker.js";
+import { FeatureAPI } from "./FeatureAPI.js";
+
+/**
+ * Identifies an independently movable dimension of a cover. The `Primary` and
+ * `Tilt` aliases resolve to whatever the endpoint's main position and tilt
+ * aspects are, so applications only need the concrete values for exotic
+ * devices with multiple position aspects.
+ */
+export enum CoverAspect {
+	Primary = "primary",
+	Tilt = "tilt",
+	OutboundLeft = "outboundLeft",
+	OutboundRight = "outboundRight",
+	InboundLeft = "inboundLeft",
+	InboundRight = "inboundRight",
+	InboundLeftRight = "inboundLeftRight",
+	VerticalSlats = "verticalSlats",
+	OutboundBottom = "outboundBottom",
+	OutboundTop = "outboundTop",
+	InboundBottom = "inboundBottom",
+	InboundTop = "inboundTop",
+	InboundTopBottom = "inboundTopBottom",
+	HorizontalSlats = "horizontalSlats",
+}
+
+export type CoverAspectType = "position" | "tilt";
+
+/** How a cover aspect is currently moving. "unknown" indicates an ongoing transition with unknown direction */
+export type CoverMovement = "idle" | "opening" | "closing" | "unknown";
+
+/** How trustworthy the advertised current value is */
+export type CoverValueReliability = "reported" | "estimated" | "stale";
+
+export interface CoverAspectCapabilities {
+	aspect: CoverAspect;
+	type: CoverAspectType;
+	label: string;
+	/** Whether the aspect can be commanded to a specific value */
+	supportsGoToValue: boolean;
+	/** Whether the current value can be read at all */
+	reportsValue: boolean;
+	/** Whether the device reliably reports the target value and duration of transitions */
+	reportsTarget: boolean;
+	/** Whether open-ended movement (start/stop) is supported */
+	supportsStartStop: boolean;
+	/** Whether a transition duration can be passed with commands */
+	supportsDuration: boolean;
+}
+
+export interface CoverCapabilities {
+	aspects: CoverAspectCapabilities[];
+	/** The concrete aspect {@link CoverAspect.Primary} resolves to, if any */
+	primaryAspect?: CoverAspect;
+	/** The concrete aspect {@link CoverAspect.Tilt} resolves to, if any */
+	primaryTiltAspect?: CoverAspect;
+}
+
+export interface CoverControlOptions {
+	/** Which aspect to control. Defaults to {@link CoverAspect.Primary}, or {@link CoverAspect.Tilt} for tilt methods */
+	aspect?: CoverAspect;
+	/** The desired transition duration. Ignored when the aspect does not support it */
+	duration?: Duration | string;
+}
+
+/**
+ * Consolidated state of one cover aspect.
+ *
+ * Positions use the raw Z-Wave scale: 0 = fully closed, 99 = fully open.
+ * Tilt always uses the standard Z-Wave slat convention: 0 = closed,
+ * 50 = open, 99 = closed the other way.
+ */
+export interface CoverAspectState {
+	aspect: CoverAspect;
+	type: CoverAspectType;
+	/** Last known value. `undefined` while the value is unknown, e.g. mid-travel on devices without position feedback */
+	currentValue?: number;
+	/** The value being moved towards, if known */
+	targetValue?: number;
+	movement: CoverMovement;
+	/** Estimated duration of the ongoing transition, if known */
+	remainingDuration?: Duration;
+	currentValueReliability: CoverValueReliability;
+}
+
+/** How a cover aspect is backed by an actual Command Class */
+type AspectBinding =
+	| {
+		backend: "windowCovering";
+		type: CoverAspectType;
+		parameter: WindowCoveringParameter;
+		positioned: boolean;
+	}
+	| { backend: "multilevelSwitch"; type: "position" }
+	| { backend: "basicWindowCovering"; type: "position" }
+	| {
+		backend: "fibaro";
+		type: CoverAspectType;
+		property: "position" | "tilt";
+	};
+
+// Window Covering parameters come in pairs of a positioned (odd) and a
+// movement-only (even) variant of the same property
+const pairToAspect: Record<number, CoverAspect> = {
+	0: CoverAspect.OutboundLeft,
+	1: CoverAspect.OutboundRight,
+	2: CoverAspect.InboundLeft,
+	3: CoverAspect.InboundRight,
+	4: CoverAspect.InboundLeftRight,
+	5: CoverAspect.VerticalSlats,
+	6: CoverAspect.OutboundBottom,
+	7: CoverAspect.OutboundTop,
+	8: CoverAspect.InboundBottom,
+	9: CoverAspect.InboundTop,
+	10: CoverAspect.InboundTopBottom,
+	11: CoverAspect.HorizontalSlats,
+};
+
+const aspectLabels: Record<CoverAspect, string> = {
+	[CoverAspect.Primary]: "Position",
+	[CoverAspect.Tilt]: "Tilt",
+	[CoverAspect.OutboundLeft]: "Outbound Left",
+	[CoverAspect.OutboundRight]: "Outbound Right",
+	[CoverAspect.InboundLeft]: "Inbound Left",
+	[CoverAspect.InboundRight]: "Inbound Right",
+	[CoverAspect.InboundLeftRight]: "Inbound Left/Right",
+	[CoverAspect.VerticalSlats]: "Vertical Slats Angle",
+	[CoverAspect.OutboundBottom]: "Outbound Bottom",
+	[CoverAspect.OutboundTop]: "Outbound Top",
+	[CoverAspect.InboundBottom]: "Inbound Bottom",
+	[CoverAspect.InboundTop]: "Inbound Top",
+	[CoverAspect.InboundTopBottom]: "Inbound Top/Bottom",
+	[CoverAspect.HorizontalSlats]: "Horizontal Slats Angle",
+};
+
+function isSlatPair(pair: number): boolean {
+	return pairToAspect[pair] === CoverAspect.VerticalSlats
+		|| pairToAspect[pair] === CoverAspect.HorizontalSlats;
+}
+
+/** The value at which a tilt aspect is fully open */
+const TILT_OPEN = 50;
+
+// The Fibaro venetian blind tilt spans its physical range linearly from 0..99,
+// which corresponds to the closed..open half of the standard slat convention
+function fibaroTiltToUnified(raw: number): number {
+	return Math.round((raw * TILT_OPEN) / 99);
+}
+function unifiedTiltToFibaro(unified: number): number {
+	return Math.round((Math.min(unified, TILT_OPEN) * 99) / TILT_OPEN);
+}
+
+function movementFromTransition(
+	binding: AspectBinding,
+	state: TransitionState,
+): CoverMovement {
+	if (state.movement === "idle") return "idle";
+	if (state.movement === "unknown") return "unknown";
+	const increasing = state.movement === "increasing";
+	if (binding.type === "position") {
+		return increasing ? "opening" : "closing";
+	}
+	// Slats open towards the midpoint and close towards both extremes
+	const current = state.currentLevel;
+	if (current == undefined) return "unknown";
+	if (increasing) {
+		return current < TILT_OPEN ? "opening" : "closing";
+	}
+	return current > TILT_OPEN ? "opening" : "closing";
+}
+
+function reliabilityFromTransition(
+	state: TransitionState,
+): CoverValueReliability {
+	switch (state.source) {
+		case "timeout":
+			return "stale";
+		case "command":
+		case "supervision":
+			return "estimated";
+		default:
+			return "reported";
+	}
+}
+
+function deviceClassIndicatesCover(
+	deviceClass: {
+		generic: { key: number };
+		specific: { key: number };
+	} | undefined,
+): boolean {
+	if (!deviceClass) return false;
+	// Generic Window Covering
+	if (deviceClass.generic.key === 0x09) return true;
+	// Generic Multilevel Switch with a motor-related specific class:
+	// Multiposition Motor, Motor Control Class A/B/C
+	return deviceClass.generic.key === 0x11
+		&& [0x03, 0x05, 0x06, 0x07].includes(deviceClass.specific.key);
+}
+
+function compatForcesCover(endpoint: EndpointBase): boolean {
+	const treatAsCover = endpoint.tryGetNode()?.deviceConfig?.compat
+		?.treatAsCover;
+	if (treatAsCover == undefined) return false;
+	return treatAsCover === "*" || treatAsCover.includes(endpoint.index);
+}
+
+function supportsFibaroVenetianBlind(endpoint: EndpointBase): boolean {
+	if (!endpoint.supportsCC(CommandClasses["Manufacturer Proprietary"])) {
+		return false;
+	}
+	const fibaroCCs = endpoint.tryGetNode()?.deviceConfig?.proprietary
+		?.fibaroCCs;
+	return isArray(fibaroCCs)
+		&& fibaroCCs.includes(FibaroCCIDs.VenetianBlind);
+}
+
+/** Determines whether the covers feature API applies to an endpoint */
+export function supportsCoversAPI(endpoint: EndpointBase): boolean {
+	if (
+		endpoint.supportsCC(CommandClasses["Window Covering"])
+		|| endpoint.supportsCC(CommandClasses["Basic Window Covering"])
+		|| supportsFibaroVenetianBlind(endpoint)
+	) {
+		return true;
+	}
+	// The Multilevel Switch CC alone could just as well be a dimmer, so require
+	// a device class that identifies the endpoint as a cover
+	return endpoint.supportsCC(CommandClasses["Multilevel Switch"])
+		&& (deviceClassIndicatesCover(endpoint.deviceClass)
+			|| compatForcesCover(endpoint));
+}
+
+/**
+ * High-level API for controlling covers (blinds, shades, curtains, ...),
+ * unifying the Window Covering CC, Multilevel Switch CC, Basic Window
+ * Covering CC and the proprietary Fibaro Venetian Blind CC.
+ */
+export class CoversAPI extends FeatureAPI {
+	public constructor(endpoint: EndpointBase) {
+		super(endpoint);
+		// Movement tracking and the resulting "cover state changed" events
+		// require the trackers to subscribe to value updates, so instantiate
+		// them for all known aspects right away
+		if (endpoint.tryGetNode()) {
+			for (const [aspect, binding] of this.#resolveBindings()) {
+				this.#tracker(aspect, binding);
+			}
+		}
+	}
+
+	#trackers = new Map<CoverAspect, TransitionTracker>();
+
+	/**
+	 * Returns the capabilities of all cover aspects of this endpoint,
+	 * based on cached data.
+	 */
+	public getCapabilitiesCached(): CoverCapabilities {
+		const bindings = this.#resolveBindings();
+		const aspects: CoverAspectCapabilities[] = [];
+		for (const [aspect, binding] of bindings) {
+			aspects.push(this.#capabilitiesFor(aspect, binding));
+		}
+		return {
+			aspects,
+			primaryAspect: this.#resolvePrimary(bindings, "position"),
+			primaryTiltAspect: this.#resolvePrimary(bindings, "tilt"),
+		};
+	}
+
+	#capabilitiesFor(
+		aspect: CoverAspect,
+		binding: AspectBinding,
+	): CoverAspectCapabilities {
+		const base = {
+			aspect,
+			type: binding.type,
+			label: aspectLabels[aspect],
+		};
+		switch (binding.backend) {
+			case "windowCovering":
+				return {
+					...base,
+					supportsGoToValue: binding.positioned,
+					reportsValue: binding.positioned,
+					reportsTarget: binding.positioned,
+					supportsStartStop: true,
+					supportsDuration: true,
+				};
+			case "multilevelSwitch": {
+				const version = this.endpoint.getCCVersion(
+					CommandClasses["Multilevel Switch"],
+				);
+				return {
+					...base,
+					supportsGoToValue: true,
+					reportsValue: true,
+					// The target value and duration are only part of the report in V4+
+					reportsTarget: version >= 4,
+					supportsStartStop: true,
+					supportsDuration: version >= 2,
+				};
+			}
+			case "basicWindowCovering":
+				return {
+					...base,
+					supportsGoToValue: false,
+					reportsValue: false,
+					reportsTarget: false,
+					supportsStartStop: true,
+					supportsDuration: false,
+				};
+			case "fibaro":
+				return {
+					...base,
+					supportsGoToValue: true,
+					reportsValue: true,
+					reportsTarget: false,
+					// Movement without a target requires the Multilevel Switch CC
+					supportsStartStop: binding.type === "position"
+						&& this.endpoint.supportsCC(
+							CommandClasses["Multilevel Switch"],
+						),
+					supportsDuration: false,
+				};
+		}
+	}
+
+	#resolveBindings(): Map<CoverAspect, AspectBinding> {
+		const bindings = new Map<CoverAspect, AspectBinding>();
+
+		if (this.endpoint.supportsCC(CommandClasses["Window Covering"])) {
+			// CL:006A.01.51.01.2: "A controlling node MUST NOT interview and
+			// provide controlling functionalities for the Multilevel Switch
+			// Command Class for a node (or endpoint) supporting this Command
+			// Class, as it is a fully redundant and less precise application
+			// functionality." The same reasoning applies to the other backends.
+			const supported = this.getValue<readonly WindowCoveringParameter[]>(
+				WindowCoveringCCValues.supportedParameters.endpoint(
+					this.endpoint.index,
+				),
+			) ?? [];
+
+			// Prefer the positioned member when a device violates the spec and
+			// advertises both members of a parameter pair
+			const byPair = new Map<number, WindowCoveringParameter>();
+			for (const param of supported) {
+				const pair = param >> 1;
+				const existing = byPair.get(pair);
+				if (existing == undefined || param % 2 === 1) {
+					byPair.set(pair, param);
+				}
+			}
+			for (const [pair, parameter] of byPair) {
+				const aspect = pairToAspect[pair];
+				if (aspect == undefined) continue;
+				bindings.set(aspect, {
+					backend: "windowCovering",
+					type: isSlatPair(pair) ? "tilt" : "position",
+					parameter,
+					positioned: parameter % 2 === 1,
+				});
+			}
+			return bindings;
+		}
+
+		const supportsMLS = this.endpoint.supportsCC(
+			CommandClasses["Multilevel Switch"],
+		);
+
+		if (supportsFibaroVenetianBlind(this.endpoint)) {
+			// Fibaro devices map the Multilevel Switch CC to the blind position,
+			// so use it for position control where possible and the proprietary
+			// CC only for the tilt
+			bindings.set(
+				CoverAspect.Primary,
+				supportsMLS
+					? { backend: "multilevelSwitch", type: "position" }
+					: {
+						backend: "fibaro",
+						type: "position",
+						property: "position",
+					},
+			);
+			bindings.set(CoverAspect.Tilt, {
+				backend: "fibaro",
+				type: "tilt",
+				property: "tilt",
+			});
+			return bindings;
+		}
+
+		if (supportsMLS) {
+			bindings.set(CoverAspect.Primary, {
+				backend: "multilevelSwitch",
+				type: "position",
+			});
+			return bindings;
+		}
+
+		if (
+			this.endpoint.supportsCC(CommandClasses["Basic Window Covering"])
+		) {
+			bindings.set(CoverAspect.Primary, {
+				backend: "basicWindowCovering",
+				type: "position",
+			});
+		}
+		return bindings;
+	}
+
+	#resolvePrimary(
+		bindings: Map<CoverAspect, AspectBinding>,
+		type: CoverAspectType,
+	): CoverAspect | undefined {
+		const alias = type === "position"
+			? CoverAspect.Primary
+			: CoverAspect.Tilt;
+		if (bindings.has(alias)) return alias;
+
+		// For Window Covering devices, prefer the aspect of the lowest
+		// supported parameter, which matches how Multilevel Switch reports
+		// are mapped to Window Covering values
+		let best: { aspect: CoverAspect; parameter: number } | undefined;
+		for (const [aspect, binding] of bindings) {
+			if (binding.type !== type) continue;
+			if (binding.backend !== "windowCovering") continue;
+			if (!best || binding.parameter < best.parameter) {
+				best = { aspect, parameter: binding.parameter };
+			}
+		}
+		return best?.aspect;
+	}
+
+	#resolveAspect(
+		requested: CoverAspect | undefined,
+		defaultType: CoverAspectType,
+	): { aspect: CoverAspect; binding: AspectBinding } {
+		const bindings = this.#resolveBindings();
+		let aspect = requested
+			?? (defaultType === "position"
+				? CoverAspect.Primary
+				: CoverAspect.Tilt);
+		if (aspect === CoverAspect.Primary || aspect === CoverAspect.Tilt) {
+			const resolved = this.#resolvePrimary(
+				bindings,
+				aspect === CoverAspect.Primary ? "position" : "tilt",
+			);
+			if (!resolved) {
+				throw new ZWaveError(
+					`This endpoint has no ${
+						aspect === CoverAspect.Primary ? "position" : "tilt"
+					} aspect`,
+					ZWaveErrorCodes.CC_NotSupported,
+				);
+			}
+			aspect = resolved;
+		}
+		const binding = bindings.get(aspect);
+		if (!binding) {
+			throw new ZWaveError(
+				`This endpoint has no cover aspect ${aspect}`,
+				ZWaveErrorCodes.CC_NotSupported,
+			);
+		}
+		return { aspect, binding };
+	}
+
+	// CC API accessors. The covers API never controls the Multilevel Switch CC
+	// when the Window Covering CC is supported, see #resolveBindings
+	#wcAPI(): WindowCoveringCCAPI {
+		return this.endpoint.commandClasses[
+			"Window Covering"
+		] as unknown as WindowCoveringCCAPI;
+	}
+
+	#mlsAPI(): MultilevelSwitchCCAPI {
+		return this.endpoint.commandClasses[
+			"Multilevel Switch"
+		] as unknown as MultilevelSwitchCCAPI;
+	}
+
+	#bwcAPI(): BasicWindowCoveringCCAPI {
+		return this.endpoint.commandClasses[
+			"Basic Window Covering"
+		] as unknown as BasicWindowCoveringCCAPI;
+	}
+
+	#fibaroAPI(): FibaroCCAPI {
+		return this.endpoint.commandClasses[
+			"Manufacturer Proprietary"
+		] as unknown as FibaroCCAPI;
+	}
+
+	#tracker(aspect: CoverAspect, binding: AspectBinding): TransitionTracker {
+		const existing = this.#trackers.get(aspect);
+		if (existing) return existing;
+
+		const node = this.endpoint.tryGetNode()!;
+		const endpointIndex = this.endpoint.index;
+
+		let currentValueId: ValueID | undefined;
+		let targetValueId: ValueID | undefined;
+		let durationValueId: ValueID | undefined;
+		let verify: (() => Promise<void>) | null | undefined;
+
+		switch (binding.backend) {
+			case "windowCovering":
+				durationValueId = WindowCoveringCCValues.duration(
+					binding.parameter,
+				).endpoint(endpointIndex);
+				if (binding.positioned) {
+					currentValueId = WindowCoveringCCValues.currentValue(
+						binding.parameter,
+					).endpoint(endpointIndex);
+					targetValueId = WindowCoveringCCValues.targetValue(
+						binding.parameter,
+					).endpoint(endpointIndex);
+				} else {
+					// Movement-only parameters advertise no meaningful levels,
+					// but their remaining duration can be queried
+					verify = () => {
+						node.schedulePoll(durationValueId!, { timeoutMs: 0 });
+						return Promise.resolve();
+					};
+				}
+				break;
+			case "multilevelSwitch":
+				currentValueId = MultilevelSwitchCCValues.currentValue
+					.endpoint(endpointIndex);
+				targetValueId = MultilevelSwitchCCValues.targetValue
+					.endpoint(endpointIndex);
+				durationValueId = MultilevelSwitchCCValues.duration
+					.endpoint(endpointIndex);
+				break;
+			case "basicWindowCovering":
+				// This CC has no state at all
+				verify = null;
+				break;
+			case "fibaro":
+				currentValueId = binding.property === "position"
+					? getFibaroVenetianBlindPositionValueId(endpointIndex)
+					: getFibaroVenetianBlindTiltValueId(endpointIndex);
+				break;
+		}
+
+		const tracker = new TransitionTracker(node, {
+			currentValueId,
+			targetValueId,
+			durationValueId,
+			verify,
+		});
+		tracker.on("transition update", (state) => {
+			node.emit(
+				"cover state changed",
+				this.endpoint as any,
+				this.#translateState(aspect, binding, state),
+			);
+		});
+		this.#trackers.set(aspect, tracker);
+		return tracker;
+	}
+
+	#translateState(
+		aspect: CoverAspect,
+		binding: AspectBinding,
+		state: TransitionState,
+	): CoverAspectState {
+		const translateLevel = (level: number | undefined) => {
+			if (level == undefined) return undefined;
+			if (binding.backend === "fibaro" && binding.type === "tilt") {
+				return fibaroTiltToUnified(level);
+			}
+			return level;
+		};
+		return {
+			aspect,
+			type: binding.type,
+			currentValue: translateLevel(state.currentLevel),
+			targetValue: translateLevel(state.targetLevel),
+			movement: movementFromTransition(binding, state),
+			remainingDuration: state.estimatedDuration,
+			currentValueReliability: reliabilityFromTransition(state),
+		};
+	}
+
+	/** Returns the consolidated state of a cover aspect, based on cached data */
+	public getStateCached(
+		aspect?: CoverAspect,
+	): CoverAspectState | undefined {
+		try {
+			const resolved = this.#resolveAspect(aspect, "position");
+			const tracker = this.#tracker(resolved.aspect, resolved.binding);
+			return this.#translateState(
+				resolved.aspect,
+				resolved.binding,
+				tracker.state,
+			);
+		} catch {
+			return undefined;
+		}
+	}
+
+	/** Returns the consolidated state of all cover aspects, based on cached data */
+	public getAllStatesCached(): CoverAspectState[] {
+		const ret: CoverAspectState[] = [];
+		for (const [aspect, binding] of this.#resolveBindings()) {
+			const tracker = this.#tracker(aspect, binding);
+			ret.push(this.#translateState(aspect, binding, tracker.state));
+		}
+		return ret;
+	}
+
+	/** Opens the cover, or tilts the slats to the open position when targeting a tilt aspect */
+	public async open(
+		options: CoverControlOptions = {},
+	): Promise<SupervisionResult | undefined> {
+		return this.#moveToExtreme("open", options);
+	}
+
+	/** Closes the cover, or tilts the slats to the closed position when targeting a tilt aspect */
+	public async close(
+		options: CoverControlOptions = {},
+	): Promise<SupervisionResult | undefined> {
+		return this.#moveToExtreme("close", options);
+	}
+
+	async #moveToExtreme(
+		direction: "open" | "close",
+		options: CoverControlOptions,
+	): Promise<SupervisionResult | undefined> {
+		const { aspect, binding } = this.#resolveAspect(
+			options.aspect,
+			"position",
+		);
+		const caps = this.#capabilitiesFor(aspect, binding);
+		if (caps.supportsGoToValue) {
+			const target = direction === "open"
+				? (binding.type === "tilt" ? TILT_OPEN : 99)
+				: 0;
+			return this.#setValueInternal(aspect, binding, target, options);
+		}
+		return this.#startTransitionInternal(
+			aspect,
+			binding,
+			direction,
+			options,
+		);
+	}
+
+	/**
+	 * Moves a cover aspect to a specific value. Positions use 0 (closed) to
+	 * 99 (open), tilt values use the slat convention 0/50/99.
+	 */
+	public async setValue(
+		value: number,
+		options: CoverControlOptions = {},
+	): Promise<SupervisionResult | undefined> {
+		const { aspect, binding } = this.#resolveAspect(
+			options.aspect,
+			"position",
+		);
+		return this.#setValueInternal(aspect, binding, value, options);
+	}
+
+	/** Moves the primary position aspect to a specific position, 0 (closed) to 99 (open) */
+	public async setPosition(
+		position: number,
+		options: CoverControlOptions = {},
+	): Promise<SupervisionResult | undefined> {
+		const { aspect, binding } = this.#resolveAspect(
+			options.aspect ?? CoverAspect.Primary,
+			"position",
+		);
+		return this.#setValueInternal(aspect, binding, position, options);
+	}
+
+	/** Tilts the slats to a specific value: 0 = closed, 50 = open, 99 = closed the other way */
+	public async setTilt(
+		tilt: number,
+		options: CoverControlOptions = {},
+	): Promise<SupervisionResult | undefined> {
+		const { aspect, binding } = this.#resolveAspect(
+			options.aspect ?? CoverAspect.Tilt,
+			"tilt",
+		);
+		return this.#setValueInternal(aspect, binding, tilt, options);
+	}
+
+	async #setValueInternal(
+		aspect: CoverAspect,
+		binding: AspectBinding,
+		value: number,
+		options: CoverControlOptions,
+	): Promise<SupervisionResult | undefined> {
+		if (value < 0 || value > 99 || !Number.isInteger(value)) {
+			throw new ZWaveError(
+				`The target value must be an integer between 0 and 99, received ${value}`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		const duration = Duration.from(options.duration);
+		const tracker = this.#tracker(aspect, binding);
+
+		switch (binding.backend) {
+			case "windowCovering": {
+				if (!binding.positioned) break;
+				return tracker.trackCommand(
+					{ type: "set", targetLevel: value, duration },
+					(onUpdate) =>
+						(this.#wcAPI().withOptions({
+							requestStatusUpdates: true,
+							onUpdate,
+						})).set(
+							[{ parameter: binding.parameter, value }],
+							duration,
+						),
+				);
+			}
+			case "multilevelSwitch":
+				return tracker.trackCommand(
+					{ type: "set", targetLevel: value, duration },
+					(onUpdate) =>
+						(this.#mlsAPI().withOptions({
+							requestStatusUpdates: true,
+							onUpdate,
+						})).set(value, duration),
+				);
+			case "fibaro": {
+				const raw = binding.property === "tilt"
+					? unifiedTiltToFibaro(value)
+					: value;
+				return tracker.trackCommand(
+					{ type: "set", targetLevel: raw },
+					async () => {
+						const api = this.#fibaroAPI();
+						if (binding.property === "position") {
+							await api.fibaroVenetianBlindsSetPosition(raw);
+						} else {
+							await api.fibaroVenetianBlindsSetTilt(raw);
+						}
+						return undefined;
+					},
+				);
+			}
+			case "basicWindowCovering":
+				break;
+		}
+		throw new ZWaveError(
+			`The cover aspect ${aspect} cannot be moved to a specific value`,
+			ZWaveErrorCodes.CC_NotSupported,
+		);
+	}
+
+	/** Starts an open-ended movement in the given direction. Use {@link stop} to end it */
+	public async startTransition(
+		direction: "open" | "close",
+		options: CoverControlOptions = {},
+	): Promise<SupervisionResult | undefined> {
+		const { aspect, binding } = this.#resolveAspect(
+			options.aspect,
+			"position",
+		);
+		return this.#startTransitionInternal(
+			aspect,
+			binding,
+			direction,
+			options,
+		);
+	}
+
+	async #startTransitionInternal(
+		aspect: CoverAspect,
+		binding: AspectBinding,
+		direction: "open" | "close",
+		options: CoverControlOptions,
+	): Promise<SupervisionResult | undefined> {
+		const duration = Duration.from(options.duration);
+		const tracker = this.#tracker(aspect, binding);
+		const levelDirection = this.#levelDirectionFor(
+			binding,
+			direction,
+			tracker.state.currentLevel,
+		);
+		const command: TransitionCommand = {
+			type: "startLevelChange",
+			direction: levelDirection,
+			duration,
+		};
+
+		switch (binding.backend) {
+			case "windowCovering":
+				return tracker.trackCommand(
+					command,
+					(onUpdate) =>
+						(this.#wcAPI().withOptions({
+							requestStatusUpdates: true,
+							onUpdate,
+						})).startLevelChange(
+							binding.parameter,
+							levelDirection,
+							duration,
+						),
+				);
+			case "multilevelSwitch":
+			case "fibaro": {
+				// Fibaro venetian blinds support open-ended movement only
+				// through the Multilevel Switch CC
+				if (
+					binding.backend === "fibaro"
+					&& (binding.type === "tilt"
+						|| !this.endpoint.supportsCC(
+							CommandClasses["Multilevel Switch"],
+						))
+				) {
+					break;
+				}
+				return tracker.trackCommand(
+					command,
+					(onUpdate) =>
+						(this.#mlsAPI().withOptions({
+							requestStatusUpdates: true,
+							onUpdate,
+						})).startLevelChange({
+							direction: levelDirection,
+							ignoreStartLevel: true,
+							duration,
+						}),
+				);
+			}
+			case "basicWindowCovering":
+				return tracker.trackCommand(
+					command,
+					(onUpdate) =>
+						(this.#bwcAPI().withOptions({
+							requestStatusUpdates: true,
+							onUpdate,
+						})).startLevelChange(
+							levelDirection,
+						),
+				);
+		}
+		throw new ZWaveError(
+			`The cover aspect ${aspect} does not support open-ended movement`,
+			ZWaveErrorCodes.CC_NotSupported,
+		);
+	}
+
+	#levelDirectionFor(
+		binding: AspectBinding,
+		direction: "open" | "close",
+		currentLevel: number | undefined,
+	): "up" | "down" {
+		if (binding.type === "position") {
+			return direction === "open" ? "up" : "down";
+		}
+		// Open slats by moving towards the midpoint, close them by moving
+		// towards the nearest extreme
+		const current = currentLevel ?? 0;
+		if (direction === "open") {
+			return current < TILT_OPEN ? "up" : "down";
+		}
+		return current < TILT_OPEN ? "down" : "up";
+	}
+
+	/** Stops an ongoing movement of a cover aspect */
+	public async stop(
+		options: { aspect?: CoverAspect } = {},
+	): Promise<SupervisionResult | undefined> {
+		const { aspect, binding } = this.#resolveAspect(
+			options.aspect,
+			"position",
+		);
+		return this.#stopInternal(aspect, binding);
+	}
+
+	async #stopInternal(
+		aspect: CoverAspect,
+		binding: AspectBinding,
+	): Promise<SupervisionResult | undefined> {
+		const tracker = this.#tracker(aspect, binding);
+		const command: TransitionCommand = { type: "stop" };
+
+		switch (binding.backend) {
+			case "windowCovering":
+				return tracker.trackCommand(
+					command,
+					(onUpdate) =>
+						(this.#wcAPI().withOptions({
+							requestStatusUpdates: true,
+							onUpdate,
+						})).stopLevelChange(
+							binding.parameter,
+						),
+				);
+			case "multilevelSwitch":
+			case "fibaro":
+				if (
+					binding.backend === "fibaro"
+					&& !this.endpoint.supportsCC(
+						CommandClasses["Multilevel Switch"],
+					)
+				) {
+					break;
+				}
+				return tracker.trackCommand(
+					command,
+					(onUpdate) =>
+						(this.#mlsAPI().withOptions({
+							requestStatusUpdates: true,
+							onUpdate,
+						})).stopLevelChange(),
+				);
+			case "basicWindowCovering":
+				return tracker.trackCommand(
+					command,
+					(onUpdate) =>
+						(this.#bwcAPI().withOptions({
+							requestStatusUpdates: true,
+							onUpdate,
+						})).stopLevelChange(),
+				);
+		}
+		throw new ZWaveError(
+			`The cover aspect ${aspect} does not support stopping`,
+			ZWaveErrorCodes.CC_NotSupported,
+		);
+	}
+
+	/**
+	 * @internal
+	 * Feeds a device-initiated Multilevel Switch Start/Stop Level Change to
+	 * the movement tracking
+	 */
+	public handleUnsolicitedLevelChange(
+		direction: "up" | "down" | "stop",
+	): void {
+		for (const [aspect, binding] of this.#resolveBindings()) {
+			if (binding.backend !== "multilevelSwitch") continue;
+			this.#tracker(aspect, binding).handleUnsolicitedLevelChange(
+				direction,
+			);
+		}
+	}
+
+	/** Stops all ongoing movements of this cover */
+	public async stopAll(): Promise<void> {
+		const stopped = new Set<string>();
+		for (const [aspect, binding] of this.#resolveBindings()) {
+			// The Multilevel Switch and Basic Window Covering CCs stop all
+			// movement at once
+			const key = binding.backend === "windowCovering"
+				? `wc-${binding.parameter}`
+				: binding.backend;
+			if (stopped.has(key)) continue;
+			stopped.add(key);
+			try {
+				await this.#stopInternal(aspect, binding);
+			} catch (e) {
+				if (
+					e instanceof ZWaveError
+					&& e.code === ZWaveErrorCodes.CC_NotSupported
+				) {
+					continue;
+				}
+				throw e;
+			}
+		}
+	}
+
+	/**
+	 * Sets multiple cover aspects at once, e.g. position and tilt. Aspects
+	 * backed by the same CC are combined into a single command.
+	 */
+	public async setValues(
+		values: { aspect: CoverAspect; value: number }[],
+		duration?: Duration | string,
+	): Promise<void> {
+		const resolvedDuration = Duration.from(duration);
+
+		const wcTargets: {
+			aspect: CoverAspect;
+			binding: AspectBinding & { backend: "windowCovering" };
+			value: number;
+		}[] = [];
+		const fibaroTargets: {
+			aspect: CoverAspect;
+			binding: AspectBinding & { backend: "fibaro" };
+			value: number;
+		}[] = [];
+		const rest: { aspect: CoverAspect; value: number }[] = [];
+
+		for (const { aspect: requested, value } of values) {
+			const { aspect, binding } = this.#resolveAspect(
+				requested,
+				"position",
+			);
+			if (binding.backend === "windowCovering" && binding.positioned) {
+				wcTargets.push({ aspect, binding, value });
+			} else if (binding.backend === "fibaro") {
+				fibaroTargets.push({ aspect, binding, value });
+			} else {
+				rest.push({ aspect: requested, value });
+			}
+		}
+
+		if (wcTargets.length > 0) {
+			const result = await this.#wcAPI().set(
+				wcTargets.map(({ binding, value }) => ({
+					parameter: binding.parameter,
+					value,
+				})),
+				resolvedDuration,
+			);
+			for (const { aspect, binding, value } of wcTargets) {
+				this.#tracker(aspect, binding).notifyCommand(
+					{
+						type: "set",
+						targetLevel: value,
+						duration: resolvedDuration,
+					},
+					result,
+				);
+			}
+		}
+
+		if (fibaroTargets.length > 0) {
+			const position = fibaroTargets.find(({ binding }) =>
+				binding.property === "position"
+			);
+			const tilt = fibaroTargets.find(({ binding }) =>
+				binding.property === "tilt"
+			);
+			const rawTilt = tilt && unifiedTiltToFibaro(tilt.value);
+			const api = this.#fibaroAPI();
+			if (position && rawTilt != undefined) {
+				await api.fibaroVenetianBlindsSet({
+					position: position.value,
+					tilt: rawTilt,
+				});
+			} else if (position) {
+				await api.fibaroVenetianBlindsSetPosition(position.value);
+			} else if (rawTilt != undefined) {
+				await api.fibaroVenetianBlindsSetTilt(rawTilt);
+			}
+			for (const { aspect, binding, value } of fibaroTargets) {
+				this.#tracker(aspect, binding).notifyCommand(
+					{
+						type: "set",
+						targetLevel: binding.property === "tilt"
+							? unifiedTiltToFibaro(value)
+							: value,
+					},
+					undefined,
+				);
+			}
+		}
+
+		for (const { aspect, value } of rest) {
+			await this.setValue(value, { aspect, duration });
+		}
+	}
+
+	/** Queries the device for the current state of a cover aspect */
+	public async refreshState(
+		aspect?: CoverAspect,
+	): Promise<CoverAspectState | undefined> {
+		const resolved = this.#resolveAspect(aspect, "position");
+		const { binding } = resolved;
+
+		switch (binding.backend) {
+			case "windowCovering":
+				if (binding.positioned) {
+					await this.#wcAPI().get(binding.parameter);
+				}
+				break;
+			case "multilevelSwitch":
+				await this.#mlsAPI().get();
+				break;
+			case "fibaro":
+				await this.#fibaroAPI().fibaroVenetianBlindsGet();
+				break;
+			case "basicWindowCovering":
+				break;
+		}
+
+		return this.getStateCached(aspect);
+	}
+
+	public override destroy(): void {
+		for (const tracker of this.#trackers.values()) {
+			tracker.destroy();
+		}
+		this.#trackers.clear();
+	}
+}

--- a/packages/zwave-js/src/lib/node/feature-apis/FeatureAPI.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/FeatureAPI.ts
@@ -11,4 +11,9 @@ export abstract class FeatureAPI {
 	protected getValue<T = unknown>(valueId: ValueID): MaybeNotKnown<T> {
 		return this.endpoint.tryGetNode()?.getValue(valueId);
 	}
+
+	/** Releases resources held by this API, e.g. event subscriptions and timers */
+	public destroy(): void {
+		// Most feature APIs hold no resources
+	}
 }

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/FibaroCC.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/FibaroCC.ts
@@ -1,0 +1,41 @@
+import {
+	FibaroVenetianBlindCCGet,
+	FibaroVenetianBlindCCReport,
+	FibaroVenetianBlindCCSet,
+} from "@zwave-js/cc/manufacturerProprietary/FibaroCC";
+import type { MockNodeBehavior } from "@zwave-js/testing";
+
+const POSITION_KEY = "FibaroVenetianBlind_position";
+const TILT_KEY = "FibaroVenetianBlind_tilt";
+
+const respondToFibaroVenetianBlindGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof FibaroVenetianBlindCCGet) {
+			const cc = new FibaroVenetianBlindCCReport({
+				nodeId: controller.ownNodeId,
+				position: (self.state.get(POSITION_KEY) as number) ?? 0,
+				tilt: (self.state.get(TILT_KEY) as number) ?? 0,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const respondToFibaroVenetianBlindSet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof FibaroVenetianBlindCCSet) {
+			if (receivedCC.position != undefined) {
+				self.state.set(POSITION_KEY, receivedCC.position);
+			}
+			if (receivedCC.tilt != undefined) {
+				self.state.set(TILT_KEY, receivedCC.tilt);
+			}
+			return { action: "ok" };
+		}
+	},
+};
+
+export const FibaroCCBehaviors: MockNodeBehavior[] = [
+	respondToFibaroVenetianBlindGet,
+	respondToFibaroVenetianBlindSet,
+];

--- a/packages/zwave-js/src/lib/node/transitions/TransitionTracker.test.ts
+++ b/packages/zwave-js/src/lib/node/transitions/TransitionTracker.test.ts
@@ -1,0 +1,253 @@
+import {
+	CommandClasses,
+	Duration,
+	SupervisionStatus,
+	type SupervisionUpdateHandler,
+	ValueDB,
+	type ValueID,
+} from "@zwave-js/core";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+	TransitionTracker,
+	type TransitionTrackerHost,
+} from "./TransitionTracker.js";
+
+const currentValueId: ValueID = {
+	commandClass: CommandClasses["Multilevel Switch"],
+	endpoint: 0,
+	property: "currentValue",
+};
+const targetValueId: ValueID = {
+	commandClass: CommandClasses["Multilevel Switch"],
+	endpoint: 0,
+	property: "targetValue",
+};
+const durationValueId: ValueID = {
+	commandClass: CommandClasses["Multilevel Switch"],
+	endpoint: 0,
+	property: "duration",
+};
+
+function setup(options: {
+	seedCurrent?: number;
+	seedTarget?: number;
+} = {}): {
+	valueDB: ValueDB;
+	host: TransitionTrackerHost;
+	schedulePoll: ReturnType<typeof vi.fn>;
+	tracker: TransitionTracker;
+	updates: ReturnType<typeof vi.fn>;
+} {
+	const valueDB = new ValueDB(2, new Map() as any, new Map() as any);
+	if (options.seedCurrent != undefined) {
+		valueDB.setValue(currentValueId, options.seedCurrent, {
+			noEvent: true,
+		});
+	}
+	if (options.seedTarget != undefined) {
+		valueDB.setValue(targetValueId, options.seedTarget, { noEvent: true });
+	}
+
+	const schedulePoll = vi.fn(() => true);
+	const host: TransitionTrackerHost = { valueDB, schedulePoll };
+	const tracker = new TransitionTracker(host, {
+		currentValueId,
+		targetValueId,
+		durationValueId,
+	});
+	const updates = vi.fn();
+	tracker.on("transition update", updates);
+
+	return { valueDB, host, schedulePoll, tracker, updates };
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+test("seeds from cached values without inferring movement from a stale target", () => {
+	const { tracker } = setup({ seedCurrent: 40, seedTarget: 99 });
+
+	expect(tracker.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 40,
+		targetLevel: undefined,
+		source: "initial",
+	});
+});
+
+test("coalesces value events from one report into a single atomic update", async () => {
+	const { valueDB, tracker, updates } = setup();
+
+	// One report persists all three values in the same tick
+	valueDB.setValue(currentValueId, 10);
+	valueDB.setValue(targetValueId, 99);
+	valueDB.setValue(durationValueId, new Duration(5, "seconds"));
+	await Promise.resolve();
+
+	expect(updates).toHaveBeenCalledTimes(1);
+	expect(tracker.state).toMatchObject({
+		movement: "increasing",
+		currentLevel: 10,
+		targetLevel: 99,
+	});
+});
+
+test("driver-sourced value updates are treated as commanded transitions", async () => {
+	const { valueDB, tracker } = setup({ seedCurrent: 10, seedTarget: 10 });
+
+	valueDB.setValue(targetValueId, 80, { source: "driver" });
+	await Promise.resolve();
+
+	expect(tracker.state).toMatchObject({
+		movement: "increasing",
+		currentLevel: 10,
+		targetLevel: 80,
+		source: "command",
+	});
+});
+
+test("trackCommand feeds supervision progress and mirrors optimistic updates", async () => {
+	const { valueDB, tracker, updates } = setup({ seedCurrent: 0 });
+
+	let onUpdate: SupervisionUpdateHandler;
+	const result = await tracker.trackCommand(
+		{ type: "set", targetLevel: 99 },
+		(handler) => {
+			onUpdate = handler;
+			return Promise.resolve({
+				status: SupervisionStatus.Working,
+				remainingDuration: new Duration(10, "seconds"),
+			});
+		},
+	);
+	expect(result).toMatchObject({ status: SupervisionStatus.Working });
+	expect(tracker.state).toMatchObject({
+		movement: "increasing",
+		targetLevel: 99,
+	});
+	// The commanded target is mirrored into the value DB
+	expect(valueDB.getValue(targetValueId)).toBe(99);
+
+	onUpdate!({ status: SupervisionStatus.Success });
+	expect(tracker.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 99,
+	});
+	expect(valueDB.getValue(currentValueId)).toBe(99);
+
+	// Start and end of the transition are exactly two updates
+	expect(updates).toHaveBeenCalledTimes(2);
+});
+
+test("a session update before the command promise settles starts the transition", async () => {
+	const { tracker } = setup({ seedCurrent: 0 });
+
+	let resolveSend: (result: undefined) => void;
+	const promise = tracker.trackCommand(
+		{ type: "set", targetLevel: 99 },
+		(handler) => {
+			handler({
+				status: SupervisionStatus.Working,
+				remainingDuration: new Duration(10, "seconds"),
+			});
+			return new Promise((resolve) => {
+				resolveSend = resolve;
+			});
+		},
+	);
+	expect(tracker.state).toMatchObject({
+		movement: "increasing",
+		targetLevel: 99,
+	});
+
+	resolveSend!(undefined);
+	await promise;
+	// The late promise result must not restart the transition
+	expect(tracker.state.movement).toBe("increasing");
+});
+
+test("a failed send restores the previous state", async () => {
+	const { tracker, updates } = setup({ seedCurrent: 0 });
+
+	await expect(
+		tracker.trackCommand(
+			{ type: "set", targetLevel: 99 },
+			() => Promise.reject(new Error("no connection")),
+		),
+	).rejects.toThrow();
+
+	expect(tracker.state.movement).toBe("idle");
+	expect(updates).not.toHaveBeenCalled();
+});
+
+test("verifies via poll after the quiet period and degrades when unanswered", async () => {
+	const { schedulePoll, tracker } = setup({ seedCurrent: 0 });
+
+	await tracker.trackCommand(
+		{ type: "set", targetLevel: 99 },
+		() => Promise.resolve(undefined),
+	);
+	expect(tracker.state.movement).toBe("increasing");
+
+	// No verification happens while the quiet period is still running
+	await vi.advanceTimersByTimeAsync(4000);
+	expect(schedulePoll).not.toHaveBeenCalled();
+
+	// Quiet period elapses without any reports
+	await vi.advanceTimersByTimeAsync(1000);
+	expect(schedulePoll).toHaveBeenCalledWith(
+		expect.objectContaining({ property: "currentValue" }),
+		{ timeoutMs: 0 },
+	);
+
+	// Both verification attempts time out
+	await vi.advanceTimersByTimeAsync(10_000);
+	expect(schedulePoll).toHaveBeenCalledTimes(2);
+	await vi.advanceTimersByTimeAsync(10_000);
+
+	expect(tracker.state).toMatchObject({
+		movement: "idle",
+		currentLevel: undefined,
+		source: "timeout",
+	});
+});
+
+test("an incoming report answers the verification", async () => {
+	const { valueDB, tracker } = setup({ seedCurrent: 99 });
+
+	await tracker.trackCommand(
+		{ type: "startLevelChange", direction: "up" },
+		() => Promise.resolve(undefined),
+	);
+	await vi.advanceTimersByTimeAsync(5000);
+
+	valueDB.setValue(currentValueId, 99);
+	await Promise.resolve();
+
+	expect(tracker.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 99,
+	});
+});
+
+test("destroy stops timers and unsubscribes from the value DB", async () => {
+	const { valueDB, tracker, updates } = setup({ seedCurrent: 0 });
+
+	await tracker.trackCommand(
+		{ type: "set", targetLevel: 99 },
+		() => Promise.resolve(undefined),
+	);
+	updates.mockClear();
+	tracker.destroy();
+
+	valueDB.setValue(currentValueId, 50);
+	await vi.advanceTimersByTimeAsync(120_000);
+
+	expect(updates).not.toHaveBeenCalled();
+	expect(tracker.state.movement).toBe("increasing");
+});

--- a/packages/zwave-js/src/lib/node/transitions/TransitionTracker.ts
+++ b/packages/zwave-js/src/lib/node/transitions/TransitionTracker.ts
@@ -1,0 +1,396 @@
+import type { SchedulePollOptions } from "@zwave-js/cc";
+import {
+	Duration,
+	type SupervisionResult,
+	type SupervisionUpdateHandler,
+	type ValueDB,
+	type ValueID,
+	type ValueUpdatedArgs,
+	normalizeValueID,
+} from "@zwave-js/core";
+import { type Timer, TypedEventTarget, setTimer } from "@zwave-js/shared";
+import {
+	type TransitionCommand,
+	type TransitionMachineInput,
+	type TransitionMachineTimers,
+	type TransitionState,
+	TransitionTrackerMachine,
+	defaultTransitionMachineConfig,
+} from "./TransitionTrackerMachine.js";
+
+export type {
+	TransitionCommand,
+	TransitionMovement,
+	TransitionState,
+	TransitionStateSource,
+} from "./TransitionTrackerMachine.js";
+
+/** The subset of node functionality the tracker depends on */
+export interface TransitionTrackerHost {
+	readonly valueDB: ValueDB;
+	schedulePoll(valueId: ValueID, options?: SchedulePollOptions): boolean;
+}
+
+export interface TransitionTrackerEventCallbacks {
+	"transition update": (
+		state: Readonly<TransitionState>,
+		previous: Readonly<TransitionState>,
+	) => void;
+}
+
+export interface TransitionTrackerOptions {
+	/** Where the current level is stored, if the dimension has a readable level at all */
+	currentValueId?: ValueID;
+	targetValueId?: ValueID;
+	durationValueId?: ValueID;
+	/** The lowest level of the tracked dimension. Default: 0 */
+	minLevel?: number;
+	/** The highest level of the tracked dimension. Default: 99 */
+	maxLevel?: number;
+	/** Assumed full transition time when no duration is known. Default: 60 seconds */
+	defaultTransitionDuration?: Duration;
+	/** Quiet time without progress updates before an unsupervised transition is verified. Default: 5 seconds */
+	idleDetectionTimeoutMs?: number;
+	/** Hard cap after which any transition is verified. Default: 5 minutes */
+	maxTransitionDurationMs?: number;
+	/** Whether to mirror commanded transitions into the value DB as optimistic updates. Default: `true` */
+	synthesizeValueUpdates?: boolean;
+	/**
+	 * How to verify the current level when the tracker has lost track of a
+	 * transition. Defaults to polling `currentValueId`. Pass `null` for
+	 * dimensions that cannot be queried at all.
+	 */
+	verify?: (() => Promise<void>) | null;
+}
+
+function isMaybeLevel(value: unknown): value is number | null {
+	return value === null || typeof value === "number";
+}
+
+function statesEqual(a: TransitionState, b: TransitionState): boolean {
+	return a.movement === b.movement
+		&& a.currentLevel === b.currentLevel
+		&& a.targetLevel === b.targetLevel
+		&& a.estimatedDuration?.unit === b.estimatedDuration?.unit
+		&& a.estimatedDuration?.value === b.estimatedDuration?.value;
+}
+
+/**
+ * Tracks transitions of a single level dimension (cover position, tilt,
+ * dimmer brightness, ...) by combining commands issued through zwave-js,
+ * supervision session updates, and incoming reports into one consolidated,
+ * consistent state with atomic change events.
+ */
+export class TransitionTracker
+	extends TypedEventTarget<TransitionTrackerEventCallbacks>
+{
+	public constructor(
+		host: TransitionTrackerHost,
+		options: TransitionTrackerOptions,
+	) {
+		super();
+		this.host = host;
+		this.currentValueId = options.currentValueId
+			&& normalizeValueID(options.currentValueId);
+		this.targetValueId = options.targetValueId
+			&& normalizeValueID(options.targetValueId);
+		this.durationValueId = options.durationValueId
+			&& normalizeValueID(options.durationValueId);
+		this.synthesizeValueUpdates = options.synthesizeValueUpdates ?? true;
+		const currentValueId = this.currentValueId;
+		this.verify = options.verify === undefined
+			? (currentValueId
+				? () => {
+					this.host.schedulePoll(currentValueId, { timeoutMs: 0 });
+					return Promise.resolve();
+				}
+				: null)
+			: options.verify;
+
+		// Seed the level from cached values, but never infer an ongoing
+		// transition from stale cached state
+		const cachedLevel = currentValueId
+			&& this.host.valueDB.getValue(currentValueId);
+		this.machine = new TransitionTrackerMachine({
+			minLevel: options.minLevel,
+			maxLevel: options.maxLevel,
+			defaultTransitionDurationMs:
+				options.defaultTransitionDuration?.toMilliseconds()
+					?? defaultTransitionMachineConfig
+						.defaultTransitionDurationMs,
+			idleDetectionTimeoutMs: options.idleDetectionTimeoutMs,
+			maxTransitionDurationMs: options.maxTransitionDurationMs,
+			canVerify: this.verify != null,
+			synthesizeValueUpdates: this.synthesizeValueUpdates,
+		}, {
+			currentLevel: typeof cachedLevel === "number"
+				? cachedLevel
+				: undefined,
+		});
+		this.lastState = this.machine.state;
+
+		this.host.valueDB
+			.on("value added", this.onValueEvent)
+			.on("value updated", this.onValueEvent);
+	}
+
+	private readonly host: TransitionTrackerHost;
+	private readonly machine: TransitionTrackerMachine;
+	private readonly currentValueId: ValueID | undefined;
+	private readonly targetValueId: ValueID | undefined;
+	private readonly durationValueId: ValueID | undefined;
+	private readonly synthesizeValueUpdates: boolean;
+	private readonly verify: (() => Promise<void>) | null;
+
+	private lastState: TransitionState;
+	private commandGeneration = 0;
+	private destroyed = false;
+
+	private timers: {
+		deadline?: { at: number; timer: Timer };
+		quiet?: { at: number; timer: Timer };
+		verification?: { at: number; timer: Timer };
+	} = {};
+
+	// Value events for one report are emitted in the same tick; collect them and
+	// dispatch a single consolidated input per microtask
+	private pendingUpdate:
+		| {
+			currentLevel?: number | null;
+			targetLevel?: number | null;
+			duration?: Duration;
+			fromDriver: boolean;
+		}
+		| undefined;
+
+	/** Returns the consolidated state of the tracked dimension */
+	public get state(): Readonly<TransitionState> {
+		return this.machine.state;
+	}
+
+	private matchValueId(
+		args: ValueID,
+	): "current" | "target" | "duration" | undefined {
+		const matches = (other: ValueID | undefined) =>
+			other != undefined
+			&& args.commandClass === other.commandClass
+			&& (args.endpoint ?? 0) === (other.endpoint ?? 0)
+			&& args.property === other.property
+			&& args.propertyKey === other.propertyKey;
+		if (matches(this.currentValueId)) return "current";
+		if (matches(this.targetValueId)) return "target";
+		if (matches(this.durationValueId)) return "duration";
+	}
+
+	private readonly onValueEvent = (
+		args: ValueUpdatedArgs | (ValueID & { newValue: unknown }),
+	): void => {
+		const which = this.matchValueId(args);
+		if (!which) return;
+
+		const fromDriver = "source" in args && args.source === "driver";
+		if (!this.pendingUpdate) {
+			this.pendingUpdate = { fromDriver };
+			queueMicrotask(() => this.flushPendingUpdate());
+		}
+		// A single node-sourced write makes the whole burst count as a report
+		this.pendingUpdate.fromDriver &&= fromDriver;
+
+		const value = args.newValue;
+		switch (which) {
+			case "current":
+				if (isMaybeLevel(value)) {
+					this.pendingUpdate.currentLevel = value;
+				}
+				break;
+			case "target":
+				if (isMaybeLevel(value)) {
+					this.pendingUpdate.targetLevel = value;
+				}
+				break;
+			case "duration": {
+				const duration = Duration.from(value as any);
+				if (duration) this.pendingUpdate.duration = duration;
+				break;
+			}
+		}
+	};
+
+	private flushPendingUpdate(): void {
+		if (this.destroyed || !this.pendingUpdate) return;
+		const update = this.pendingUpdate;
+		this.pendingUpdate = undefined;
+
+		if (update.fromDriver) {
+			this.dispatch({
+				type: "syntheticUpdate",
+				currentLevel: update.currentLevel,
+				targetLevel: update.targetLevel,
+			});
+		} else {
+			this.dispatch({
+				type: "report",
+				currentLevel: update.currentLevel,
+				targetLevel: update.targetLevel,
+				duration: update.duration,
+			});
+		}
+	}
+
+	private dispatch(input: TransitionMachineInput): void {
+		if (this.destroyed) return;
+		const now = Date.now();
+		const { timers, effects } = this.machine.handleInput(input, now);
+		this.reconcileTimers(timers, now);
+
+		for (const effect of effects) {
+			switch (effect.type) {
+				case "requestVerification":
+					void this.verify?.().catch(() => {
+						// A failed verification attempt is settled by the verification timeout
+					});
+					break;
+				case "setValueOptimistic": {
+					const valueId = effect.which === "current"
+						? this.currentValueId
+						: this.targetValueId;
+					if (valueId) {
+						this.host.valueDB.setValue(valueId, effect.level, {
+							source: "driver",
+						});
+					}
+					break;
+				}
+			}
+		}
+
+		const state = this.machine.state;
+		if (!statesEqual(state, this.lastState)) {
+			const previous = this.lastState;
+			this.lastState = state;
+			this.emit("transition update", state, previous);
+		} else {
+			this.lastState = state;
+		}
+	}
+
+	private reconcileTimers(
+		desired: TransitionMachineTimers,
+		now: number,
+	): void {
+		const reconcile = (
+			key: "deadline" | "quiet" | "verification",
+			at: number | undefined,
+			input: TransitionMachineInput,
+		) => {
+			const existing = this.timers[key];
+			if (existing?.at === at) return;
+			existing?.timer.clear();
+			this.timers[key] = at == undefined
+				? undefined
+				: {
+					at,
+					timer: setTimer(
+						() => this.dispatch(input),
+						Math.max(0, at - now),
+					).unref(),
+				};
+		};
+		reconcile("deadline", desired.deadline, { type: "deadlineElapsed" });
+		reconcile("quiet", desired.quiet, { type: "quietPeriodElapsed" });
+		reconcile("verification", desired.verification, {
+			type: "verificationTimedOut",
+		});
+	}
+
+	/**
+	 * Executes a level-affecting command while keeping the tracker informed
+	 * about its progress, including supervision status updates.
+	 *
+	 * The `send` callback performs the actual communication and receives a
+	 * handler that must be passed to the CC API via
+	 * `withOptions({ requestStatusUpdates: true, onUpdate })`.
+	 */
+	public async trackCommand(
+		command: TransitionCommand,
+		send: (
+			onSupervisionUpdate: SupervisionUpdateHandler,
+		) => Promise<SupervisionResult | undefined>,
+	): Promise<SupervisionResult | undefined> {
+		const generation = ++this.commandGeneration;
+		let settled = false;
+
+		this.dispatch({ type: "commandIssued", command });
+
+		const onUpdate: SupervisionUpdateHandler = (update) => {
+			// Ignore updates from sessions that were superseded by a newer command
+			if (generation !== this.commandGeneration) return;
+			// The initial result is dispatched from the command promise
+			if (!settled) return;
+			this.dispatch({
+				type: "supervisionUpdate",
+				status: update.status,
+				remainingDuration: update.remainingDuration,
+			});
+		};
+
+		try {
+			const result = await send((update) => {
+				if (generation !== this.commandGeneration) return;
+				if (!settled) {
+					// A session update before the promise settles means the
+					// transition has started
+					settled = true;
+					this.dispatch({ type: "commandResult", result: update });
+				} else {
+					onUpdate(update);
+				}
+			});
+			if (!settled && generation === this.commandGeneration) {
+				settled = true;
+				this.dispatch({ type: "commandResult", result });
+			}
+			return result;
+		} catch (e) {
+			if (!settled && generation === this.commandGeneration) {
+				settled = true;
+				this.dispatch({ type: "commandFailed" });
+			}
+			throw e;
+		}
+	}
+
+	/**
+	 * Informs the tracker about a command that was sent outside of
+	 * {@link trackCommand}, e.g. as part of a combined command affecting
+	 * multiple dimensions at once.
+	 */
+	public notifyCommand(
+		command: TransitionCommand,
+		result: SupervisionResult | undefined,
+	): void {
+		this.commandGeneration++;
+		this.dispatch({ type: "commandIssued", command });
+		this.dispatch({ type: "commandResult", result });
+	}
+
+	/** Feeds a device-initiated level change, e.g. from an unsolicited Multilevel Switch Start/Stop Level Change */
+	public handleUnsolicitedLevelChange(
+		direction: "up" | "down" | "stop",
+	): void {
+		this.dispatch({ type: "unsolicitedLevelChange", direction });
+	}
+
+	/** Removes all listeners and stops all timers */
+	public destroy(): void {
+		this.destroyed = true;
+		this.host.valueDB
+			.off("value added", this.onValueEvent)
+			.off("value updated", this.onValueEvent);
+		for (const key of ["deadline", "quiet", "verification"] as const) {
+			this.timers[key]?.timer.clear();
+			this.timers[key] = undefined;
+		}
+		this.removeAllListeners();
+	}
+}

--- a/packages/zwave-js/src/lib/node/transitions/TransitionTrackerMachine.test.ts
+++ b/packages/zwave-js/src/lib/node/transitions/TransitionTrackerMachine.test.ts
@@ -1,0 +1,500 @@
+import { Duration, SupervisionStatus } from "@zwave-js/core";
+import { expect, test } from "vitest";
+import {
+	type TransitionMachineConfig,
+	type TransitionMachineInput,
+	TransitionTrackerMachine,
+} from "./TransitionTrackerMachine.js";
+
+function setup(
+	config: Partial<TransitionMachineConfig> = {},
+	currentLevel?: number,
+): TransitionTrackerMachine {
+	return new TransitionTrackerMachine(config, { currentLevel });
+}
+
+const set = (
+	targetLevel: number,
+	duration?: Duration,
+): TransitionMachineInput => ({
+	type: "commandIssued",
+	command: { type: "set", targetLevel, duration },
+});
+
+const startLevelChange = (
+	direction: "up" | "down",
+	duration?: Duration,
+): TransitionMachineInput => ({
+	type: "commandIssued",
+	command: { type: "startLevelChange", direction, duration },
+});
+
+const stop: TransitionMachineInput = {
+	type: "commandIssued",
+	command: { type: "stop" },
+};
+
+const result = (
+	status?: SupervisionStatus,
+	remainingDuration?: Duration,
+): TransitionMachineInput => ({
+	type: "commandResult",
+	result: status == undefined
+		? undefined
+		: { status, remainingDuration } as any,
+});
+
+test("supervised set: Working -> Success completes at the target", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 1000);
+	const started = machine.handleInput(
+		result(SupervisionStatus.Working, new Duration(10, "seconds")),
+		1000,
+	);
+
+	expect(machine.state).toMatchObject({
+		movement: "increasing",
+		currentLevel: 0,
+		targetLevel: 99,
+	});
+	// Slack for a 10 s transition is max(1 s, 10%) = 1 s
+	expect(started.timers.deadline).toBe(1000 + 11_000);
+	expect(started.timers.quiet).toBeUndefined();
+	expect(started.effects).toContainEqual({
+		type: "setValueOptimistic",
+		which: "target",
+		level: 99,
+	});
+
+	const finished = machine.handleInput({
+		type: "supervisionUpdate",
+		status: SupervisionStatus.Success,
+	}, 6000);
+
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 99,
+		targetLevel: undefined,
+	});
+	expect(finished.timers).toEqual({});
+	expect(finished.effects).toContainEqual({
+		type: "setValueOptimistic",
+		which: "current",
+		level: 99,
+	});
+});
+
+test("supervised set: Working updates refresh the deadline", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	machine.handleInput(
+		result(SupervisionStatus.Working, new Duration(10, "seconds")),
+		0,
+	);
+	const updated = machine.handleInput({
+		type: "supervisionUpdate",
+		status: SupervisionStatus.Working,
+		remainingDuration: new Duration(8, "seconds"),
+	}, 3000);
+
+	expect(updated.timers.deadline).toBe(3000 + 9000);
+	expect(machine.state.estimatedDuration).toMatchObject({
+		value: 8,
+		unit: "seconds",
+	});
+});
+
+test("supervised set: session failure triggers verification", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	machine.handleInput(
+		result(SupervisionStatus.Working, new Duration(10, "seconds")),
+		0,
+	);
+	const interrupted = machine.handleInput({
+		type: "supervisionUpdate",
+		status: SupervisionStatus.Fail,
+	}, 4000);
+
+	expect(interrupted.effects).toContainEqual({ type: "requestVerification" });
+	expect(interrupted.timers.verification).toBe(4000 + 10_000);
+
+	// The verification report settles the state at the actual position
+	machine.handleInput({ type: "report", currentLevel: 42 }, 4500);
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 42,
+	});
+});
+
+test("supervised set: immediate Success is an instant transition", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(50), 0);
+	const finished = machine.handleInput(result(SupervisionStatus.Success), 0);
+
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 50,
+	});
+	expect(finished.effects).toContainEqual({
+		type: "setValueOptimistic",
+		which: "current",
+		level: 50,
+	});
+});
+
+test("supervision update while the command promise is pending starts the transition", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	machine.handleInput({
+		type: "supervisionUpdate",
+		status: SupervisionStatus.Working,
+		remainingDuration: new Duration(5, "seconds"),
+	}, 0);
+
+	expect(machine.state).toMatchObject({
+		movement: "increasing",
+		targetLevel: 99,
+	});
+});
+
+test("unsupervised set with duration relies on the deadline only", () => {
+	const machine = setup({}, 99);
+
+	machine.handleInput(set(0, new Duration(20, "seconds")), 0);
+	const started = machine.handleInput(result(), 0);
+
+	expect(machine.state).toMatchObject({
+		movement: "decreasing",
+		targetLevel: 0,
+	});
+	// Slack for a 20 s transition is 10% = 2 s
+	expect(started.timers.deadline).toBe(22_000);
+	expect(started.timers.quiet).toBeUndefined();
+	expect(started.effects).toContainEqual({
+		type: "setValueOptimistic",
+		which: "target",
+		level: 0,
+	});
+
+	// The end report settles the transition
+	machine.handleInput(
+		{ type: "report", currentLevel: 0, targetLevel: 0 },
+		18_000,
+	);
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 0,
+	});
+});
+
+test("unsupervised set without duration uses a rolling quiet period", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	const started = machine.handleInput(result(), 0);
+	expect(started.timers.quiet).toBe(5000);
+	// The default transition duration of 60 s gets 10% slack
+	expect(started.timers.deadline).toBe(66_000);
+
+	// Intermediate reports restart the quiet period
+	const progress = machine.handleInput(
+		{ type: "report", currentLevel: 30 },
+		4000,
+	);
+	expect(progress.timers.quiet).toBe(9000);
+	expect(machine.state).toMatchObject({
+		movement: "increasing",
+		currentLevel: 30,
+		targetLevel: 99,
+	});
+
+	// Silence triggers verification, the response ends the transition
+	const quiet = machine.handleInput({ type: "quietPeriodElapsed" }, 9000);
+	expect(quiet.effects).toContainEqual({ type: "requestVerification" });
+	machine.handleInput({ type: "report", currentLevel: 99 }, 9500);
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 99,
+	});
+});
+
+test("start level change at the travel limit never stays moving", () => {
+	const machine = setup({}, 99);
+
+	machine.handleInput(startLevelChange("up"), 0);
+	machine.handleInput(result(), 0);
+	expect(machine.state).toMatchObject({
+		movement: "increasing",
+		targetLevel: 99,
+	});
+
+	// The device is already at the limit and never reports anything
+	const quiet = machine.handleInput({ type: "quietPeriodElapsed" }, 5000);
+	expect(quiet.effects).toContainEqual({ type: "requestVerification" });
+	machine.handleInput({ type: "report", currentLevel: 99 }, 5500);
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 99,
+	});
+});
+
+test("supervised start level change with immediate Success remains an open-ended transition", () => {
+	const machine = setup({}, 50);
+
+	machine.handleInput(startLevelChange("down"), 0);
+	const started = machine.handleInput(result(SupervisionStatus.Success), 0);
+
+	expect(machine.state).toMatchObject({
+		movement: "decreasing",
+		targetLevel: 0,
+	});
+	expect(started.timers.quiet).toBe(5000);
+});
+
+test("stop: an unsupervised stop waits briefly for a resting position report", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	machine.handleInput(result(), 0);
+
+	machine.handleInput(stop, 3000);
+	const stopped = machine.handleInput(result(), 3000);
+	expect(stopped.timers.deadline).toBe(5000);
+
+	machine.handleInput({ type: "report", currentLevel: 40 }, 4000);
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 40,
+		targetLevel: undefined,
+	});
+});
+
+test("stop: supervised Success verifies the resting position", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	machine.handleInput(
+		result(SupervisionStatus.Working, new Duration(10, "seconds")),
+		0,
+	);
+
+	machine.handleInput(stop, 3000);
+	const stopped = machine.handleInput(
+		result(SupervisionStatus.Success),
+		3000,
+	);
+	expect(stopped.effects).toContainEqual({ type: "requestVerification" });
+});
+
+test("device-initiated transition with full reporting (Window Covering)", () => {
+	const machine = setup({}, 10);
+
+	const started = machine.handleInput({
+		type: "report",
+		currentLevel: 10,
+		targetLevel: 99,
+		duration: new Duration(15, "seconds"),
+	}, 0);
+
+	expect(machine.state).toMatchObject({
+		movement: "increasing",
+		currentLevel: 10,
+		targetLevel: 99,
+	});
+	expect(started.timers.deadline).toBe(16_500);
+
+	machine.handleInput({
+		type: "report",
+		currentLevel: 99,
+		targetLevel: 99,
+		duration: new Duration(0, "seconds"),
+	}, 15_000);
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 99,
+	});
+});
+
+test("device-initiated transition with current-only reports (MLS v1-3)", () => {
+	const machine = setup({}, 0);
+
+	// A changed current level without target information indicates movement
+	machine.handleInput({ type: "report", currentLevel: 20 }, 0);
+	expect(machine.state).toMatchObject({
+		movement: "increasing",
+		currentLevel: 20,
+		targetLevel: undefined,
+	});
+
+	machine.handleInput({ type: "report", currentLevel: 40 }, 2000);
+	expect(machine.state.movement).toBe("increasing");
+
+	// After the reports stop, verification settles the state
+	const quiet = machine.handleInput({ type: "quietPeriodElapsed" }, 7000);
+	expect(quiet.effects).toContainEqual({ type: "requestVerification" });
+	machine.handleInput({ type: "report", currentLevel: 55 }, 7500);
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 55,
+	});
+});
+
+test("a consistent report while idle only updates the level", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput({
+		type: "report",
+		currentLevel: 60,
+		targetLevel: 60,
+		duration: new Duration(0, "seconds"),
+	}, 0);
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: 60,
+	});
+});
+
+test("unsolicited level change reports movement with unknown target", () => {
+	const machine = setup({}, 50);
+
+	const started = machine.handleInput({
+		type: "unsolicitedLevelChange",
+		direction: "down",
+	}, 0);
+	expect(machine.state).toMatchObject({
+		movement: "decreasing",
+		targetLevel: undefined,
+	});
+	expect(started.timers.quiet).toBe(5000);
+
+	machine.handleInput({
+		type: "unsolicitedLevelChange",
+		direction: "stop",
+	}, 2000);
+	const afterStop = machine.handleInput({ type: "deadlineElapsed" }, 4000);
+	expect(afterStop.effects).toContainEqual({ type: "requestVerification" });
+});
+
+test("degrades to unknown after exhausted verification attempts", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	machine.handleInput(result(), 0);
+	machine.handleInput({ type: "quietPeriodElapsed" }, 5000);
+
+	const retry = machine.handleInput({ type: "verificationTimedOut" }, 15_000);
+	expect(retry.effects).toContainEqual({ type: "requestVerification" });
+
+	machine.handleInput({ type: "verificationTimedOut" }, 25_000);
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		currentLevel: undefined,
+		targetLevel: undefined,
+		source: "timeout",
+	});
+});
+
+test("without verification support, timeouts degrade immediately", () => {
+	const machine = setup({ canVerify: false }, undefined);
+
+	machine.handleInput(startLevelChange("up"), 0);
+	machine.handleInput(result(), 0);
+	expect(machine.state).toMatchObject({
+		movement: "increasing",
+		currentLevel: undefined,
+	});
+
+	const elapsed = machine.handleInput({ type: "deadlineElapsed" }, 70_000);
+	expect(elapsed.effects).not.toContainEqual({
+		type: "requestVerification",
+	});
+	expect(machine.state).toMatchObject({
+		movement: "idle",
+		source: "timeout",
+	});
+});
+
+test("a level reported as unknown clears the current level", () => {
+	const machine = setup({}, 30);
+
+	machine.handleInput(set(99), 0);
+	machine.handleInput(result(), 0);
+	machine.handleInput({ type: "report", currentLevel: null }, 1000);
+	expect(machine.state.currentLevel).toBeUndefined();
+	expect(machine.state.movement).toBe("increasing");
+});
+
+test("a new command supersedes the ongoing transition", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	machine.handleInput(result(), 0);
+	expect(machine.state.movement).toBe("increasing");
+
+	machine.handleInput({ type: "report", currentLevel: 50 }, 1000);
+	machine.handleInput(set(0), 2000);
+	machine.handleInput(
+		result(SupervisionStatus.Working, new Duration(5, "seconds")),
+		2000,
+	);
+	expect(machine.state).toMatchObject({
+		movement: "decreasing",
+		targetLevel: 0,
+	});
+});
+
+test("a failed send restores the previous state", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	machine.handleInput(result(), 0);
+
+	machine.handleInput(stop, 2000);
+	machine.handleInput({ type: "commandFailed" }, 2000);
+	expect(machine.state).toMatchObject({
+		movement: "increasing",
+		targetLevel: 99,
+	});
+});
+
+test("a synthetic target update tracks raw setValue commands", () => {
+	const machine = setup({}, 10);
+
+	const started = machine.handleInput({
+		type: "syntheticUpdate",
+		targetLevel: 80,
+	}, 0);
+	expect(machine.state).toMatchObject({
+		movement: "increasing",
+		currentLevel: 10,
+		targetLevel: 80,
+		source: "command",
+	});
+	expect(started.timers.quiet).toBe(5000);
+});
+
+test("an unknown remaining duration falls back to the default deadline", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99), 0);
+	const started = machine.handleInput(
+		result(SupervisionStatus.Working, Duration.unknown()),
+		0,
+	);
+	// Default 60 s + 10% slack
+	expect(started.timers.deadline).toBe(66_000);
+});
+
+test("the deadline is bounded by the maximum transition duration", () => {
+	const machine = setup({}, 0);
+
+	machine.handleInput(set(99, new Duration(20, "minutes")), 0);
+	const started = machine.handleInput(result(), 0);
+	expect(started.timers.deadline).toBe(300_000);
+});

--- a/packages/zwave-js/src/lib/node/transitions/TransitionTrackerMachine.ts
+++ b/packages/zwave-js/src/lib/node/transitions/TransitionTrackerMachine.ts
@@ -1,0 +1,850 @@
+import {
+	Duration,
+	type SupervisionResult,
+	SupervisionStatus,
+} from "@zwave-js/core";
+
+/** The direction a tracked level is currently moving in. "unknown" means an ongoing transition with underivable direction */
+export type TransitionMovement =
+	| "idle"
+	| "increasing"
+	| "decreasing"
+	| "unknown";
+
+/** What caused the most recent transition state change */
+export type TransitionStateSource =
+	| "initial"
+	| "command"
+	| "report"
+	| "supervision"
+	| "timeout";
+
+/** Consolidated, consistent view of a tracked level dimension */
+export interface TransitionState {
+	movement: TransitionMovement;
+	/** Last known level. `undefined` while the level is unknown, e.g. mid-travel on devices without position feedback */
+	currentLevel?: number;
+	/** The level being moved towards, if known */
+	targetLevel?: number;
+	/** Estimated duration of the ongoing transition, if known */
+	estimatedDuration?: Duration;
+	source: TransitionStateSource;
+}
+
+/** A level-affecting command issued through the tracker */
+export type TransitionCommand =
+	| {
+		type: "set";
+		targetLevel: number;
+		duration?: Duration;
+	}
+	| {
+		type: "startLevelChange";
+		direction: "up" | "down";
+		duration?: Duration;
+	}
+	| { type: "stop" };
+
+export type TransitionMachineInput =
+	| { type: "commandIssued"; command: TransitionCommand }
+	| { type: "commandResult"; result: SupervisionResult | undefined }
+	| { type: "commandFailed" }
+	| {
+		type: "supervisionUpdate";
+		status: SupervisionStatus;
+		remainingDuration?: Duration;
+	}
+	// For level fields, `null` means the device reported the level as unknown,
+	// `undefined` means the field was not part of the update
+	| {
+		type: "report";
+		currentLevel?: number | null;
+		targetLevel?: number | null;
+		duration?: Duration;
+	}
+	| {
+		type: "syntheticUpdate";
+		currentLevel?: number | null;
+		targetLevel?: number | null;
+	}
+	| { type: "unsolicitedLevelChange"; direction: "up" | "down" | "stop" }
+	| { type: "deadlineElapsed" }
+	| { type: "quietPeriodElapsed" }
+	| { type: "verificationTimedOut" };
+
+export type TransitionMachineEffect =
+	| { type: "requestVerification" }
+	| {
+		type: "setValueOptimistic";
+		which: "current" | "target";
+		level: number;
+	};
+
+/** Desired active timers as absolute timestamps. The host reconciles these with its running timers */
+export interface TransitionMachineTimers {
+	deadline?: number;
+	quiet?: number;
+	verification?: number;
+}
+
+export interface TransitionMachineResult {
+	timers: TransitionMachineTimers;
+	effects: TransitionMachineEffect[];
+}
+
+export interface TransitionMachineConfig {
+	minLevel: number;
+	maxLevel: number;
+	/** Assumed full transition time when no duration is known */
+	defaultTransitionDurationMs: number;
+	/** Quiet time without progress updates before an unsupervised transition is verified */
+	idleDetectionTimeoutMs: number;
+	/** Hard cap after which any transition is verified */
+	maxTransitionDurationMs: number;
+	/** Lower bound for the slack added to expected transition durations */
+	minSlackMs: number;
+	/** Whether the level can be verified by querying the device */
+	canVerify: boolean;
+	verificationTimeoutMs: number;
+	maxVerificationAttempts: number;
+	/** Whether to emit optimistic value update effects for commanded transitions */
+	synthesizeValueUpdates: boolean;
+}
+
+export const defaultTransitionMachineConfig = {
+	minLevel: 0,
+	maxLevel: 99,
+	defaultTransitionDurationMs: 60_000,
+	idleDetectionTimeoutMs: 5_000,
+	maxTransitionDurationMs: 300_000,
+	minSlackMs: 1_000,
+	canVerify: true,
+	verificationTimeoutMs: 10_000,
+	maxVerificationAttempts: 2,
+	synthesizeValueUpdates: true,
+} as const satisfies TransitionMachineConfig;
+
+type Direction = "up" | "down";
+
+type MachineState =
+	| { type: "idle" }
+	| {
+		type: "commandPending";
+		command: TransitionCommand;
+		// Restored when sending the command fails
+		previous: MachineState;
+	}
+	| {
+		type: "movingSupervised";
+		direction?: Direction;
+		target?: number;
+		deadlineAt: number;
+	}
+	| {
+		type: "movingUnsupervised";
+		direction?: Direction;
+		target?: number;
+		deadlineAt: number;
+		quietAt?: number;
+	}
+	| {
+		type: "movingByDevice";
+		direction?: Direction;
+		target?: number;
+		deadlineAt: number;
+		quietAt?: number;
+	}
+	| { type: "stopPending"; deadlineAt: number }
+	| { type: "verifying"; attempt: number; verificationAt: number };
+
+function movementFromDirection(
+	direction: Direction | undefined,
+): TransitionMovement {
+	if (direction === "up") return "increasing";
+	if (direction === "down") return "decreasing";
+	return "unknown";
+}
+
+/**
+ * Pure state machine for tracking level transitions of a single dimension
+ * (cover position, tilt, dimmer brightness, ...). All time-dependent behavior
+ * is expressed through the injected `nowMs` and the returned desired timers,
+ * so the machine itself is fully deterministic and unit-testable.
+ */
+export class TransitionTrackerMachine {
+	public constructor(
+		config: Partial<TransitionMachineConfig> = {},
+		seed: { currentLevel?: number } = {},
+	) {
+		// Options that are present but undefined must not override the defaults
+		const merged = { ...defaultTransitionMachineConfig };
+		for (const [key, value] of Object.entries(config)) {
+			if (value !== undefined) (merged as any)[key] = value;
+		}
+		this.config = merged;
+		this.currentLevel = seed.currentLevel;
+	}
+
+	private readonly config: TransitionMachineConfig;
+	private machineState: MachineState = { type: "idle" };
+
+	// Best known level information, shared across states
+	private currentLevel: number | undefined;
+	private targetLevel: number | undefined;
+	private estimatedDuration: Duration | undefined;
+	private source: TransitionStateSource = "initial";
+
+	/** Returns the consolidated public view of the tracked dimension */
+	public get state(): TransitionState {
+		const moving = this.isMoving();
+		return {
+			movement: moving
+				? movementFromDirection(this.movingDirection())
+				: "idle",
+			currentLevel: this.currentLevel,
+			targetLevel: moving ? this.targetLevel : undefined,
+			estimatedDuration: moving ? this.estimatedDuration : undefined,
+			source: this.source,
+		};
+	}
+
+	private isMoving(): boolean {
+		switch (this.machineState.type) {
+			case "movingSupervised":
+			case "movingUnsupervised":
+			case "movingByDevice":
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	private movingDirection(): Direction | undefined {
+		switch (this.machineState.type) {
+			case "movingSupervised":
+			case "movingUnsupervised":
+			case "movingByDevice":
+				return this.machineState.direction;
+			default:
+				return undefined;
+		}
+	}
+
+	/** Computes the deadline for an expected transition duration, bounded by the hard cap */
+	private deadlineFor(nowMs: number, durationMs: number | undefined): number {
+		const expected = durationMs ?? this.config.defaultTransitionDurationMs;
+		const slack = Math.max(this.config.minSlackMs, expected / 10);
+		return nowMs
+			+ Math.min(expected + slack, this.config.maxTransitionDurationMs);
+	}
+
+	private inferDirection(
+		explicit: Direction | undefined,
+		target: number | undefined,
+		previousLevel: number | undefined,
+	): Direction | undefined {
+		if (explicit) return explicit;
+		if (target != undefined && this.currentLevel != undefined) {
+			if (target > this.currentLevel) return "up";
+			if (target < this.currentLevel) return "down";
+			return undefined;
+		}
+		if (this.currentLevel != undefined && previousLevel != undefined) {
+			if (this.currentLevel > previousLevel) return "up";
+			if (this.currentLevel < previousLevel) return "down";
+		}
+		return undefined;
+	}
+
+	private extremeFor(direction: Direction): number {
+		return direction === "up" ? this.config.maxLevel : this.config.minLevel;
+	}
+
+	/** Applies an input and returns the desired timers and side effects */
+	public handleInput(
+		input: TransitionMachineInput,
+		nowMs: number,
+	): TransitionMachineResult {
+		const effects: TransitionMachineEffect[] = [];
+
+		switch (input.type) {
+			case "commandIssued":
+				this.machineState = {
+					type: "commandPending",
+					command: input.command,
+					previous: this.machineState,
+				};
+				break;
+
+			case "commandFailed":
+				if (this.machineState.type === "commandPending") {
+					this.machineState = this.machineState.previous;
+				}
+				break;
+
+			case "commandResult":
+				this.onCommandResult(input.result, nowMs, effects);
+				break;
+
+			case "supervisionUpdate":
+				this.onSupervisionUpdate(
+					input.status,
+					input.remainingDuration,
+					nowMs,
+					effects,
+				);
+				break;
+
+			case "report":
+				this.onReport(input, nowMs, effects, "report");
+				break;
+
+			case "syntheticUpdate":
+				// Optimistic writes caused by raw setValue calls indicate a
+				// commanded transition the tracker did not initiate itself
+				this.onSyntheticUpdate(input, nowMs);
+				break;
+
+			case "unsolicitedLevelChange":
+				this.onUnsolicitedLevelChange(input.direction, nowMs);
+				break;
+
+			case "deadlineElapsed":
+			case "quietPeriodElapsed":
+				if (
+					this.isMoving() || this.machineState.type === "stopPending"
+				) {
+					this.enterVerifying(nowMs, effects);
+				}
+				break;
+
+			case "verificationTimedOut":
+				this.onVerificationTimedOut(nowMs, effects);
+				break;
+		}
+
+		return { timers: this.desiredTimers(), effects };
+	}
+
+	private desiredTimers(): TransitionMachineTimers {
+		switch (this.machineState.type) {
+			case "movingSupervised":
+				return { deadline: this.machineState.deadlineAt };
+			case "movingUnsupervised":
+			case "movingByDevice":
+				return {
+					deadline: this.machineState.deadlineAt,
+					quiet: this.machineState.quietAt,
+				};
+			case "stopPending":
+				return { deadline: this.machineState.deadlineAt };
+			case "verifying":
+				return { verification: this.machineState.verificationAt };
+			default:
+				return {};
+		}
+	}
+
+	private onCommandResult(
+		result: SupervisionResult | undefined,
+		nowMs: number,
+		effects: TransitionMachineEffect[],
+	): void {
+		if (this.machineState.type !== "commandPending") return;
+		const { command } = this.machineState;
+
+		// Resolve the commanded target and direction
+		let target: number | undefined;
+		let direction: Direction | undefined;
+		let commandDuration: Duration | undefined;
+		if (command.type === "set") {
+			target = command.targetLevel;
+			direction = this.inferDirection(undefined, target, undefined);
+			commandDuration = command.duration;
+		} else if (command.type === "startLevelChange") {
+			direction = command.direction;
+			target = this.extremeFor(direction);
+			commandDuration = command.duration;
+		}
+
+		if (command.type === "stop") {
+			if (result?.status === SupervisionStatus.Success) {
+				// The device stopped somewhere along the way; find out where
+				this.source = "supervision";
+				this.enterVerifying(nowMs, effects);
+			} else if (result?.status === SupervisionStatus.Fail) {
+				this.enterVerifying(nowMs, effects);
+			} else {
+				this.machineState = {
+					type: "stopPending",
+					// Give the device a moment to report its resting position on its own
+					deadlineAt: nowMs + 2000,
+				};
+				this.source = "command";
+			}
+			return;
+		}
+
+		switch (result?.status) {
+			case SupervisionStatus.Working: {
+				this.estimatedDuration = result.remainingDuration;
+				this.targetLevel = target;
+				this.machineState = {
+					type: "movingSupervised",
+					direction,
+					target,
+					deadlineAt: this.deadlineFor(
+						nowMs,
+						result.remainingDuration.toMilliseconds(),
+					),
+				};
+				this.source = "command";
+				if (
+					this.config.synthesizeValueUpdates
+					&& command.type === "set"
+					&& target != undefined
+				) {
+					effects.push({
+						type: "setValueOptimistic",
+						which: "target",
+						level: target,
+					});
+				}
+				break;
+			}
+
+			case SupervisionStatus.Success: {
+				if (command.type === "set") {
+					// The transition completed instantly
+					this.currentLevel = target;
+					this.targetLevel = undefined;
+					this.machineState = { type: "idle" };
+					this.source = "supervision";
+					if (
+						this.config.synthesizeValueUpdates
+						&& target != undefined
+					) {
+						effects.push({
+							type: "setValueOptimistic",
+							which: "current",
+							level: target,
+						});
+					}
+				} else {
+					// Supervised Start Level Change commands are typically confirmed
+					// with Success while the movement is still ongoing, so treat this
+					// like an unsupervised open-ended transition
+					this.startUnsupervisedMoving(
+						direction,
+						target,
+						commandDuration,
+						nowMs,
+						effects,
+						command.type,
+					);
+				}
+				break;
+			}
+
+			case SupervisionStatus.Fail: {
+				this.enterVerifying(nowMs, effects);
+				break;
+			}
+
+			// NoSupport and unsupervised sends both mean the command was accepted
+			// without any completion feedback
+			case SupervisionStatus.NoSupport:
+			default: {
+				this.startUnsupervisedMoving(
+					direction,
+					target,
+					commandDuration,
+					nowMs,
+					effects,
+					command.type,
+				);
+				break;
+			}
+		}
+	}
+
+	private startUnsupervisedMoving(
+		direction: Direction | undefined,
+		target: number | undefined,
+		duration: Duration | undefined,
+		nowMs: number,
+		effects: TransitionMachineEffect[],
+		commandType: "set" | "startLevelChange",
+	): void {
+		const durationMs = duration?.toMilliseconds();
+		this.estimatedDuration = duration;
+		this.targetLevel = target;
+		this.machineState = {
+			type: "movingUnsupervised",
+			direction,
+			target,
+			deadlineAt: this.deadlineFor(nowMs, durationMs),
+			// With a known duration the deadline is authoritative; otherwise rely
+			// on a rolling quiet period to detect the end of the transition
+			quietAt: durationMs == undefined
+				? nowMs + this.config.idleDetectionTimeoutMs
+				: undefined,
+		};
+		this.source = "command";
+		if (
+			this.config.synthesizeValueUpdates
+			&& commandType === "set"
+			&& target != undefined
+		) {
+			effects.push({
+				type: "setValueOptimistic",
+				which: "target",
+				level: target,
+			});
+		}
+	}
+
+	private onSupervisionUpdate(
+		status: SupervisionStatus,
+		remainingDuration: Duration | undefined,
+		nowMs: number,
+		effects: TransitionMachineEffect[],
+	): void {
+		// A session update while the command promise is still pending means the
+		// transition has started
+		if (this.machineState.type === "commandPending") {
+			this.onCommandResult(
+				status === SupervisionStatus.Working
+					? {
+						status,
+						remainingDuration: remainingDuration
+							?? Duration.unknown(),
+					}
+					: { status: status as any },
+				nowMs,
+				effects,
+			);
+			return;
+		}
+
+		if (this.machineState.type !== "movingSupervised") return;
+
+		switch (status) {
+			case SupervisionStatus.Working:
+				this.estimatedDuration = remainingDuration;
+				this.machineState = {
+					...this.machineState,
+					deadlineAt: this.deadlineFor(
+						nowMs,
+						remainingDuration?.toMilliseconds(),
+					),
+				};
+				this.source = "supervision";
+				break;
+
+			case SupervisionStatus.Success:
+				if (this.machineState.target != undefined) {
+					this.currentLevel = this.machineState.target;
+					this.targetLevel = undefined;
+					this.machineState = { type: "idle" };
+					this.source = "supervision";
+					if (this.config.synthesizeValueUpdates) {
+						effects.push({
+							type: "setValueOptimistic",
+							which: "current",
+							level: this.currentLevel,
+						});
+					}
+				} else {
+					// The transition finished, but at an unknown level
+					this.enterVerifying(nowMs, effects);
+				}
+				break;
+
+			case SupervisionStatus.Fail:
+				// The transition was interrupted, e.g. by manual control
+				this.enterVerifying(nowMs, effects);
+				break;
+		}
+	}
+
+	private onReport(
+		report: {
+			currentLevel?: number | null;
+			targetLevel?: number | null;
+			duration?: Duration;
+		},
+		nowMs: number,
+		effects: TransitionMachineEffect[],
+		source: TransitionStateSource,
+	): void {
+		const previousLevel = this.currentLevel;
+		if (report.currentLevel !== undefined) {
+			this.currentLevel = report.currentLevel ?? undefined;
+		}
+		const reportedTarget = report.targetLevel === undefined
+			? undefined
+			: report.targetLevel ?? undefined;
+		const durationMs = report.duration?.toMilliseconds();
+
+		switch (this.machineState.type) {
+			case "idle": {
+				const movementReported =
+					// An explicit target differing from the current level
+					(reportedTarget != undefined
+						&& this.currentLevel != undefined
+						&& reportedTarget !== this.currentLevel)
+					// or a nonzero remaining duration
+					|| (durationMs != undefined && durationMs > 0)
+					// or a changed current level without any target information
+					|| (reportedTarget == undefined
+						&& report.currentLevel !== undefined
+						&& this.currentLevel !== previousLevel);
+				if (movementReported) {
+					const target = reportedTarget;
+					this.targetLevel = target;
+					this.estimatedDuration = report.duration;
+					this.machineState = {
+						type: "movingByDevice",
+						direction: this.inferDirection(
+							undefined,
+							target,
+							previousLevel,
+						),
+						target,
+						deadlineAt: this.deadlineFor(nowMs, durationMs),
+						quietAt: durationMs == undefined
+							? nowMs + this.config.idleDetectionTimeoutMs
+							: undefined,
+					};
+				}
+				this.source = source;
+				break;
+			}
+
+			case "movingSupervised": {
+				// The supervision session remains authoritative for the end of the
+				// transition, but level and target updates are taken at face value
+				if (reportedTarget != undefined) {
+					this.targetLevel = reportedTarget;
+					this.machineState = {
+						...this.machineState,
+						target: reportedTarget,
+						direction: this.inferDirection(
+							undefined,
+							reportedTarget,
+							previousLevel,
+						) ?? this.machineState.direction,
+					};
+				}
+				this.source = source;
+				break;
+			}
+
+			case "movingUnsupervised":
+			case "movingByDevice": {
+				if (reportedTarget != undefined) {
+					this.targetLevel = reportedTarget;
+					this.machineState = {
+						...this.machineState,
+						target: reportedTarget,
+						direction: this.inferDirection(
+							undefined,
+							reportedTarget,
+							previousLevel,
+						) ?? this.machineState.direction,
+					};
+				}
+				const target = this.machineState.target;
+				if (this.machineState.direction == undefined) {
+					const inferred = this.inferDirection(
+						undefined,
+						target,
+						previousLevel,
+					);
+					if (inferred) {
+						this.machineState = {
+							...this.machineState,
+							direction: inferred,
+						};
+					}
+				}
+				const transitionEnded =
+					// The current level reached the target
+					(target != undefined
+						&& this.currentLevel != undefined
+						&& this.currentLevel === target)
+					// or the device advertised the transition as finished
+					|| (durationMs != undefined
+						&& durationMs === 0
+						&& report.duration?.unit !== "unknown");
+				if (transitionEnded) {
+					this.targetLevel = undefined;
+					this.estimatedDuration = undefined;
+					this.machineState = { type: "idle" };
+				} else {
+					if (report.duration != undefined) {
+						this.estimatedDuration = report.duration;
+					}
+					// Progress information restarts the quiet period
+					this.machineState = {
+						...this.machineState,
+						deadlineAt: durationMs != undefined
+							? this.deadlineFor(nowMs, durationMs)
+							: this.machineState.deadlineAt,
+						quietAt: this.machineState.quietAt != undefined
+							? nowMs + this.config.idleDetectionTimeoutMs
+							: undefined,
+					};
+				}
+				this.source = source;
+				break;
+			}
+
+			case "stopPending": {
+				// Any level report after a stop is the resting position
+				this.targetLevel = undefined;
+				this.estimatedDuration = undefined;
+				this.machineState = { type: "idle" };
+				this.source = source;
+				break;
+			}
+
+			case "verifying": {
+				const movementReported = (reportedTarget != undefined
+					&& this.currentLevel != undefined
+					&& reportedTarget !== this.currentLevel)
+					|| (durationMs != undefined && durationMs > 0);
+				if (movementReported) {
+					this.targetLevel = reportedTarget;
+					this.estimatedDuration = report.duration;
+					this.machineState = {
+						type: "movingByDevice",
+						direction: this.inferDirection(
+							undefined,
+							reportedTarget,
+							previousLevel,
+						),
+						target: reportedTarget,
+						deadlineAt: this.deadlineFor(nowMs, durationMs),
+						quietAt: durationMs == undefined
+							? nowMs + this.config.idleDetectionTimeoutMs
+							: undefined,
+					};
+				} else {
+					this.targetLevel = undefined;
+					this.estimatedDuration = undefined;
+					this.machineState = { type: "idle" };
+				}
+				this.source = source;
+				break;
+			}
+
+			case "commandPending":
+				// Early echo of the previous state; level info was already absorbed
+				this.source = source;
+				break;
+		}
+	}
+
+	private onSyntheticUpdate(
+		update: { currentLevel?: number | null; targetLevel?: number | null },
+		nowMs: number,
+	): void {
+		// A driver-sourced optimistic target write means a command was issued
+		// outside the tracker, e.g. through raw setValue
+		if (this.machineState.type === "commandPending") return;
+		if (this.isMoving()) return;
+
+		const target = update.targetLevel === undefined
+			? undefined
+			: update.targetLevel ?? undefined;
+		if (target == undefined) {
+			if (update.currentLevel !== undefined) {
+				this.currentLevel = update.currentLevel ?? undefined;
+			}
+			return;
+		}
+		if (this.currentLevel != undefined && target === this.currentLevel) {
+			return;
+		}
+
+		this.targetLevel = target;
+		this.estimatedDuration = undefined;
+		this.machineState = {
+			type: "movingUnsupervised",
+			direction: this.inferDirection(undefined, target, undefined),
+			target,
+			deadlineAt: this.deadlineFor(nowMs, undefined),
+			quietAt: nowMs + this.config.idleDetectionTimeoutMs,
+		};
+		this.source = "command";
+	}
+
+	private onUnsolicitedLevelChange(
+		direction: "up" | "down" | "stop",
+		nowMs: number,
+	): void {
+		if (direction === "stop") {
+			if (this.isMoving()) {
+				this.machineState = {
+					type: "stopPending",
+					deadlineAt: nowMs + 2000,
+				};
+				this.source = "report";
+			}
+			return;
+		}
+
+		this.targetLevel = undefined;
+		this.estimatedDuration = undefined;
+		this.machineState = {
+			type: "movingByDevice",
+			direction,
+			target: undefined,
+			deadlineAt: this.deadlineFor(nowMs, undefined),
+			quietAt: nowMs + this.config.idleDetectionTimeoutMs,
+		};
+		this.source = "report";
+	}
+
+	private enterVerifying(
+		nowMs: number,
+		effects: TransitionMachineEffect[],
+	): void {
+		if (!this.config.canVerify) {
+			this.degrade();
+			return;
+		}
+		const attempt = this.machineState.type === "verifying"
+			? this.machineState.attempt + 1
+			: 1;
+		this.machineState = {
+			type: "verifying",
+			attempt,
+			verificationAt: nowMs + this.config.verificationTimeoutMs,
+		};
+		effects.push({ type: "requestVerification" });
+	}
+
+	private onVerificationTimedOut(
+		nowMs: number,
+		effects: TransitionMachineEffect[],
+	): void {
+		if (this.machineState.type !== "verifying") return;
+		if (this.machineState.attempt < this.config.maxVerificationAttempts) {
+			this.enterVerifying(nowMs, effects);
+		} else {
+			this.degrade();
+		}
+	}
+
+	/** Gives up on the current transition: not moving, level unknown */
+	private degrade(): void {
+		this.currentLevel = undefined;
+		this.targetLevel = undefined;
+		this.estimatedDuration = undefined;
+		this.machineState = { type: "idle" };
+		this.source = "timeout";
+	}
+}

--- a/packages/zwave-js/src/lib/test/node/covers.BasicWindowCovering.test.ts
+++ b/packages/zwave-js/src/lib/test/node/covers.BasicWindowCovering.test.ts
@@ -1,0 +1,76 @@
+import {
+	BasicWindowCoveringCCStartLevelChange,
+	BasicWindowCoveringCCStopLevelChange,
+} from "@zwave-js/cc/BasicWindowCoveringCC";
+import { CommandClasses } from "@zwave-js/core";
+import { MockZWaveFrameType, ccCaps } from "@zwave-js/testing";
+import { CoverAspect } from "../../../Node.js";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest("Basic Window Covering: movement-only control", {
+	nodeCapabilities: {
+		// Simple Window Covering Control
+		genericDeviceClass: 0x09,
+		specificDeviceClass: 0x01,
+		commandClasses: [
+			CommandClasses.Version,
+			ccCaps({
+				ccId: CommandClasses["Basic Window Covering"],
+				version: 1,
+			}),
+		],
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const covers = node.covers;
+		t.expect(covers).toBeDefined();
+
+		const caps = covers!.getCapabilitiesCached();
+		t.expect(caps.primaryAspect).toBe(CoverAspect.Primary);
+		t.expect(caps.aspects[0]).toMatchObject({
+			aspect: CoverAspect.Primary,
+			type: "position",
+			supportsGoToValue: false,
+			reportsValue: false,
+			reportsTarget: false,
+			supportsStartStop: true,
+			supportsDuration: false,
+		});
+
+		mockNode.clearReceivedControllerFrames();
+
+		await covers!.open();
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload
+					instanceof BasicWindowCoveringCCStartLevelChange
+				&& frame.payload.direction === "up",
+			{
+				errorMessage:
+					"Expected a Basic Window Covering StartLevelChange up",
+			},
+		);
+
+		await covers!.stop();
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload
+					instanceof BasicWindowCoveringCCStopLevelChange,
+			{
+				errorMessage:
+					"Expected a Basic Window Covering StopLevelChange",
+			},
+		);
+
+		await t.expect(covers!.setPosition(50)).rejects.toThrow(
+			"cannot be moved",
+		);
+
+		// Without any feedback, the position remains unknown, but movement
+		// state is still tracked
+		const state = covers!.getStateCached()!;
+		t.expect(state.currentValue).toBeUndefined();
+	},
+});

--- a/packages/zwave-js/src/lib/test/node/covers.Fibaro.test.ts
+++ b/packages/zwave-js/src/lib/test/node/covers.Fibaro.test.ts
@@ -1,0 +1,88 @@
+import { MultilevelSwitchCCSet } from "@zwave-js/cc/MultilevelSwitchCC";
+import { FibaroVenetianBlindCCSet } from "@zwave-js/cc/manufacturerProprietary/FibaroCC";
+import { CommandClasses } from "@zwave-js/core";
+import { MockZWaveFrameType, ccCaps } from "@zwave-js/testing";
+import path from "node:path";
+import { CoverAspect } from "../../../Node.js";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest("Fibaro Venetian Blind: position via MLS, tilt via Fibaro CC", {
+	nodeCapabilities: {
+		manufacturerId: 0x010f,
+		productType: 0xbeef,
+		productId: 0xcafe,
+
+		// Motor Control Class B
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x06,
+		commandClasses: [
+			CommandClasses.Version,
+			CommandClasses["Manufacturer Specific"],
+			ccCaps({
+				ccId: CommandClasses["Multilevel Switch"],
+				version: 3,
+				defaultValue: 0,
+			}),
+			CommandClasses["Manufacturer Proprietary"],
+		],
+	},
+
+	additionalDriverOptions: {
+		storage: {
+			deviceConfigPriorityDir: path.join(
+				__dirname,
+				"fixtures/fibaroVenetianBlind",
+			),
+		},
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const covers = node.covers;
+		t.expect(covers).toBeDefined();
+
+		const caps = covers!.getCapabilitiesCached();
+		t.expect(caps.primaryAspect).toBe(CoverAspect.Primary);
+		t.expect(caps.primaryTiltAspect).toBe(CoverAspect.Tilt);
+
+		const tiltCaps = caps.aspects.find((a) => a.type === "tilt")!;
+		t.expect(tiltCaps).toMatchObject({
+			supportsGoToValue: true,
+			reportsValue: true,
+			reportsTarget: false,
+			supportsStartStop: false,
+		});
+
+		mockNode.clearReceivedControllerFrames();
+
+		// Position control uses the Multilevel Switch CC, which Fibaro maps
+		// to the blind position
+		await covers!.setPosition(80);
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload instanceof MultilevelSwitchCCSet
+				&& frame.payload.targetValue === 80,
+			{ errorMessage: "Expected a Multilevel Switch CC Set to 80" },
+		);
+
+		// Fully open tilt (unified 50) maps to the Fibaro scale maximum
+		await covers!.setTilt(50);
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload instanceof FibaroVenetianBlindCCSet
+				&& frame.payload.tilt === 99,
+			{ errorMessage: "Expected a Fibaro Venetian Blind Set tilt 99" },
+		);
+
+		// Closed tilt maps to the Fibaro scale minimum
+		await covers!.setTilt(0);
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload instanceof FibaroVenetianBlindCCSet
+				&& frame.payload.tilt === 0,
+			{ errorMessage: "Expected a Fibaro Venetian Blind Set tilt 0" },
+		);
+	},
+});

--- a/packages/zwave-js/src/lib/test/node/covers.MultilevelSwitch.test.ts
+++ b/packages/zwave-js/src/lib/test/node/covers.MultilevelSwitch.test.ts
@@ -1,0 +1,171 @@
+import { SwitchType } from "@zwave-js/cc";
+import {
+	MultilevelSwitchCCReport,
+	MultilevelSwitchCCSet,
+	MultilevelSwitchCCStartLevelChange,
+	MultilevelSwitchCCStopLevelChange,
+} from "@zwave-js/cc/MultilevelSwitchCC";
+import { CommandClasses, Duration } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	ccCaps,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import type { CoverAspectState } from "../../../Node.js";
+import { CoverAspect } from "../../../Node.js";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest("Multilevel Switch: covers API is gated by device class", {
+	nodeCapabilities: {
+		// Multilevel Power Switch, i.e. a dimmer
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x01,
+		commandClasses: [
+			CommandClasses.Version,
+			ccCaps({
+				ccId: CommandClasses["Multilevel Switch"],
+				version: 4,
+				defaultValue: 0,
+			}),
+		],
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		t.expect(node.covers).toBeUndefined();
+	},
+});
+
+integrationTest("Multilevel Switch: V4 capabilities and control", {
+	nodeCapabilities: {
+		// Motor Control Class C
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x07,
+		commandClasses: [
+			CommandClasses.Version,
+			ccCaps({
+				ccId: CommandClasses["Multilevel Switch"],
+				version: 4,
+				defaultValue: 0,
+				primarySwitchType: SwitchType["Close/Open"],
+			}),
+		],
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const covers = node.covers;
+		t.expect(covers).toBeDefined();
+
+		const caps = covers!.getCapabilitiesCached();
+		t.expect(caps.primaryAspect).toBe(CoverAspect.Primary);
+		t.expect(caps.aspects[0]).toMatchObject({
+			aspect: CoverAspect.Primary,
+			type: "position",
+			supportsGoToValue: true,
+			reportsValue: true,
+			reportsTarget: true,
+			supportsStartStop: true,
+			supportsDuration: true,
+		});
+
+		mockNode.clearReceivedControllerFrames();
+
+		await covers!.open();
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload instanceof MultilevelSwitchCCSet
+				&& frame.payload.targetValue === 99,
+			{ errorMessage: "Expected a Multilevel Switch CC Set to 99" },
+		);
+
+		await covers!.startTransition("close");
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload
+					instanceof MultilevelSwitchCCStartLevelChange
+				&& frame.payload.direction === "down",
+			{
+				errorMessage:
+					"Expected a Multilevel Switch CC StartLevelChange down",
+			},
+		);
+
+		await covers!.stop();
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload
+					instanceof MultilevelSwitchCCStopLevelChange,
+			{
+				errorMessage: "Expected a Multilevel Switch CC StopLevelChange",
+			},
+		);
+	},
+});
+
+integrationTest("Multilevel Switch: V3 does not report the target value", {
+	nodeCapabilities: {
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x07,
+		commandClasses: [
+			CommandClasses.Version,
+			ccCaps({
+				ccId: CommandClasses["Multilevel Switch"],
+				version: 3,
+				defaultValue: 0,
+			}),
+		],
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const caps = node.covers!.getCapabilitiesCached();
+		t.expect(caps.aspects[0]).toMatchObject({
+			reportsTarget: false,
+			supportsDuration: true,
+		});
+	},
+});
+
+integrationTest("Multilevel Switch: reports emit cover state events", {
+	nodeCapabilities: {
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x07,
+		commandClasses: [
+			CommandClasses.Version,
+			ccCaps({
+				ccId: CommandClasses["Multilevel Switch"],
+				version: 4,
+				defaultValue: 0,
+			}),
+		],
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const states: CoverAspectState[] = [];
+		node.on("cover state changed", (_endpoint, state) => {
+			states.push(state);
+		});
+		mockNode.clearReceivedControllerFrames();
+
+		// The device starts moving on its own and reports it
+		const cc = new MultilevelSwitchCCReport({
+			nodeId: mockController.ownNodeId,
+			currentValue: 20,
+			targetValue: 0,
+			duration: new Duration(5, "seconds"),
+		});
+		await mockNode.sendToController(
+			createMockZWaveRequestFrame(cc, { ackRequested: false }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		t.expect(states).toHaveLength(1);
+		t.expect(states[0]).toMatchObject({
+			aspect: CoverAspect.Primary,
+			currentValue: 20,
+			targetValue: 0,
+			movement: "closing",
+		});
+	},
+});

--- a/packages/zwave-js/src/lib/test/node/covers.WindowCovering.test.ts
+++ b/packages/zwave-js/src/lib/test/node/covers.WindowCovering.test.ts
@@ -1,0 +1,296 @@
+import { WindowCoveringParameter } from "@zwave-js/cc";
+import {
+	WindowCoveringCCReport,
+	WindowCoveringCCSet,
+	WindowCoveringCCStartLevelChange,
+	WindowCoveringCCStopLevelChange,
+} from "@zwave-js/cc/WindowCoveringCC";
+import { CommandClasses, Duration } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	ccCaps,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import type { CoverAspectState } from "../../../Node.js";
+import { CoverAspect } from "../../../Node.js";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest("Window Covering: positioned parameters", {
+	nodeCapabilities: {
+		// Motor Control Class C
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x07,
+		commandClasses: [
+			CommandClasses.Version,
+			// Every Window Covering device must also support the Multilevel
+			// Switch CC, which the covers API must never control
+			ccCaps({
+				ccId: CommandClasses["Multilevel Switch"],
+				version: 4,
+				defaultValue: 0,
+			}),
+			ccCaps({
+				ccId: CommandClasses["Window Covering"],
+				version: 1,
+				supportedParameters: [
+					WindowCoveringParameter["Outbound Left"],
+				],
+			}),
+		],
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const covers = node.covers;
+		t.expect(covers).toBeDefined();
+
+		const caps = covers!.getCapabilitiesCached();
+		t.expect(caps.primaryAspect).toBe(CoverAspect.OutboundLeft);
+		t.expect(caps.primaryTiltAspect).toBeUndefined();
+		t.expect(caps.aspects).toHaveLength(1);
+		t.expect(caps.aspects[0]).toMatchObject({
+			aspect: CoverAspect.OutboundLeft,
+			type: "position",
+			supportsGoToValue: true,
+			reportsValue: true,
+			reportsTarget: true,
+			supportsStartStop: true,
+			supportsDuration: true,
+		});
+
+		mockNode.clearReceivedControllerFrames();
+
+		// open() moves the positioned parameter to 99
+		await covers!.open();
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload instanceof WindowCoveringCCSet
+				&& frame.payload.targetValues.length === 1
+				&& frame.payload.targetValues[0].parameter
+					=== WindowCoveringParameter["Outbound Left"]
+				&& frame.payload.targetValues[0].value === 99,
+			{ errorMessage: "Expected a Window Covering CC Set to 99" },
+		);
+
+		await covers!.setPosition(37, { duration: "10s" });
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload instanceof WindowCoveringCCSet
+				&& frame.payload.targetValues[0].value === 37
+				&& frame.payload.duration?.toMilliseconds() === 10_000,
+			{ errorMessage: "Expected a Window Covering CC Set to 37" },
+		);
+
+		await covers!.stop();
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload instanceof WindowCoveringCCStopLevelChange
+				&& frame.payload.parameter
+					=== WindowCoveringParameter["Outbound Left"],
+			{
+				errorMessage: "Expected a Window Covering CC StopLevelChange",
+			},
+		);
+
+		// CL:006A.01.51.01.2: "A controlling node MUST NOT interview and
+		// provide controlling functionalities for the Multilevel Switch
+		// Command Class for a node (or endpoint) supporting this Command
+		// Class, as it is a fully redundant and less precise application
+		// functionality."
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload.ccId
+					=== CommandClasses["Multilevel Switch"],
+			{
+				noMatch: true,
+				errorMessage:
+					"The covers API must never control the Multilevel Switch CC when Window Covering is supported",
+			},
+		);
+	},
+});
+
+integrationTest("Window Covering: no-position parameters", {
+	nodeCapabilities: {
+		genericDeviceClass: 0x11,
+		// Motor Control Class A
+		specificDeviceClass: 0x05,
+		commandClasses: [
+			CommandClasses.Version,
+			ccCaps({
+				ccId: CommandClasses["Window Covering"],
+				version: 1,
+				supportedParameters: [
+					WindowCoveringParameter["Outbound Left (no position)"],
+				],
+			}),
+		],
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const covers = node.covers!;
+		const caps = covers.getCapabilitiesCached();
+		t.expect(caps.aspects[0]).toMatchObject({
+			aspect: CoverAspect.OutboundLeft,
+			supportsGoToValue: false,
+			reportsValue: false,
+			reportsTarget: false,
+			supportsStartStop: true,
+		});
+
+		mockNode.clearReceivedControllerFrames();
+
+		// Without position support, open() falls back to a level change
+		await covers.open();
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload
+					instanceof WindowCoveringCCStartLevelChange
+				&& frame.payload.direction === "up",
+			{
+				errorMessage:
+					"Expected a Window Covering CC StartLevelChange up",
+			},
+		);
+
+		await t.expect(covers.setPosition(50)).rejects.toThrow(
+			"cannot be moved",
+		);
+	},
+});
+
+integrationTest("Window Covering: multiple aspects incl. slats", {
+	nodeCapabilities: {
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x07,
+		commandClasses: [
+			CommandClasses.Version,
+			ccCaps({
+				ccId: CommandClasses["Window Covering"],
+				version: 1,
+				supportedParameters: [
+					WindowCoveringParameter["Outbound Bottom"],
+					WindowCoveringParameter["Horizontal Slats Angle"],
+				],
+			}),
+		],
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const covers = node.covers!;
+		const caps = covers.getCapabilitiesCached();
+		t.expect(caps.aspects).toHaveLength(2);
+		t.expect(caps.primaryAspect).toBe(CoverAspect.OutboundBottom);
+		t.expect(caps.primaryTiltAspect).toBe(CoverAspect.HorizontalSlats);
+		const tiltCaps = caps.aspects.find((a) => a.type === "tilt")!;
+		t.expect(tiltCaps.aspect).toBe(CoverAspect.HorizontalSlats);
+
+		mockNode.clearReceivedControllerFrames();
+
+		// Opening the tilt aspect moves the slats to the midpoint
+		await covers.open({ aspect: CoverAspect.Tilt });
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload instanceof WindowCoveringCCSet
+				&& frame.payload.targetValues[0].parameter
+					=== WindowCoveringParameter["Horizontal Slats Angle"]
+				&& frame.payload.targetValues[0].value === 50,
+			{ errorMessage: "Expected the slats to be moved to 50" },
+		);
+
+		// Both aspects are combined into a single Set command
+		mockNode.clearReceivedControllerFrames();
+		await covers.setValues([
+			{ aspect: CoverAspect.Primary, value: 25 },
+			{ aspect: CoverAspect.Tilt, value: 75 },
+		]);
+		mockNode.assertReceivedControllerFrame(
+			(frame) =>
+				frame.type === MockZWaveFrameType.Request
+				&& frame.payload instanceof WindowCoveringCCSet
+				&& frame.payload.targetValues.length === 2,
+			{
+				errorMessage:
+					"Expected one Set command containing both parameters",
+			},
+		);
+	},
+});
+
+integrationTest("Window Covering: reports emit atomic cover state events", {
+	nodeCapabilities: {
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x07,
+		commandClasses: [
+			CommandClasses.Version,
+			ccCaps({
+				ccId: CommandClasses["Window Covering"],
+				version: 1,
+				supportedParameters: [
+					WindowCoveringParameter["Outbound Bottom"],
+				],
+			}),
+		],
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const states: CoverAspectState[] = [];
+		node.on("cover state changed", (_endpoint, state) => {
+			states.push(state);
+		});
+
+		// The device starts moving on its own and reports it
+		const cc = new WindowCoveringCCReport({
+			nodeId: mockController.ownNodeId,
+			parameter: WindowCoveringParameter["Outbound Bottom"],
+			currentValue: 10,
+			targetValue: 99,
+			duration: new Duration(10, "seconds"),
+		});
+		await mockNode.sendToController(
+			createMockZWaveRequestFrame(cc, { ackRequested: false }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		// One report with three values produces exactly one event
+		t.expect(states).toHaveLength(1);
+		t.expect(states[0]).toMatchObject({
+			aspect: CoverAspect.OutboundBottom,
+			type: "position",
+			currentValue: 10,
+			targetValue: 99,
+			movement: "opening",
+			currentValueReliability: "reported",
+		});
+
+		// The final report ends the transition
+		const endCC = new WindowCoveringCCReport({
+			nodeId: mockController.ownNodeId,
+			parameter: WindowCoveringParameter["Outbound Bottom"],
+			currentValue: 99,
+			targetValue: 99,
+			duration: new Duration(0, "seconds"),
+		});
+		await mockNode.sendToController(
+			createMockZWaveRequestFrame(endCC, { ackRequested: false }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		t.expect(states).toHaveLength(2);
+		t.expect(states[1]).toMatchObject({
+			currentValue: 99,
+			movement: "idle",
+		});
+
+		const cached = node.covers!.getStateCached();
+		t.expect(cached).toMatchObject({
+			currentValue: 99,
+			movement: "idle",
+		});
+	},
+});

--- a/packages/zwave-js/src/lib/test/node/covers.compat.test.ts
+++ b/packages/zwave-js/src/lib/test/node/covers.compat.test.ts
@@ -1,0 +1,38 @@
+import { CommandClasses } from "@zwave-js/core";
+import { ccCaps } from "@zwave-js/testing";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest("treatAsCover forces cover treatment for MLS endpoints", {
+	nodeCapabilities: {
+		manufacturerId: 0xdead,
+		productType: 0xbeef,
+		productId: 0xcafe,
+
+		// Multilevel Power Switch, i.e. a dimmer by device class
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x01,
+		commandClasses: [
+			CommandClasses.Version,
+			CommandClasses["Manufacturer Specific"],
+			ccCaps({
+				ccId: CommandClasses["Multilevel Switch"],
+				version: 4,
+				defaultValue: 0,
+			}),
+		],
+	},
+
+	additionalDriverOptions: {
+		storage: {
+			deviceConfigPriorityDir: path.join(
+				__dirname,
+				"fixtures/treatAsCover",
+			),
+		},
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		t.expect(node.covers).toBeDefined();
+	},
+});

--- a/packages/zwave-js/src/lib/test/node/fixtures/fibaroVenetianBlind/deviceConfig.json
+++ b/packages/zwave-js/src/lib/test/node/fixtures/fibaroVenetianBlind/deviceConfig.json
@@ -1,0 +1,19 @@
+{
+	"manufacturer": "Test Manufacturer",
+	"manufacturerId": "0x010f",
+	"label": "Test Venetian Blind",
+	"description": "Venetian Blind Controller",
+	"devices": [
+		{
+			"productType": "0xbeef",
+			"productId": "0xcafe"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"proprietary": {
+		"fibaroCCs": [38]
+	}
+}

--- a/packages/zwave-js/src/lib/test/node/fixtures/treatAsCover/deviceConfig.json
+++ b/packages/zwave-js/src/lib/test/node/fixtures/treatAsCover/deviceConfig.json
@@ -1,0 +1,19 @@
+{
+	"manufacturer": "Test Manufacturer",
+	"manufacturerId": "0xdead",
+	"label": "Test Shutter",
+	"description": "Shutter misreporting as a dimmer",
+	"devices": [
+		{
+			"productType": "0xbeef",
+			"productId": "0xcafe"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"compat": {
+		"treatAsCover": "*"
+	}
+}


### PR DESCRIPTION
Adds a high-level feature API for covers, following the Access Control API precedent (#8738). Applications no longer need to reverse-engineer movement state from raw CC values and version-specific reporting quirks (see the HA PR trail starting at home-assistant/core#163368).

### What's included

**Transition tracking infrastructure** (`lib/node/transitions/`)
- A pure, timer-free state machine plus a node-bound tracker that consolidate commands, supervision session updates, optimistic value updates and incoming reports into one consistent movement state per level dimension. Reusable for a future dimmer API.
- Handles the full scenario matrix: supervised (Working/Success/Fail incl. interruption at the device), unsupervised WCC / MLS v1–3 / v4 reporting patterns, device-initiated transitions, manual stop/reverse, split current/target value events (microtask coalescing → atomic updates), and StartLevelChange at the travel limit (quiet-timer → verification poll via `schedulePoll`, degrading to "idle, position unknown" instead of staying stuck "opening").

**`endpoint.covers` (`CoversAPI`)**
- Backends: Window Covering CC > Fibaro Venetian Blind CC > Multilevel Switch CC > Basic Window Covering CC per aspect. MLS is never controlled when WCC is supported (CL:006A.01.51.01.2).
- Gating: WCC/BWC/Fibaro always; MLS only when the device class indicates a cover (Motor Control A/B/C, Multiposition Motor, generic Window Covering) or the new `treatAsCover` compat flag forces it.
- Aspect model: WCC parameter pairs collapse into 12 concrete aspects plus `Primary`/`Tilt` aliases, so simple apps never touch parameter numbers while exotic devices keep every supported parameter addressable. Capabilities per aspect: `supportsGoToValue`, `reportsValue`, `reportsTarget` (false for MLS < v4), `supportsStartStop`, `supportsDuration`.
- Control: `open`/`close` (go-to-value with StartLevelChange fallback for non-positioned covers), `setPosition`/`setTilt`/`setValue`, `startTransition`/`stop`/`stopAll`, `setValues` (multi-aspect writes combine into a single WCC/Fibaro Set), `refreshState`.
- Conventions: raw 0–99, 0 = fully closed; tilt always 0 = closed / 50 = open / 99 = closed the other way (Fibaro's linear tilt is translated).
- State/events: `getStateCached()`/`getAllStatesCached()` and one atomic `"cover state changed"` node event per consolidated change — no more racy separate current/target updates. Feature APIs are instantiated on node ready so events fire without prior access.
- Fibaro: position is controlled via MLS (which FGR devices map to the position), tilt via the proprietary CC; `FibaroVenetianBlindCCSet` deserialization and a combined position+tilt API method were added along the way.

### Notes for review
- The transition tracker's timeout policy: slack = max(1 s, 10 % of duration); unknown durations bound by 60 s default + rolling 5 s quiet period; verification 2 × 10 s then degrade.
- Multi-endpoint MLS tilt (Shelly Wave Shutter style, `coverTiltEndpoints` mapping) is deliberately left for a follow-up.
- Raw `node.setValue` writes are tracked observed-only (degraded, no supervision progress) as discussed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)