### PR TITLE
perf(test): parallelize integration tests, avoid unnecessary timeouts

### DIFF
--- a/.claude/skills/integration-tests/SKILL.md
+++ b/.claude/skills/integration-tests/SKILL.md
@@ -89,6 +89,21 @@ integrationTest("Description of what is being tested", {
 | `testBody`                    | `(t, driver, node, controller, mockNode) => Promise<void>` | **required** | Test assertions                                |
 | `additionalDriverOptions`     | `PartialZWaveOptions`                                      | —            | Override driver config                         |
 
+### Concurrency
+
+Tests within a file run **concurrently** by default. Each test gets its own isolated in-memory mock port and cache directory, and concurrency simply overlaps the many waits for mock round-trips, so the whole suite finishes several times faster.
+
+Opt a single test out with `integrationTest.sequential(...)` (also `.sequential.only` / `.sequential.skip`). Reserve this for tests that assert on absolute timing, retry counts, or message ordering — CPU contention from neighboring tests perturbs those and makes them flaky. Everything else should stay on the concurrent default.
+
+```typescript
+// Runs alone, not overlapped with the other tests in this file
+integrationTest.sequential("retries SendData up to 3 times", {
+	// ...
+});
+```
+
+Both harnesses (`integrationTestSuite.ts` and `integrationTestSuiteMulti.ts`) share this behavior.
+
 ## Multi-Node Test Harness
 
 For tests requiring multiple mock nodes, use `integrationTestSuiteMulti.ts`:
@@ -493,6 +508,7 @@ Examples:
    - [ ] Define `nodeCapabilities` with `ccCaps()` for type safety
    - [ ] Add `customSetup` if mock node state needs pre-population
    - [ ] Set `clearMessageStatsBeforeTest: false` if verifying interview frames
+   - [ ] Use `integrationTest.sequential(...)` only if the test asserts on timing, retry counts, or ordering
 
 3. **Write assertions**
    - [ ] Use `node.getValue()` / `node.getValueMetadata()` for value checks

--- a/packages/serial/src/mock/MockPort.ts
+++ b/packages/serial/src/mock/MockPort.ts
@@ -63,15 +63,21 @@ export class MockPort {
 	}
 
 	public emitData(data: BytesView): void {
-		this.#sourceController?.enqueue(data);
+		try {
+			this.#sourceController?.enqueue(data);
+		} catch {
+			// The stream may already be closed while the driver is being torn down.
+			// Late frames from the mock during teardown can be dropped safely.
+		}
 	}
 
 	public destroy(): void {
 		try {
 			this.#sourceController?.close();
-			this.#sourceController = undefined;
 		} catch {
 			// Ignore - the controller might already be closed
+		} finally {
+			this.#sourceController = undefined;
 		}
 	}
 }

--- a/packages/serial/src/mock/MockPort.ts
+++ b/packages/serial/src/mock/MockPort.ts
@@ -66,8 +66,7 @@ export class MockPort {
 		try {
 			this.#sourceController?.enqueue(data);
 		} catch {
-			// The stream may already be closed while the driver is being torn down.
-			// Late frames from the mock during teardown can be dropped safely.
+			// Drop late frames during teardown
 		}
 	}
 

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -386,8 +386,6 @@ export class MockController {
 		timeout: number,
 		errorMessage?: string,
 	): Promise<void> {
-		// During teardown the host (driver) is gone and will never ACK, so don't
-		// wait for one - otherwise the expectation rejects with nobody to catch it.
 		if (this.destroyed) return;
 		const ack = new TimedExpectation(
 			timeout,
@@ -710,8 +708,6 @@ export class MockController {
 	public destroy(): void {
 		this.destroyed = true;
 		this.air.abort();
-		// Resolve any in-flight host-ACK expectations so their timeouts don't
-		// reject after the driver has been torn down.
 		for (const ack of this.expectedHostACKs) {
 			ack.resolve();
 		}

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -228,6 +228,7 @@ export class MockController {
 	public readonly mockPort: MockPort;
 	public readonly serial: ZWaveSerialStream;
 
+	private destroyed: boolean = false;
 	private expectedHostACKs: TimedExpectation[] = [];
 	private expectedHostMessages: TimedExpectation<Message, Message>[] = [];
 	private expectedNodeFrames: Map<
@@ -385,6 +386,9 @@ export class MockController {
 		timeout: number,
 		errorMessage?: string,
 	): Promise<void> {
+		// During teardown the host (driver) is gone and will never ACK, so don't
+		// wait for one - otherwise the expectation rejects with nobody to catch it.
+		if (this.destroyed) return;
 		const ack = new TimedExpectation(
 			timeout,
 			undefined,
@@ -704,7 +708,14 @@ export class MockController {
 	}
 
 	public destroy(): void {
+		this.destroyed = true;
 		this.air.abort();
+		// Resolve any in-flight host-ACK expectations so their timeouts don't
+		// reject after the driver has been torn down.
+		for (const ack of this.expectedHostACKs) {
+			ack.resolve();
+		}
+		this.expectedHostACKs = [];
 	}
 }
 

--- a/packages/testing/src/MockNode.ts
+++ b/packages/testing/src/MockNode.ts
@@ -157,7 +157,7 @@ export class MockNode {
 			}
 		}
 
-		// Answer the mandatory Basic CC support probe (spec CL:0020.01.21.02.2)
+		// Avoid ~1s interview timeout per test from the Basic CC support probe
 		if (!this.implementedCCs.has(CommandClasses.Basic)) {
 			this.addCC(CommandClasses.Basic, { isSupported: true });
 		}

--- a/packages/testing/src/MockNode.ts
+++ b/packages/testing/src/MockNode.ts
@@ -1,7 +1,7 @@
 import { type CCEncodingContext, type CommandClass } from "@zwave-js/cc";
 import {
 	type CommandClassInfo,
-	type CommandClasses,
+	CommandClasses,
 	type MaybeNotKnown,
 	NOT_KNOWN,
 	SecurityClass,
@@ -155,6 +155,13 @@ export class MockNode {
 				const { ccId, ...ccInfo } = cc;
 				this.addCC(ccId, ccInfo);
 			}
+		}
+
+		// Basic CC is mandatory and not advertised in the NIF; controllers determine its
+		// support by probing with a Basic Get. Default mock nodes to supporting it so the
+		// probe succeeds, unless a test explicitly configures Basic CC.
+		if (!this.implementedCCs.has(CommandClasses.Basic)) {
+			this.addCC(CommandClasses.Basic, { isSupported: true });
 		}
 
 		let index = 0;

--- a/packages/testing/src/MockNode.ts
+++ b/packages/testing/src/MockNode.ts
@@ -157,9 +157,7 @@ export class MockNode {
 			}
 		}
 
-		// Basic CC is mandatory and not advertised in the NIF; controllers determine its
-		// support by probing with a Basic Get. Default mock nodes to supporting it so the
-		// probe succeeds, unless a test explicitly configures Basic CC.
+		// Answer the mandatory Basic CC support probe (spec CL:0020.01.21.02.2)
 		if (!this.implementedCCs.has(CommandClasses.Basic)) {
 			this.addCC(CommandClasses.Basic, { isSupported: true });
 		}

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -116,13 +116,6 @@ const respondToVersionCCCommandClassGet: MockNodeBehavior = {
 				}
 			}
 
-			// Basic CC is always supported implicitly
-			if (
-				version === 0 && receivedCC.requestedCC === CommandClasses.Basic
-			) {
-				version = 1;
-			}
-
 			const cc = new VersionCCCommandClassReport({
 				nodeId: controller.ownNodeId,
 				endpointIndex: "index" in endpoint ? endpoint.index : undefined,

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
@@ -7,7 +7,7 @@ import { createMockZWaveRequestFrame } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import { integrationTest } from "../integrationTestSuite.js";
 
-integrationTest(
+integrationTest.sequential(
 	"Notifications with enum event parameters are evaluated correctly",
 	{
 		// debug: true,
@@ -83,7 +83,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"Notification types with multiple states and optional enums merge/extend states for all of them",
 	{
 		// debug: true,
@@ -186,7 +186,7 @@ integrationTest(
 	},
 );
 
-integrationTest("The 'simple' Door state value works correctly", {
+integrationTest.sequential("The 'simple' Door state value works correctly", {
 	// debug: true,
 
 	nodeCapabilities: {
@@ -308,7 +308,7 @@ integrationTest("The 'simple' Door state value works correctly", {
 	},
 });
 
-integrationTest(
+integrationTest.sequential(
 	"The synthetic 'Opening state' value works correctly",
 	{
 		// debug: true,
@@ -451,7 +451,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"The synthetic 'Door tilt state' value works correctly",
 	{
 		// debug: true,
@@ -618,7 +618,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"Notification types with 'replace'-type enums fall back to the default value if the event parameter is not contained in the CC",
 	{
 		// debug: true,

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationMultipleEventsMetadata.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationMultipleEventsMetadata.test.ts
@@ -2,7 +2,7 @@ import { NotificationCCValues } from "@zwave-js/cc/NotificationCC";
 import { CommandClasses, type ValueMetadataNumeric } from "@zwave-js/core";
 import { integrationTest } from "../integrationTestSuite.js";
 
-integrationTest(
+integrationTest.sequential(
 	"Notification types with multiple supported events preserve states for all of them",
 	{
 		// debug: true,

--- a/packages/zwave-js/src/lib/test/compat/notificationAlarmMapping.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationAlarmMapping.test.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 import sinon from "sinon";
 import { integrationTest } from "../integrationTestSuite.js";
 
-integrationTest(
+integrationTest.sequential(
 	"the alarmMapping compat flag works correctly (using the example Kwikset 910)",
 	{
 		// debug: true,
@@ -72,7 +72,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"the alarmMapping compat flag adds to supported notification types and events",
 	{
 		nodeCapabilities: {

--- a/packages/zwave-js/src/lib/test/compat/notificationRemapping.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationRemapping.test.ts
@@ -12,7 +12,7 @@ import { wait } from "alcalzone-shared/async";
 import path from "node:path";
 import { integrationTest } from "../integrationTestSuite.js";
 
-integrationTest(
+integrationTest.sequential(
 	"remapNotifications compat flag remaps supported events and metadata during interview",
 	{
 		// debug: true,

--- a/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
@@ -8,7 +8,7 @@ import { wait } from "alcalzone-shared/async";
 import path from "node:path";
 import { integrationTest } from "../integrationTestSuite.js";
 
-integrationTest(
+integrationTest.sequential(
 	"remapNotifications compat flag syncs doorStateSimple when remapping to/clearing door open/closed events",
 	{
 		// debug: true,

--- a/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
@@ -41,7 +41,7 @@ const controllerCapabilitiesNoBridge: MockControllerCapabilities = {
 	),
 };
 
-integrationTest(
+integrationTest.sequential(
 	"update the controller status and wait if TX status is Fail",
 	{
 		// debug: true,
@@ -161,7 +161,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"When sending fails continuously, soft-reset to recover",
 	{
 		// debug: true,

--- a/packages/zwave-js/src/lib/test/driver/controllerUnresponsive.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/controllerUnresponsive.test.ts
@@ -12,7 +12,7 @@ import { integrationTest } from "../integrationTestSuite.js";
 
 let shouldRespond = true;
 
-integrationTest(
+integrationTest.sequential(
 	"When the controller is unresponsive, retry the command as configured, then soft-reset it to recover",
 	{
 		// debug: true,
@@ -73,7 +73,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"When the controller is still unresponsive after soft reset, re-open the serial port",
 	{
 		// debug: true,
@@ -148,7 +148,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"When the serial port cannot be reopened during unresponsive controller recovery, the driver emits an error and destroys itself",
 	{
 		// debug: true,
@@ -236,7 +236,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"The unresponsive controller recovery does not kick in when it was enabled via config",
 	{
 		// debug: true,

--- a/packages/zwave-js/src/lib/test/driver/nodeDeadReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeDeadReject.test.ts
@@ -1,5 +1,10 @@
 import { BasicCCGet, BasicCCSet } from "@zwave-js/cc";
-import { NodeStatus, ZWaveErrorCodes, assertZWaveError } from "@zwave-js/core";
+import {
+	CommandClasses,
+	NodeStatus,
+	ZWaveErrorCodes,
+	assertZWaveError,
+} from "@zwave-js/core";
 import {
 	MockZWaveFrameType,
 	type MockZWaveRequestFrame,
@@ -205,6 +210,12 @@ integrationTest(
 			__dirname,
 			"fixtures/nodeDeadReject",
 		),
+		// A dead node must not answer the Basic Get, so the command fails via the missing callback
+		nodeCapabilities: {
+			commandClasses: [
+				{ ccId: CommandClasses.Basic, isSupported: false },
+			],
+		},
 
 		testBody: async (t, driver, node2, mockController, mockNode) => {
 			node2.markAsAlive();

--- a/packages/zwave-js/src/lib/test/driver/nodeDeadReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeDeadReject.test.ts
@@ -210,7 +210,7 @@ integrationTest(
 			__dirname,
 			"fixtures/nodeDeadReject",
 		),
-		// A dead node must not answer the Basic Get, so the command fails via the missing callback
+		// Opt out of the default Basic CC support so the node stays dead
 		nodeCapabilities: {
 			commandClasses: [
 				{ ccId: CommandClasses.Basic, isSupported: false },

--- a/packages/zwave-js/src/lib/test/driver/sendDataMissingCallbackAbort.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataMissingCallbackAbort.test.ts
@@ -46,7 +46,7 @@ const controllerCapabilitiesNoBridge: MockControllerCapabilities = {
 	),
 };
 
-integrationTest(
+integrationTest.sequential(
 	"Abort transmission and soft-reset stick if SendData is missing the callback",
 	{
 		// debug: true,
@@ -151,7 +151,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"Mark node as dead if SendData is still missing the callback after soft-reset",
 	{
 		// Real-world experience has shown that for older controllers this situation can be caused by dead nodes
@@ -251,7 +251,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"Missing callback recovery works if the command can be retried",
 	{
 		// debug: true,
@@ -358,7 +358,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"Missing callback recovery only kicks in for SendData commands",
 	{
 		// debug: true,
@@ -400,7 +400,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"With soft-reset disabled, transmissions do not get stuck after a missing Send Data callback",
 	{
 		// debug: true,
@@ -512,7 +512,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"After a missing Send Data callback, Send Data Abort is not executed twice",
 	{
 		// debug: true,
@@ -747,7 +747,7 @@ integrationTestMulti(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"Retry transmissions if the controller is reset by the watchdog while waiting for the callback",
 	{
 		// debug: true,

--- a/packages/zwave-js/src/lib/test/driver/sendDataMissingResponse.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataMissingResponse.test.ts
@@ -38,7 +38,7 @@ const controllerCapabilitiesNoBridge: MockControllerCapabilities = {
 	),
 };
 
-integrationTest(
+integrationTest.sequential(
 	"Abort transmission and wait for callback if SendData is missing the response",
 	{
 		// debug: true,
@@ -134,7 +134,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"Recover controller if callback times out after timed out SendData response",
 	{
 		// debug: true,
@@ -211,7 +211,7 @@ integrationTest(
 	},
 );
 
-// integrationTest(
+// integrationTest.sequential(
 // 	"Mark node as dead if SendData is still missing the callback after soft-reset",
 // 	{
 // 		// Real-world experience has shown that for older controllers this situation can be caused by dead nodes
@@ -308,7 +308,7 @@ integrationTest(
 // 	},
 // );
 
-// integrationTest(
+// integrationTest.sequential(
 // 	"Missing callback recovery works if the command can be retried",
 // 	{
 // 		// debug: true,
@@ -413,7 +413,7 @@ integrationTest(
 // 	},
 // );
 
-// integrationTest(
+// integrationTest.sequential(
 // 	"Missing callback recovery only kicks in for SendData commands",
 // 	{
 // 		// debug: true,

--- a/packages/zwave-js/src/lib/test/driver/sendDataRetryOnQueueFail.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataRetryOnQueueFail.test.ts
@@ -24,7 +24,7 @@ const controllerCapabilitiesNoBridge: MockControllerCapabilities = {
 	),
 };
 
-integrationTest(
+integrationTest.sequential(
 	"SendData commands are retried up to 3 times if the frame was not queued",
 	{
 		// debug: true,
@@ -91,7 +91,7 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.sequential(
 	"When queuing eventually succeeds, finish the transaction normally",
 	{
 		// debug: true,

--- a/packages/zwave-js/src/lib/test/driver/setValueSucceedAfterFailure.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueSucceedAfterFailure.test.ts
@@ -64,10 +64,6 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node2, mockController, mockNode) => {
-			driver.updateLogConfig({
-				level: "silly",
-			});
-
 			node2.markAsAlive();
 			// @ts-expect-error
 			node2._deviceConfig = {
@@ -119,8 +115,6 @@ integrationTest(
 
 			await basicSetPromise2;
 			t.expect(node2.status).toBe(NodeStatus.Alive);
-
-			await wait(10000);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -203,6 +203,9 @@ function suite(
 			await wait(100);
 
 			await driver.destroy();
+			// Stop the mock too, so late frames or pending host-ACK waits don't
+			// throw after the driver is gone.
+			mockController?.destroy();
 			tcpServer?.close(noop);
 			if (!debug) {
 				await fsp.rm(cacheDir, { recursive: true, force: true })

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -55,17 +55,27 @@ export interface IntegrationTestContext {
 export interface IntegrationTestFn {
 	(name: string, options: IntegrationTestOptions): void;
 }
-export interface IntegrationTest extends IntegrationTestFn {
+export interface IntegrationTestModifiers {
 	/** Only runs the tests inside this `integrationTest` suite for the current file */
 	only: IntegrationTestFn;
 	/** Skips running the tests inside this `integrationTest` suite for the current file */
 	skip: IntegrationTestFn;
+}
+export interface IntegrationTest
+	extends IntegrationTestFn, IntegrationTestModifiers
+{
+	/**
+	 * Runs this test sequentially instead of concurrently with the other tests in the file.
+	 * Use for tests that assert on timing or ordering, which CPU contention would perturb.
+	 */
+	sequential: IntegrationTestFn & IntegrationTestModifiers;
 }
 
 function suite(
 	name: string,
 	options: IntegrationTestOptions,
 	modifier?: "only" | "skip",
+	concurrency: "concurrent" | "sequential" = "concurrent",
 ) {
 	const {
 		controllerCapabilities,
@@ -176,12 +186,17 @@ function suite(
 		});
 	}
 
-	// Integration tests need to run in serial, or they might block the serial port on CI
+	// Tests within a file run concurrently by default, overlapping their many mock
+	// round-trip waits for a large speedup. Each test has an isolated in-memory mock
+	// port and cache dir. Timing-sensitive tests opt out via `integrationTest.sequential`.
+	const base = concurrency === "sequential"
+		? test.sequential
+		: test.concurrent;
 	const fn = modifier === "only"
-		? test.sequential.only
+		? base.only
 		: modifier === "skip"
-		? test.sequential.skip
-		: test.sequential;
+		? base.skip
+		: base;
 	fn(name, async (t) => {
 		t.onTestFinished(async () => {
 			// Give everything a chance to settle before destroying the driver.
@@ -216,4 +231,25 @@ integrationTest.only = (name: string, options: IntegrationTestOptions) => {
 
 integrationTest.skip = (name: string, options: IntegrationTestOptions) => {
 	suite(name, options, "skip");
+};
+
+integrationTest.sequential = ((
+	name: string,
+	options: IntegrationTestOptions,
+): void => {
+	suite(name, options, undefined, "sequential");
+}) as IntegrationTest["sequential"];
+
+integrationTest.sequential.only = (
+	name: string,
+	options: IntegrationTestOptions,
+) => {
+	suite(name, options, "only", "sequential");
+};
+
+integrationTest.sequential.skip = (
+	name: string,
+	options: IntegrationTestOptions,
+) => {
+	suite(name, options, "skip", "sequential");
 };

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -186,9 +186,6 @@ function suite(
 		});
 	}
 
-	// Tests within a file run concurrently by default, overlapping their many mock
-	// round-trip waits for a large speedup. Each test has an isolated in-memory mock
-	// port and cache dir. Timing-sensitive tests opt out via `integrationTest.sequential`.
 	const base = concurrency === "sequential"
 		? test.sequential
 		: test.concurrent;

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -199,14 +199,15 @@ function suite(
 			// Give everything a chance to settle before destroying the driver.
 			await wait(100);
 
-			await driver.destroy();
-			// Stop the mock too, so late frames or pending host-ACK waits don't
-			// throw after the driver is gone.
-			mockController?.destroy();
-			tcpServer?.close(noop);
-			if (!debug) {
-				await fsp.rm(cacheDir, { recursive: true, force: true })
-					.catch(noop);
+			try {
+				await driver.destroy();
+			} finally {
+				mockController?.destroy();
+				tcpServer?.close(noop);
+				if (!debug) {
+					await fsp.rm(cacheDir, { recursive: true, force: true })
+						.catch(noop);
+				}
 			}
 		});
 

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -189,6 +189,9 @@ function suite(
 			await wait(100);
 
 			await driver.destroy();
+			// Stop the mock too, so late frames or pending host-ACK waits don't
+			// throw after the driver is gone.
+			mockController?.destroy();
 			if (!debug) {
 				await fsp.rm(cacheDir, { recursive: true, force: true })
 					.catch(noop);

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -172,9 +172,6 @@ function suite(
 		});
 	}
 
-	// Tests within a file run concurrently by default, overlapping their many mock
-	// round-trip waits for a large speedup. Each test has an isolated in-memory mock
-	// port and cache dir. Timing-sensitive tests opt out via `integrationTest.sequential`.
 	const base = concurrency === "sequential"
 		? test.sequential
 		: test.concurrent;

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -46,17 +46,27 @@ export interface IntegrationTestOptions {
 export interface IntegrationTestFn {
 	(name: string, options: IntegrationTestOptions): void;
 }
-export interface IntegrationTest extends IntegrationTestFn {
+export interface IntegrationTestModifiers {
 	/** Only runs the tests inside this `integrationTest` suite for the current file */
 	only: IntegrationTestFn;
 	/** Skips running the tests inside this `integrationTest` suite for the current file */
 	skip: IntegrationTestFn;
+}
+export interface IntegrationTest
+	extends IntegrationTestFn, IntegrationTestModifiers
+{
+	/**
+	 * Runs this test sequentially instead of concurrently with the other tests in the file.
+	 * Use for tests that assert on timing or ordering, which CPU contention would perturb.
+	 */
+	sequential: IntegrationTestFn & IntegrationTestModifiers;
 }
 
 function suite(
 	name: string,
 	options: IntegrationTestOptions,
 	modifier?: "only" | "skip",
+	concurrency: "concurrent" | "sequential" = "concurrent",
 ) {
 	const {
 		controllerCapabilities,
@@ -162,12 +172,17 @@ function suite(
 		});
 	}
 
-	// Integration tests need to run in serial, or they might block the serial port on CI
+	// Tests within a file run concurrently by default, overlapping their many mock
+	// round-trip waits for a large speedup. Each test has an isolated in-memory mock
+	// port and cache dir. Timing-sensitive tests opt out via `integrationTest.sequential`.
+	const base = concurrency === "sequential"
+		? test.sequential
+		: test.concurrent;
 	const fn = modifier === "only"
-		? test.sequential.only
+		? base.only
 		: modifier === "skip"
-		? test.sequential.skip
-		: test.sequential;
+		? base.skip
+		: base;
 	fn(name, async (t) => {
 		t.onTestFinished(async () => {
 			// Give everything a chance to settle before destroying the driver.
@@ -199,4 +214,25 @@ integrationTest.only = (name: string, options: IntegrationTestOptions) => {
 
 integrationTest.skip = (name: string, options: IntegrationTestOptions) => {
 	suite(name, options, "skip");
+};
+
+integrationTest.sequential = ((
+	name: string,
+	options: IntegrationTestOptions,
+): void => {
+	suite(name, options, undefined, "sequential");
+}) as IntegrationTest["sequential"];
+
+integrationTest.sequential.only = (
+	name: string,
+	options: IntegrationTestOptions,
+) => {
+	suite(name, options, "only", "sequential");
+};
+
+integrationTest.sequential.skip = (
+	name: string,
+	options: IntegrationTestOptions,
+) => {
+	suite(name, options, "skip", "sequential");
 };

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -185,13 +185,14 @@ function suite(
 			// Give everything a chance to settle before destroying the driver.
 			await wait(100);
 
-			await driver.destroy();
-			// Stop the mock too, so late frames or pending host-ACK waits don't
-			// throw after the driver is gone.
-			mockController?.destroy();
-			if (!debug) {
-				await fsp.rm(cacheDir, { recursive: true, force: true })
-					.catch(noop);
+			try {
+				await driver.destroy();
+			} finally {
+				mockController?.destroy();
+				if (!debug) {
+					await fsp.rm(cacheDir, { recursive: true, force: true })
+						.catch(noop);
+				}
 			}
 		});
 


### PR DESCRIPTION
## Summary

- Integration tests within a file now run concurrently (overlapping mock round-trip waits). Timing-sensitive tests opt out via `integrationTest.sequential(...)`.
- Mock nodes default to supporting Basic CC, so the mandatory Basic Get probe succeeds immediately instead of waiting the ~1s report timeout 240 times.
- Teardown races fixed: MockPort drops late frames, MockController resolves pending host-ACKs on destroy.
- 5 SendData recovery files + 5 live-interview Notification files marked `.sequential`.

## Measured impact

Wall time (local, full 1385-test suite): ~87s → ~19.5s (~4.5×).
CI vitest Duration (Node 22, slowest shard): ~100s → ~69s (~30%).

## Not included

- Lowering `report` timeout — no concurrent gain, breaks 3 tests.
- Cache-fixture conversion for large UserCode/UserCredential files — separate change.
- Remaining minor mock gaps (WakeUp, Firmware, Battery, Association) — off critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)