### PR TITLE
chore(bot): suggest related issues and discussions automatically

### DIFF
--- a/.github/bot-scripts/answerFromDocs.cjs
+++ b/.github/bot-scripts/answerFromDocs.cjs
@@ -5,15 +5,16 @@
 const fs = require("node:fs/promises");
 const { retrieve } = require("./docsSearch.cjs");
 const { CHAT_MODEL, embed, modelsRequest } = require("./modelsApi.cjs");
+const {
+	QUESTION_CATEGORY_SLUGS,
+	cleanQuestion,
+	loadPostsIndex,
+	rankRelatedPosts,
+} = require("./postsIndex.cjs");
 
 const DOCS_BASE_URL = "https://zwave-js.github.io/zwave-js/#";
 const DOCS_ANSWER_COMMENT_TAG = "<!-- DOCS_ANSWER_COMMENT_TAG -->";
 
-// Discussion categories where questions are expected
-const QUESTION_CATEGORY_SLUGS = [
-	"request-support-investigate-issue",
-	"q-a",
-];
 // Users whose posts should never be answered automatically
 const EXCLUDED_USERS = ["AlCalzone", "zwave-js-bot"];
 
@@ -26,46 +27,10 @@ const MIN_SIMILARITY = 0.2;
 const ANSWER_CONFIDENCE = 75;
 const LINKS_CONFIDENCE = 40;
 
-// Limit the question size to keep the prompt within the token budget
-const MAX_QUESTION_LENGTH = 6000;
-
-/**
- * Reduces template boilerplate and log/code dumps in the post body,
- * which would otherwise dilute the query used for retrieval
- * @param {string} title
- * @param {string} body
- */
-function cleanQuestion(title, body) {
-	// Template instructions are hidden in HTML comments.
-	// Replacements can create new comment sequences, repeat until stable.
-	let text = body;
-	let previous;
-	do {
-		previous = text;
-		text = text.replace(/<!--[\s\S]*?-->/g, "");
-	} while (text !== previous);
-
-	text = text
-		// Checked/unchecked checklist items carry no information
-		.replace(/^\s*-\s*\[[ xX]\].*$/gm, "")
-		// Retrieval matches on prose, not logs. Long code blocks would
-		// dilute the embedding and blow the question length budget, so
-		// they are shortened to head + tail. This is NOT log analysis -
-		// that is the log analyzer's job, this bot only matches the
-		// question against the documentation.
-		.replace(/(```|~~~)[\s\S]*?\1/g, (block) => {
-			const lines = block.split("\n");
-			if (lines.length <= 15) return block;
-			return [
-				...lines.slice(0, 8),
-				"...",
-				...lines.slice(-4),
-			].join("\n");
-		})
-		.replace(/\n{3,}/g, "\n\n")
-		.trim();
-	return `${title}\n\n${text}`.slice(0, MAX_QUESTION_LENGTH);
-}
+// A related post is only suggested above this cosine similarity.
+// A wrong suggestion is worse than a missed one, so keep this high.
+const POSTS_MIN_SIMILARITY = 0.55;
+const MAX_RELATED_POSTS = 3;
 
 /** @param {{file: string, anchor: string}} chunk */
 function chunkUrl(chunk) {
@@ -162,12 +127,182 @@ ${excerpts}`;
 }
 
 /**
- * Answers a user's question in an issue or discussion based on the documentation.
+ * Retrieves documentation for the question, judges whether it answers it,
+ * and renders the docs part of the comment
+ * @param {string} question
+ * @param {number[]} questionEmbedding
+ * @param {any} index The docs embeddings index
+ * @param {string} token
+ * @returns {Promise<string | undefined>}
+ */
+async function buildDocsAnswerSection(
+	question,
+	questionEmbedding,
+	index,
+	token,
+) {
+	const { results: ranked, bestSimilarity } = retrieve(
+		index,
+		questionEmbedding,
+		question,
+		MAX_RETRIEVED_CHUNKS,
+	);
+
+	if (bestSimilarity < MIN_SIMILARITY) {
+		console.log(
+			`Best similarity ${
+				bestSimilarity.toFixed(3)
+			} below floor, post is likely off-topic`,
+		);
+		return;
+	}
+
+	console.log(
+		"Top matches:",
+		ranked.map((r) =>
+			`cos=${r.similarity.toFixed(3)} bm25=${
+				r.lexical.toFixed(1)
+			} ${r.chunk.file}#${r.chunk.anchor}`
+		),
+	);
+	if (ranked.length === 0) {
+		console.log("No relevant documentation found");
+		return;
+	}
+
+	// Ask the model whether the docs answer the question
+	/** @type {{confidence: number, answer: string | null, relatedExcerpts: number[]}} */
+	let result;
+	try {
+		result = await judgeAnswer(question, ranked, token);
+	} catch (e) {
+		console.log("Failed to parse model response:", e);
+		return;
+	}
+	console.log("Model response:", JSON.stringify(result));
+
+	const related = (result.relatedExcerpts ?? [])
+		.map((i) => ranked[i]?.chunk)
+		.filter(Boolean);
+
+	if (result.confidence < LINKS_CONFIDENCE || related.length === 0) {
+		console.log("Confidence too low, not answering");
+		return;
+	}
+
+	// When linking to a section, don't also link to its subsections
+	const isAncestor = (
+		/** @type {any} */ a,
+		/** @type {any} */ b,
+	) => a.file === b.file
+		&& a.breadcrumbs.length < b.breadcrumbs.length
+		&& a.breadcrumbs.every(
+			(/** @type {string} */ crumb, /** @type {number} */ i) =>
+				crumb === b.breadcrumbs[i],
+		);
+	// Sub-splits of the same section share a URL, only link it once
+	/** @type {Set<string>} */
+	const seenUrls = new Set();
+	const deduped = related.filter((chunk) => {
+		if (related.some((other) => isAncestor(other, chunk))) return false;
+		const url = chunkUrl(chunk);
+		if (seenUrls.has(url)) return false;
+		seenUrls.add(url);
+		return true;
+	});
+
+	const links = deduped
+		.map((chunk) => {
+			const label = chunk.breadcrumbs.join(" → ");
+			return `- [${label}](${chunkUrl(chunk)})`;
+		})
+		.join("\n");
+
+	const single = deduped.length === 1;
+	if (result.confidence >= ANSWER_CONFIDENCE && result.answer) {
+		return `${result.answer}
+
+${
+			single
+				? "This section of the documentation has more details:"
+				: "These sections of the documentation have more details:"
+		}
+${links}`;
+	} else {
+		return `${
+			single
+				? "This section of the documentation might answer your question:"
+				: "These sections of the documentation might answer your question:"
+		}
+
+${links}`;
+	}
+}
+
+/** @param {import("./postsIndex.cjs").IndexedPost} post */
+function describePostState(post) {
+	if (post.type === "issue") {
+		return post.state === "open" ? "open issue" : "closed issue";
+	}
+	if (post.state === "answered") return "answered discussion";
+	if (post.state === "closed") return "closed discussion";
+	return "discussion";
+}
+
+/**
+ * Ranks existing posts by similarity and renders the related-posts part
+ * of the comment
+ * @param {NonNullable<Awaited<ReturnType<typeof loadPostsIndex>>>} index
+ * @param {number[]} questionEmbedding
+ * @param {{type: "issue" | "discussion", number: number}} self
+ * @returns {string | undefined}
+ */
+function buildRelatedPostsSection(index, questionEmbedding, self) {
+	// Log more candidates than are shown, as tuning signal for the floor
+	const candidates = rankRelatedPosts(index, questionEmbedding, self, {
+		minSimilarity: 0,
+		maxResults: 10,
+	});
+	console.log(
+		"Top related posts:",
+		candidates.map((c) =>
+			`cos=${c.similarity.toFixed(3)} ${c.post.type} #${c.post.number}`
+		),
+	);
+
+	const shown = candidates
+		.filter((c) => c.similarity >= POSTS_MIN_SIMILARITY)
+		.slice(0, MAX_RELATED_POSTS);
+	if (shown.length === 0) {
+		console.log("No sufficiently similar posts found");
+		return;
+	}
+
+	const links = shown
+		.map(({ post }) => {
+			// Square brackets in titles would break the markdown link
+			const title = post.title.replace(/([[\]])/g, "\\$1");
+			return `- [${title}](${post.url}) (${describePostState(post)})`;
+		})
+		.join("\n");
+
+	return `${
+		shown.length === 1
+			? "This existing post looks similar to yours and might be related — a maintainer will confirm:"
+			: "These existing posts look similar to yours and might be related — a maintainer will confirm:"
+	}
+
+${links}`;
+}
+
+/**
+ * Answers a user's question in an issue or discussion based on the
+ * documentation, and/or suggests similar existing posts, in a single comment.
  *
  * Expects the following environment variables:
  * - MODELS_TOKEN: token with models:read permission
  * - DOCS_INDEX_PATH: path to the embeddings index created by buildDocsIndex.cjs
- * - DRY_RUN: if set to "true", log the would-be comment instead of posting it
+ * - POSTS_INDEX_PATH: path to the embeddings index created by buildPostsIndex.cjs
  *
  * @param {{github: Github, context: Context, core?: any}} param
  */
@@ -179,8 +314,6 @@ async function main(param) {
 		console.log("No MODELS_TOKEN provided, skipping");
 		return;
 	}
-	const dryRun = process.env.DRY_RUN === "true";
-
 	// Figure out where the question comes from
 	const isDiscussion = !!context.payload.discussion;
 	const post = context.payload.discussion ?? context.payload.issue;
@@ -220,150 +353,112 @@ async function main(param) {
 
 	// Check for an existing answer before spending any Models API requests.
 	// This also makes re-runs on edited posts cheap no-ops.
-	if (
-		!dryRun
-		&& await alreadyAnswered({ github, context }, post, isDiscussion)
-	) {
+	if (await alreadyAnswered({ github, context }, post, isDiscussion)) {
 		console.log("Already answered, skipping");
 		return;
 	}
 
-	// Load the pre-built embeddings index
-	const indexPath = process.env.DOCS_INDEX_PATH;
+	// Load the pre-built embeddings indices. Either may be missing,
+	// each one enables its part of the comment.
+	const docsIndexPath = process.env.DOCS_INDEX_PATH;
 	/** @type {any} */
-	let index;
+	let docsIndex;
 	try {
-		index = JSON.parse(await fs.readFile(indexPath, "utf8"));
+		docsIndex = JSON.parse(await fs.readFile(docsIndexPath, "utf8"));
+		console.log(
+			`Loaded docs index with ${docsIndex.chunks.length} chunks (created ${docsIndex.createdAt})`,
+		);
 	} catch {
-		console.log(`No docs index found at ${indexPath}, skipping`);
-		return;
+		console.log(`No docs index found at ${docsIndexPath}`);
 	}
-	console.log(
-		`Loaded docs index with ${index.chunks.length} chunks (created ${index.createdAt})`,
-	);
+
+	let postsIndex = await loadPostsIndex(process.env.POSTS_INDEX_PATH);
+	if (postsIndex) {
+		console.log(
+			`Loaded posts index with ${postsIndex.posts.length} posts (created ${postsIndex.createdAt})`,
+		);
+	} else {
+		console.log(
+			`No posts index found at ${process.env.POSTS_INDEX_PATH}`,
+		);
+	}
+
+	if (!docsIndex && !postsIndex) return;
 
 	const question = cleanQuestion(post.title, post.body ?? "");
 
-	// Hybrid retrieval: 1 embedding request, then in-process search
+	// A single embedding request serves both docs retrieval and
+	// related-post ranking. Similarities are only comparable within
+	// one model, so an index embedded with a different model is skipped.
+	const embeddingModel = docsIndex?.model ?? postsIndex?.model;
+	if (postsIndex && postsIndex.model !== embeddingModel) {
+		console.log(
+			`Posts index model ${postsIndex.model} does not match ${embeddingModel}, ignoring it`,
+		);
+		postsIndex = undefined;
+		if (!docsIndex) return;
+	}
 	const [questionEmbedding] = await embed(
 		[question],
 		modelsToken,
-		index.model,
-	);
-	const { results: ranked, bestSimilarity } = retrieve(
-		index,
-		questionEmbedding,
-		question,
-		MAX_RETRIEVED_CHUNKS,
+		embeddingModel,
 	);
 
-	if (bestSimilarity < MIN_SIMILARITY) {
-		console.log(
-			`Best similarity ${
-				bestSimilarity.toFixed(3)
-			} below floor, post is likely off-topic`,
-		);
+	const docsSection = docsIndex
+		? await buildDocsAnswerSection(
+			question,
+			questionEmbedding,
+			docsIndex,
+			modelsToken,
+		)
+		: undefined;
+
+	const postsSection = postsIndex
+		? buildRelatedPostsSection(postsIndex, questionEmbedding, {
+			type: isDiscussion ? "discussion" : "issue",
+			number: post.number,
+		})
+		: undefined;
+
+	if (!docsSection && !postsSection) {
+		console.log("Nothing to answer or suggest, skipping");
 		return;
 	}
-
-	console.log(
-		"Top matches:",
-		ranked.map((r) =>
-			`cos=${r.similarity.toFixed(3)} bm25=${
-				r.lexical.toFixed(1)
-			} ${r.chunk.file}#${r.chunk.anchor}`
-		),
-	);
-	if (ranked.length === 0) {
-		console.log("No relevant documentation found, skipping");
-		return;
-	}
-
-	// Ask the model whether the docs answer the question
-	/** @type {{confidence: number, answer: string | null, relatedExcerpts: number[]}} */
-	let result;
-	try {
-		result = await judgeAnswer(question, ranked, modelsToken);
-	} catch (e) {
-		console.log("Failed to parse model response:", e);
-		return;
-	}
-	console.log("Model response:", JSON.stringify(result));
-
-	const related = (result.relatedExcerpts ?? [])
-		.map((i) => ranked[i]?.chunk)
-		.filter(Boolean);
-
-	if (result.confidence < LINKS_CONFIDENCE || related.length === 0) {
-		console.log("Confidence too low, not answering");
-		return;
-	}
-
-	// When linking to a section, don't also link to its subsections
-	const isAncestor = (
-		/** @type {any} */ a,
-		/** @type {any} */ b,
-	) => a.file === b.file
-		&& a.breadcrumbs.length < b.breadcrumbs.length
-		&& a.breadcrumbs.every(
-			(/** @type {string} */ crumb, /** @type {number} */ i) =>
-				crumb === b.breadcrumbs[i],
-		);
-	// Sub-splits of the same section share a URL, only link it once
-	/** @type {Set<string>} */
-	const seenUrls = new Set();
-	const deduped = related.filter((chunk) => {
-		if (related.some((other) => isAncestor(other, chunk))) return false;
-		const url = chunkUrl(chunk);
-		if (seenUrls.has(url)) return false;
-		seenUrls.add(url);
-		return true;
-	});
 
 	// Compose the comment
-	const links = deduped
-		.map((chunk) => {
-			const label = chunk.breadcrumbs.join(" → ");
-			return `- [${label}](${chunkUrl(chunk)})`;
-		})
-		.join("\n");
-
 	let body = `**Beep, boop! 🤖**
 
-_I've tried to answer your question based on the documentation. If this doesn't help, please wait for a human to show up._
-
 `;
-	const single = deduped.length === 1;
-	if (result.confidence >= ANSWER_CONFIDENCE && result.answer) {
-		body += `${result.answer}
+	if (docsSection) {
+		body +=
+			`_I've tried to answer your question based on the documentation. If this doesn't help, please wait for a human to show up._
 
-${
-			single
-				? "This section of the documentation has more details:"
-				: "These sections of the documentation have more details:"
+${docsSection}`;
+		if (postsSection) {
+			body += `
+
+---
+
+${postsSection}`;
 		}
-${links}`;
 	} else {
-		body += `${
-			single
-				? "This section of the documentation might answer your question:"
-				: "These sections of the documentation might answer your question:"
-		}
+		body +=
+			`_I've found existing posts that look similar to yours. If they don't help, please wait for a human to show up._
 
-${links}`;
+${postsSection}`;
 	}
 	body += `
 
 ---
 
-_This answer was generated automatically based on the documentation. AI can make mistakes, always check important info._
+_${
+		docsSection
+			? "This answer was"
+			: "These suggestions were"
+	} generated automatically${
+		docsSection ? " based on the documentation" : ""
+	}. AI can make mistakes, always check important info._
 ${DOCS_ANSWER_COMMENT_TAG}`;
-
-	if (dryRun) {
-		console.log("DRY RUN - would post the following comment:");
-		console.log(body);
-		return;
-	}
 
 	if (isDiscussion) {
 		await github.graphql(

--- a/.github/bot-scripts/answerFromDocs.cjs
+++ b/.github/bot-scripts/answerFromDocs.cjs
@@ -280,8 +280,8 @@ function buildRelatedPostsSection(index, questionEmbedding, self) {
 
 	const links = shown
 		.map(({ post }) => {
-			// Square brackets in titles would break the markdown link
-			const title = post.title.replace(/([[\]])/g, "\\$1");
+			// Backslashes and square brackets in titles would break the markdown link
+			const title = post.title.replace(/[\\[\]]/g, "\\$&");
 			return `- [${title}](${post.url}) (${describePostState(post)})`;
 		})
 		.join("\n");

--- a/.github/bot-scripts/buildPostsIndex.cjs
+++ b/.github/bot-scripts/buildPostsIndex.cjs
@@ -1,0 +1,337 @@
+// @ts-check
+
+// Builds a semantic search index over GitHub issues and discussions
+// by embedding their title + cleaned body using GitHub Models.
+// Indexed are open issues, issues closed within the last year, and all
+// discussions in the question categories.
+// Usage: node buildPostsIndex.cjs <owner/repo> <output-file>
+// Requires GITHUB_TOKEN with models:read permission and read access
+// to the repository's issues and discussions.
+
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const { embed, EMBEDDING_MODEL } = require("./modelsApi.cjs");
+const {
+	POSTS_INDEX_VERSION,
+	QUESTION_CATEGORY_SLUGS,
+	hashPost,
+	postEmbeddingText,
+} = require("./postsIndex.cjs");
+
+const GITHUB_API_BASE = "https://api.github.com";
+
+// Closed issues older than this are no longer useful duplicate targets
+const CLOSED_ISSUE_MAX_AGE_MS = 365 * 24 * 3600 * 1000;
+
+// Stay well below the 64K tokens/request limit for embedding requests
+const MAX_BATCH_TOKENS = 40_000;
+const MAX_BATCH_INPUTS = 128;
+// The free tier allows 15 requests/minute
+const THROTTLE_MS = 4500;
+
+/** @param {string} str */
+function estimateTokens(str) {
+	return Math.ceil(str.length / 4);
+}
+
+/**
+ * Fetches all pages of a REST collection endpoint
+ * @param {string} url Initial URL including query parameters
+ * @param {string} token
+ * @returns {Promise<any[]>}
+ */
+async function ghRestPaginated(url, token) {
+	/** @type {any[]} */
+	const results = [];
+	/** @type {string | undefined} */
+	let next = url;
+	while (next) {
+		const response = await fetch(next, {
+			headers: {
+				Accept: "application/vnd.github+json",
+				Authorization: `Bearer ${token}`,
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		});
+		if (!response.ok) {
+			throw new Error(
+				`GitHub API request failed with status ${response.status}: ${await response
+					.text()
+					.catch(() => "")}`,
+			);
+		}
+		results.push(...await response.json());
+		next = response.headers
+			.get("link")
+			?.match(/<([^>]+)>;\s*rel="next"/)?.[1];
+	}
+	return results;
+}
+
+/**
+ * @param {string} query
+ * @param {object} variables
+ * @param {string} token
+ * @returns {Promise<any>}
+ */
+async function ghGraphql(query, variables, token) {
+	const response = await fetch(`${GITHUB_API_BASE}/graphql`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	if (!response.ok) {
+		throw new Error(
+			`GitHub GraphQL request failed with status ${response.status}: ${await response
+				.text()
+				.catch(() => "")}`,
+		);
+	}
+	const result = await response.json();
+	if (result.errors?.length) {
+		throw new Error(
+			`GitHub GraphQL request failed: ${JSON.stringify(result.errors)}`,
+		);
+	}
+	return result.data;
+}
+
+/**
+ * Fetches open issues and issues closed within the last year
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} token
+ */
+async function fetchIssues(owner, repo, token) {
+	const closedCutoff = new Date(Date.now() - CLOSED_ISSUE_MAX_AGE_MS);
+
+	const open = await ghRestPaginated(
+		`${GITHUB_API_BASE}/repos/${owner}/${repo}/issues?state=open&per_page=100`,
+		token,
+	);
+	// "since" filters on updated_at; closing an issue updates it, so all
+	// issues closed within the window are included. Filter on closed_at
+	// to drop issues that were merely commented on since the cutoff.
+	const closed = await ghRestPaginated(
+		`${GITHUB_API_BASE}/repos/${owner}/${repo}/issues?state=closed&since=${closedCutoff.toISOString()}&per_page=100`,
+		token,
+	);
+
+	// The issues endpoint also returns PRs
+	const issues = [
+		...open,
+		...closed.filter(
+			(issue) =>
+				issue.closed_at
+				&& new Date(issue.closed_at) >= closedCutoff,
+		),
+	].filter((issue) => !issue.pull_request);
+
+	return issues.map((issue) => ({
+		type: /** @type {const} */ ("issue"),
+		number: issue.number,
+		title: issue.title,
+		body: issue.body ?? "",
+		url: issue.html_url,
+		state: issue.state === "open"
+			? /** @type {const} */ ("open")
+			: /** @type {const} */ ("closed"),
+		createdAt: issue.created_at,
+		closedAt: issue.closed_at ?? null,
+		labels: (issue.labels ?? []).map((/** @type {any} */ l) => l.name),
+	}));
+}
+
+/**
+ * Fetches all discussions in the question categories
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} token
+ */
+async function fetchDiscussions(owner, repo, token) {
+	const categoryData = await ghGraphql(
+		`
+		query getCategories($owner: String!, $repo: String!) {
+			repository(owner: $owner, name: $repo) {
+				discussionCategories(first: 25) {
+					nodes { id slug }
+				}
+			}
+		}
+		`,
+		{ owner, repo },
+		token,
+	);
+	const categoryIds = categoryData.repository.discussionCategories.nodes
+		.filter((/** @type {any} */ c) =>
+			QUESTION_CATEGORY_SLUGS.includes(c.slug)
+		)
+		.map((/** @type {any} */ c) => c.id);
+
+	/** @type {any[]} */
+	const discussions = [];
+	for (const categoryId of categoryIds) {
+		/** @type {string | null} */
+		let cursor = null;
+		do {
+			const data = await ghGraphql(
+				`
+				query getDiscussions($owner: String!, $repo: String!, $categoryId: ID!, $cursor: String) {
+					repository(owner: $owner, name: $repo) {
+						discussions(categoryId: $categoryId, first: 100, after: $cursor) {
+							pageInfo { hasNextPage endCursor }
+							nodes {
+								number
+								title
+								body
+								url
+								closed
+								closedAt
+								createdAt
+								answerChosenAt
+							}
+						}
+					}
+				}
+				`,
+				{ owner, repo, categoryId, cursor },
+				token,
+			);
+			const page = data.repository.discussions;
+			discussions.push(...page.nodes);
+			cursor = page.pageInfo.hasNextPage
+				? page.pageInfo.endCursor
+				: null;
+		} while (cursor);
+	}
+
+	return discussions.map((discussion) => ({
+		type: /** @type {const} */ ("discussion"),
+		number: discussion.number,
+		title: discussion.title,
+		body: discussion.body ?? "",
+		url: discussion.url,
+		state: discussion.answerChosenAt
+			? /** @type {const} */ ("answered")
+			: discussion.closed
+			? /** @type {const} */ ("closed")
+			: /** @type {const} */ ("open"),
+		createdAt: discussion.createdAt,
+		closedAt: discussion.closedAt ?? null,
+		labels: [],
+	}));
+}
+
+async function main() {
+	const [repoSlug, outputFile] = process.argv.slice(2);
+	const [owner, repo] = repoSlug?.split("/") ?? [];
+	if (!owner || !repo || !outputFile) {
+		console.error(
+			"Usage: node buildPostsIndex.cjs <owner/repo> <output-file>",
+		);
+		process.exit(1);
+	}
+	const token = process.env.GITHUB_TOKEN;
+	if (!token) {
+		console.error("GITHUB_TOKEN environment variable is required");
+		process.exit(1);
+	}
+
+	// Reuse embeddings from a previous index for unchanged posts
+	/** @type {Map<string, number[]>} */
+	const previousEmbeddings = new Map();
+	try {
+		const previous = JSON.parse(await fs.readFile(outputFile, "utf8"));
+		if (
+			previous.version === POSTS_INDEX_VERSION
+			&& previous.model === EMBEDDING_MODEL
+		) {
+			for (const post of previous.posts) {
+				previousEmbeddings.set(post.hash, post.embedding);
+			}
+			console.log(
+				`Found previous index with ${previousEmbeddings.size} posts`,
+			);
+		}
+	} catch {
+		// No previous index available, embed everything
+	}
+
+	const issues = await fetchIssues(owner, repo, token);
+	console.log(`Fetched ${issues.length} issues`);
+	const discussions = await fetchDiscussions(owner, repo, token);
+	console.log(`Fetched ${discussions.length} discussions`);
+
+	const allPosts = [...issues, ...discussions].map(({ body, ...post }) => {
+		const embeddedText = postEmbeddingText(post.title, body);
+		const hash = hashPost(embeddedText);
+		return {
+			...post,
+			hash,
+			embeddedText,
+			embedding: previousEmbeddings.get(hash),
+		};
+	});
+
+	const pending = allPosts.filter((p) => !p.embedding);
+	console.log(`${pending.length} posts need new embeddings`);
+
+	// Batch the pending posts, respecting per-request limits
+	let cursor = 0;
+	let requestCount = 0;
+	while (cursor < pending.length) {
+		const batch = [];
+		let batchTokens = 0;
+		while (
+			cursor < pending.length
+			&& batch.length < MAX_BATCH_INPUTS
+		) {
+			const tokens = estimateTokens(pending[cursor].embeddedText);
+			if (batch.length > 0 && batchTokens + tokens > MAX_BATCH_TOKENS) {
+				break;
+			}
+			batch.push(pending[cursor]);
+			batchTokens += tokens;
+			cursor++;
+		}
+
+		if (requestCount > 0) {
+			await new Promise((resolve) => setTimeout(resolve, THROTTLE_MS));
+		}
+		console.log(
+			`Embedding batch of ${batch.length} posts (~${batchTokens} tokens)...`,
+		);
+		const embeddings = await embed(
+			batch.map((p) => p.embeddedText),
+			token,
+		);
+		requestCount++;
+		for (let i = 0; i < batch.length; i++) {
+			// Round to reduce index size, this has no measurable impact on similarity
+			batch[i].embedding = embeddings[i].map(
+				(x) => Math.round(x * 1e5) / 1e5,
+			);
+		}
+	}
+	console.log(`Done, used ${requestCount} embedding requests`);
+
+	const index = {
+		version: POSTS_INDEX_VERSION,
+		model: EMBEDDING_MODEL,
+		createdAt: new Date().toISOString(),
+		posts: allPosts.map(({ embeddedText, ...post }) => post),
+	};
+	await fs.mkdir(path.dirname(outputFile), { recursive: true });
+	await fs.writeFile(outputFile, JSON.stringify(index));
+	console.log(`Wrote index with ${allPosts.length} posts to ${outputFile}`);
+}
+
+if (require.main === module) {
+	main().catch((e) => {
+		console.error(e);
+		process.exit(1);
+	});
+}

--- a/.github/bot-scripts/evalRelatedPosts.cjs
+++ b/.github/bot-scripts/evalRelatedPosts.cjs
@@ -1,0 +1,133 @@
+// @ts-check
+
+// Evaluates the retrieval quality of the related-posts suggestions
+// against a golden set of questions with known related issues/discussions.
+// Run daily in CI to catch regressions from changes to the cleaning/
+// ranking logic or embedding model.
+//
+// Usage: node evalRelatedPosts.cjs <index-file>
+// Requires GITHUB_TOKEN in the environment.
+
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const { embed } = require("./modelsApi.cjs");
+const { rankRelatedPosts } = require("./postsIndex.cjs");
+
+const NUM_RESULTS = 5;
+// Allow a small number of misses before failing, retrieval is not exact
+const MIN_HIT_RATE = Number(process.env.MIN_HIT_RATE || "0.8");
+
+async function main() {
+	const [indexFile] = process.argv.slice(2);
+	if (!indexFile) {
+		console.error("Usage: node evalRelatedPosts.cjs <index-file>");
+		process.exit(1);
+	}
+	const token = process.env.GITHUB_TOKEN;
+	if (!token) {
+		console.error("GITHUB_TOKEN environment variable is required");
+		process.exit(1);
+	}
+
+	const index = JSON.parse(await fs.readFile(indexFile, "utf8"));
+	/** @type {{question: string, expectedPosts: {type: string, number: number}[]}[]} */
+	const allCases = JSON.parse(
+		await fs.readFile(
+			path.join(__dirname, "relatedPostsEvalCases.json"),
+			"utf8",
+		),
+	);
+
+	// Expected posts can leave the index (closed issues age out after a
+	// year), which is not a retrieval regression. Skip those cases.
+	const inIndex = (/** @type {{type: string, number: number}} */ p) =>
+		index.posts.some(
+			(/** @type {any} */ ip) =>
+				ip.type === p.type && ip.number === p.number,
+		);
+	const cases = allCases.filter((c) => {
+		if (c.expectedPosts.some(inIndex)) return true;
+		console.log(
+			`⏭️ ${
+				c.question.split("\n")[0]
+			} - no expected post in the index anymore, skipping`,
+		);
+		return false;
+	});
+
+	// A single batched request embeds all eval questions at once
+	const embeddings = await embed(
+		cases.map((c) => c.question),
+		token,
+		index.model,
+	);
+
+	let hits = 0;
+	const failures = [];
+	for (let i = 0; i < cases.length; i++) {
+		const { question, expectedPosts } = cases[i];
+		const results = rankRelatedPosts(
+			index,
+			embeddings[i],
+			// Eval questions are not posts themselves, exclude nothing
+			{ type: "", number: 0 },
+			{ minSimilarity: 0, maxResults: NUM_RESULTS },
+		);
+		const retrieved = results.map(
+			({ post, similarity }) =>
+				`${post.type} #${post.number} (cos=${similarity.toFixed(3)})`,
+		);
+		const hit = expectedPosts.some((e) =>
+			results.some(
+				({ post }) => post.type === e.type && post.number === e.number,
+			)
+		);
+		const title = question.split("\n")[0];
+		const expected = expectedPosts.map((e) => `${e.type} #${e.number}`);
+		if (hit) {
+			hits++;
+			console.log(`✅ ${title}`);
+		} else {
+			failures.push({ title, expected, retrieved });
+			console.log(`❌ ${title}`);
+			console.log(`   expected one of: ${expected.join(", ")}`);
+			console.log(`   retrieved: ${retrieved.join(", ")}`);
+		}
+	}
+
+	const hitRate = hits / cases.length;
+	console.log(
+		`\nhit@${NUM_RESULTS}: ${hits}/${cases.length} (${
+			(hitRate * 100).toFixed(1)
+		}%), required: ${(MIN_HIT_RATE * 100).toFixed(1)}%`,
+	);
+
+	// Write a summary for the workflow to include in the tracking issue
+	if (process.env.GITHUB_OUTPUT) {
+		const summary = [
+			`hit@${NUM_RESULTS}: ${hits}/${cases.length} (${
+				(hitRate * 100).toFixed(1)
+			}%)`,
+			...failures.map((f) =>
+				`- ❌ ${f.title}\n  - expected one of: ${
+					f.expected.join(", ")
+				}\n  - retrieved: ${f.retrieved.join(", ")}`
+			),
+		].join("\n");
+		await fs.appendFile(
+			process.env.GITHUB_OUTPUT,
+			`summary<<EOF\n${summary}\nEOF\n`,
+		);
+	}
+
+	if (hitRate < MIN_HIT_RATE) {
+		process.exit(1);
+	}
+}
+
+if (require.main === module) {
+	main().catch((e) => {
+		console.error(e);
+		process.exit(1);
+	});
+}

--- a/.github/bot-scripts/index.cjs
+++ b/.github/bot-scripts/index.cjs
@@ -33,4 +33,7 @@ module.exports = {
 	extractLogfileUrlFromDiscussion: (...args) =>
 		require("./extractLogfileUrlFromDiscussion.cjs")(...args),
 	escalate: (...args) => require("./escalate.cjs")(...args),
+	updatePostsIndex: (...args) => require("./updatePostsIndex.cjs")(...args),
+	updateEvalTrackingIssue: (...args) =>
+		require("./updateEvalTrackingIssue.cjs")(...args),
 };

--- a/.github/bot-scripts/postsIndex.cjs
+++ b/.github/bot-scripts/postsIndex.cjs
@@ -1,0 +1,144 @@
+// @ts-check
+
+// Shared logic for the posts embeddings index: an index over GitHub
+// issues and discussions used to suggest related/duplicate posts.
+// The index is built nightly by buildPostsIndex.cjs and updated
+// incrementally by updatePostsIndex.cjs when new posts arrive.
+
+const crypto = require("node:crypto");
+const fs = require("node:fs/promises");
+const { cosineSimilarity } = require("./docsSearch.cjs");
+
+const POSTS_INDEX_VERSION = 1;
+
+// Discussion categories where questions are expected
+const QUESTION_CATEGORY_SLUGS = [
+	"request-support-investigate-issue",
+	"q-a",
+];
+
+// Limit the post size to keep prompt and embedding within the token budget
+const MAX_QUESTION_LENGTH = 6000;
+
+/**
+ * Reduces template boilerplate and log/code dumps in the post body,
+ * which would otherwise dilute the query used for retrieval
+ * @param {string} title
+ * @param {string} body
+ */
+function cleanQuestion(title, body) {
+	// Template instructions are hidden in HTML comments.
+	// Replacements can create new comment sequences, repeat until stable.
+	let text = body;
+	let previous;
+	do {
+		previous = text;
+		text = text.replace(/<!--[\s\S]*?-->/g, "");
+	} while (text !== previous);
+
+	text = text
+		// Checked/unchecked checklist items carry no information
+		.replace(/^\s*-\s*\[[ xX]\].*$/gm, "")
+		// Retrieval matches on prose, not logs. Long code blocks would
+		// dilute the embedding and blow the question length budget, so
+		// they are shortened to head + tail. This is NOT log analysis -
+		// that is the log analyzer's job, this bot only matches the
+		// question against the documentation and existing posts.
+		.replace(/(```|~~~)[\s\S]*?\1/g, (block) => {
+			const lines = block.split("\n");
+			if (lines.length <= 15) return block;
+			return [
+				...lines.slice(0, 8),
+				"...",
+				...lines.slice(-4),
+			].join("\n");
+		})
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+	return `${title}\n\n${text}`.slice(0, MAX_QUESTION_LENGTH);
+}
+
+/**
+ * The exact text that gets embedded for a post. Queries against the
+ * index MUST be cleaned the same way for similarities to be comparable.
+ * @param {string} title
+ * @param {string} body
+ */
+function postEmbeddingText(title, body) {
+	return cleanQuestion(title, body);
+}
+
+/** @param {string} embeddedText */
+function hashPost(embeddedText) {
+	return crypto.createHash("sha256").update(embeddedText).digest("hex");
+}
+
+/**
+ * @typedef {{
+ *   type: "issue" | "discussion",
+ *   number: number,
+ *   title: string,
+ *   url: string,
+ *   state: "open" | "closed" | "answered",
+ *   createdAt: string,
+ *   closedAt: string | null,
+ *   labels: string[],
+ *   hash: string,
+ *   embedding: number[],
+ * }} IndexedPost
+ */
+
+/**
+ * Loads and validates a posts index, returning undefined if it is
+ * missing or incompatible so callers can degrade gracefully
+ * @param {string | undefined} path
+ * @returns {Promise<{version: number, model: string, createdAt: string, posts: IndexedPost[]} | undefined>}
+ */
+async function loadPostsIndex(path) {
+	if (!path) return undefined;
+	try {
+		const index = JSON.parse(await fs.readFile(path, "utf8"));
+		if (
+			index.version !== POSTS_INDEX_VERSION
+			|| !Array.isArray(index.posts)
+		) {
+			return undefined;
+		}
+		return index;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Ranks indexed posts by similarity to the given embedding
+ * @param {{posts: IndexedPost[]}} index
+ * @param {number[]} questionEmbedding
+ * @param {{type: string, number: number}} self The post being triaged, excluded from results
+ * @param {{minSimilarity: number, maxResults: number}} options
+ * @returns {{post: IndexedPost, similarity: number}[]} Most similar first
+ */
+function rankRelatedPosts(index, questionEmbedding, self, options) {
+	return index.posts
+		.filter(
+			(post) => post.type !== self.type || post.number !== self.number,
+		)
+		.map((post) => ({
+			post,
+			similarity: cosineSimilarity(questionEmbedding, post.embedding),
+		}))
+		.filter(({ similarity }) => similarity >= options.minSimilarity)
+		.sort((a, b) => b.similarity - a.similarity)
+		.slice(0, options.maxResults);
+}
+
+module.exports = {
+	POSTS_INDEX_VERSION,
+	QUESTION_CATEGORY_SLUGS,
+	MAX_QUESTION_LENGTH,
+	cleanQuestion,
+	postEmbeddingText,
+	hashPost,
+	loadPostsIndex,
+	rankRelatedPosts,
+};

--- a/.github/bot-scripts/relatedPostsEvalCases.json
+++ b/.github/bot-scripts/relatedPostsEvalCases.json
@@ -1,0 +1,26 @@
+[
+	{
+		"question": "Controller connection broken after updating Z-Wave JS UI\n\nI connect to my controller over the network using ser2net. After updating from 13.10.1 to a newer version, the driver fails to start. Rolling back fixes it.",
+		"expectedPosts": [{ "type": "discussion", "number": 7504 }]
+	},
+	{
+		"question": "RF region switches back to Europe (Long Range) on its own\n\nI set the region of my controller to USA (Long Range), but after a restart it is EU (LR) again. How do I make this stick?",
+		"expectedPosts": [{ "type": "discussion", "number": 8900 }]
+	},
+	{
+		"question": "Show which nodes are unreachable\n\nIt would be great if there was an API to figure out which devices in the network are dead or unreachable, so applications can highlight them.",
+		"expectedPosts": [{ "type": "issue", "number": 4207 }]
+	},
+	{
+		"question": "Read firmware from a device\n\nIs it possible to download the currently installed firmware image from a Z-Wave device, e.g. to clone it onto another device?",
+		"expectedPosts": [{ "type": "issue", "number": 1354 }]
+	},
+	{
+		"question": "Using zwave-js as a secondary controller\n\nI want to run zwave-js as a secondary controller in a network managed by another hub, but inclusion and the interview behave strangely. Is this supported?",
+		"expectedPosts": [
+			{ "type": "issue", "number": 7148 },
+			{ "type": "issue", "number": 8100 },
+			{ "type": "issue", "number": 8168 }
+		]
+	}
+]

--- a/.github/bot-scripts/updateEvalTrackingIssue.cjs
+++ b/.github/bot-scripts/updateEvalTrackingIssue.cjs
@@ -1,0 +1,85 @@
+// @ts-check
+
+/// <reference path="types.d.ts" />
+
+// Opens, updates or closes a tracking issue based on the outcome of a
+// daily retrieval-quality evaluation.
+//
+// Expects the following environment variables:
+// - TRACKING_ISSUE_TITLE: exact title used to find and create the issue
+// - EVAL_NAME: human-readable name of the evaluation for the issue body
+// - EVAL_OUTCOME: the outcome of the evaluation step ("success"/"failure")
+// - EVAL_SUMMARY: the summary output of the evaluation step
+
+/**
+ * @param {{github: Github, context: Context}} param
+ */
+async function main(param) {
+	const { github, context } = param;
+
+	const title = process.env.TRACKING_ISSUE_TITLE;
+	if (!title) {
+		console.log("No TRACKING_ISSUE_TITLE provided, skipping");
+		return;
+	}
+	const failed = process.env.EVAL_OUTCOME === "failure";
+
+	// Find an existing tracking issue, open or closed
+	const { data: issues } = await github.rest.issues.listForRepo({
+		...context.repo,
+		creator: "github-actions[bot]",
+		state: "all",
+		per_page: 100,
+	});
+	const tracking = issues.find((i) => i.title === title);
+
+	const runUrl =
+		`${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+	const body =
+		`The daily evaluation of the ${process.env.EVAL_NAME} did not meet the required hit rate.
+
+${process.env.EVAL_SUMMARY || "(no summary available)"}
+
+See the [workflow run](${runUrl}) for details.`;
+
+	if (failed) {
+		if (!tracking) {
+			await github.rest.issues.create({
+				...context.repo,
+				title,
+				body,
+			});
+		} else if (tracking.state === "closed") {
+			await github.rest.issues.update({
+				...context.repo,
+				issue_number: tracking.number,
+				state: "open",
+			});
+			await github.rest.issues.createComment({
+				...context.repo,
+				issue_number: tracking.number,
+				body,
+			});
+		} else {
+			await github.rest.issues.createComment({
+				...context.repo,
+				issue_number: tracking.number,
+				body,
+			});
+		}
+	} else if (tracking && tracking.state === "open") {
+		await github.rest.issues.createComment({
+			...context.repo,
+			issue_number: tracking.number,
+			body:
+				`The evaluation passed again in the latest [workflow run](${runUrl}). Closing.`,
+		});
+		await github.rest.issues.update({
+			...context.repo,
+			issue_number: tracking.number,
+			state: "closed",
+		});
+	}
+}
+
+module.exports = main;

--- a/.github/bot-scripts/updatePostsIndex.cjs
+++ b/.github/bot-scripts/updatePostsIndex.cjs
@@ -1,0 +1,109 @@
+// @ts-check
+
+/// <reference path="types.d.ts" />
+
+// Incrementally adds a just-opened (or edited) issue or discussion to
+// the posts embeddings index, so it can be suggested as a related post
+// for questions arriving before the next nightly rebuild.
+
+const fs = require("node:fs/promises");
+const { embed } = require("./modelsApi.cjs");
+const {
+	QUESTION_CATEGORY_SLUGS,
+	hashPost,
+	loadPostsIndex,
+	postEmbeddingText,
+} = require("./postsIndex.cjs");
+
+/**
+ * Expects the following environment variables:
+ * - MODELS_TOKEN: token with models:read permission
+ * - POSTS_INDEX_PATH: path to the index created by buildPostsIndex.cjs
+ *
+ * @param {{github: Github, context: Context}} param
+ * @returns {Promise<boolean>} Whether the index was modified
+ */
+async function main(param) {
+	const { context } = param;
+
+	const modelsToken = process.env.MODELS_TOKEN;
+	if (!modelsToken) {
+		console.log("No MODELS_TOKEN provided, skipping");
+		return false;
+	}
+
+	const isDiscussion = !!context.payload.discussion;
+	const post = context.payload.discussion ?? context.payload.issue;
+	if (!post) {
+		console.log("No issue or discussion in payload, skipping");
+		return false;
+	}
+	// All posts are indexed as duplicate targets regardless of author,
+	// including those the bot would never answer
+
+	if (isDiscussion) {
+		const categorySlug = context.payload.discussion.category?.slug;
+		if (!QUESTION_CATEGORY_SLUGS.includes(categorySlug)) {
+			console.log(`Skipping discussion in category ${categorySlug}`);
+			return false;
+		}
+	} else if (context.payload.issue?.pull_request) {
+		console.log("Skipping pull request");
+		return false;
+	}
+
+	const indexPath = process.env.POSTS_INDEX_PATH;
+	const index = await loadPostsIndex(indexPath);
+	if (!index) {
+		// The nightly rebuild will pick this post up
+		console.log(`No posts index found at ${indexPath}, skipping`);
+		return false;
+	}
+
+	const embeddedText = postEmbeddingText(post.title, post.body ?? "");
+	const hash = hashPost(embeddedText);
+
+	const type = isDiscussion ? "discussion" : "issue";
+	const existing = index.posts.find(
+		(p) => p.type === type && p.number === post.number,
+	);
+	if (existing?.hash === hash) {
+		console.log("Post is already indexed and unchanged, skipping");
+		return false;
+	}
+
+	const [embedding] = await embed([embeddedText], modelsToken, index.model);
+	/** @type {import("./postsIndex.cjs").IndexedPost} */
+	const entry = {
+		type,
+		number: post.number,
+		title: post.title,
+		url: post.html_url,
+		state: "open",
+		createdAt: post.created_at,
+		closedAt: null,
+		labels: isDiscussion
+			? []
+			: (post.labels ?? []).map((/** @type {any} */ l) => l.name),
+		hash,
+		// Round to reduce index size, this has no measurable impact on similarity
+		embedding: embedding.map((x) => Math.round(x * 1e5) / 1e5),
+	};
+
+	if (existing) {
+		index.posts[index.posts.indexOf(existing)] = entry;
+		console.log(`Updated ${type} #${post.number} in the posts index`);
+	} else {
+		index.posts.push(entry);
+		console.log(`Added ${type} #${post.number} to the posts index`);
+	}
+
+	// indexPath is defined, loadPostsIndex would have returned undefined otherwise
+	await fs.writeFile(
+		/** @type {string} */ (indexPath),
+		JSON.stringify(index),
+	);
+	return true;
+}
+
+module.exports = main;

--- a/.github/workflows/posts-embeddings.yml
+++ b/.github/workflows/posts-embeddings.yml
@@ -1,0 +1,92 @@
+name: Build posts embeddings index
+
+# Builds and caches a semantic search index over issues and discussions,
+# used by the bot to suggest related/duplicate posts.
+# Between the nightly rebuilds, new posts are appended incrementally by
+# the update-posts-index jobs in the issue and discussion bot workflows.
+
+on:
+  schedule:
+    # Nightly, reconciles closed/edited posts and any appends that were
+    # lost to concurrent cache saves
+    - cron: '30 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  models: read
+  issues: read
+  discussions: read
+
+jobs:
+  build-index:
+    runs-on: [ubuntu-latest]
+
+    steps:
+    - name: Checkout master branch
+      uses: actions/checkout@v7
+
+    # Cache keys are immutable, so the rolling index is always saved under
+    # a fresh run-scoped key and restored via the newest prefix match.
+    # The explicit restore/save split ensures a failed build does not
+    # re-save a stale index under a new key.
+    - name: Restore previous index
+      uses: actions/cache/restore@v6
+      with:
+        path: .posts-index
+        # There is no exact key to match, the newest index is picked
+        # via the prefix
+        key: posts-embeddings-v1-
+        restore-keys: |
+          posts-embeddings-v1-
+
+    - name: Build index
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: node .github/bot-scripts/buildPostsIndex.cjs ${{ github.repository }} .posts-index/index.json
+
+    - name: Save index
+      uses: actions/cache/save@v6
+      with:
+        path: .posts-index
+        key: posts-embeddings-v1-${{ github.run_id }}
+
+  evaluate:
+    needs: build-index
+    runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
+      models: read
+      issues: write
+
+    steps:
+    - name: Checkout master branch
+      uses: actions/checkout@v7
+
+    - name: Restore posts index
+      id: restore-index
+      uses: actions/cache/restore@v6
+      with:
+        path: .posts-index
+        key: posts-embeddings-v1-${{ github.run_id }}
+
+    - name: Evaluate retrieval quality
+      id: eval
+      if: steps.restore-index.outputs.cache-hit == 'true'
+      continue-on-error: true
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: node .github/bot-scripts/evalRelatedPosts.cjs .posts-index/index.json
+
+    - name: Update tracking issue
+      if: steps.restore-index.outputs.cache-hit == 'true'
+      uses: actions/github-script@v9
+      env:
+        TRACKING_ISSUE_TITLE: "🚨 Related posts bot retrieval quality regression"
+        EVAL_NAME: related posts bot
+        EVAL_OUTCOME: ${{ steps.eval.outcome }}
+        EVAL_SUMMARY: ${{ steps.eval.outputs.summary }}
+      with:
+        script: |
+          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
+          await bot.updateEvalTrackingIssue({github, context});

--- a/.github/workflows/zwave-js-bot_discussion.yml
+++ b/.github/workflows/zwave-js-bot_discussion.yml
@@ -54,12 +54,15 @@ jobs:
           await bot.answerFromDocs({github, context});
 
   # Add the new post to the posts index, so it can be suggested as a
-  # related post before the next nightly rebuild
+  # related post before the next nightly rebuild.
+  # Edits are reconciled by the nightly rebuild instead, so repeated
+  # edits cannot burn Models API requests and cache storage.
   update-posts-index:
     runs-on: [ubuntu-latest]
     permissions:
       contents: read
       models: read
+    if: github.event.action == 'created'
 
     steps:
     - name: Checkout master branch

--- a/.github/workflows/zwave-js-bot_discussion.yml
+++ b/.github/workflows/zwave-js-bot_discussion.yml
@@ -1,0 +1,96 @@
+name: 'Z-Wave Bot: Discussion created/edited'
+
+on:
+  discussion:
+    types: [created, edited]
+
+jobs:
+  # Answer questions that are covered by the documentation and/or
+  # suggest similar existing posts
+  answer-from-docs:
+    runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
+      models: read
+    if: |
+      github.event.discussion.user.login != 'AlCalzone' &&
+      github.event.discussion.user.login != 'zwave-js-bot'
+
+    steps:
+    - name: Checkout master branch
+      uses: actions/checkout@v7
+
+    - name: Restore docs index
+      id: restore-index
+      uses: actions/cache/restore@v6
+      with:
+        path: .docs-index
+        key: docs-embeddings-v1-${{ hashFiles('docs/**/*.md') }}
+        restore-keys: |
+          docs-embeddings-v1-
+
+    - name: Restore posts index
+      id: restore-posts-index
+      uses: actions/cache/restore@v6
+      with:
+        path: .posts-index
+        # There is no exact key to match, the newest index is picked
+        # via the prefix
+        key: posts-embeddings-v1-
+        restore-keys: |
+          posts-embeddings-v1-
+
+    - name: Answer from documentation
+      if: steps.restore-index.outputs.cache-matched-key != '' || steps.restore-posts-index.outputs.cache-matched-key != ''
+      uses: actions/github-script@v9
+      env:
+        MODELS_TOKEN: ${{ github.token }}
+        DOCS_INDEX_PATH: .docs-index/index.json
+        POSTS_INDEX_PATH: .posts-index/index.json
+      with:
+        github-token: ${{ secrets.BOT_TOKEN }}
+        script: |
+          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
+          await bot.answerFromDocs({github, context});
+
+  # Add the new post to the posts index, so it can be suggested as a
+  # related post before the next nightly rebuild
+  update-posts-index:
+    runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
+      models: read
+
+    steps:
+    - name: Checkout master branch
+      uses: actions/checkout@v7
+
+    - name: Restore posts index
+      id: restore-posts-index
+      uses: actions/cache/restore@v6
+      with:
+        path: .posts-index
+        # There is no exact key to match, the newest index is picked
+        # via the prefix
+        key: posts-embeddings-v1-
+        restore-keys: |
+          posts-embeddings-v1-
+
+    - name: Add post to index
+      id: update
+      if: steps.restore-posts-index.outputs.cache-matched-key != ''
+      uses: actions/github-script@v9
+      env:
+        MODELS_TOKEN: ${{ github.token }}
+        POSTS_INDEX_PATH: .posts-index/index.json
+      with:
+        script: |
+          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
+          return bot.updatePostsIndex({github, context});
+
+    - name: Save posts index
+      if: steps.update.outputs.result == 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: .posts-index
+        key: posts-embeddings-v1-${{ github.run_id }}

--- a/.github/workflows/zwave-js-bot_issue.yml
+++ b/.github/workflows/zwave-js-bot_issue.yml
@@ -229,13 +229,15 @@ jobs:
           await bot.answerFromDocs({github, context});
 
   # Add the new post to the posts index, so it can be suggested as a
-  # related post before the next nightly rebuild
+  # related post before the next nightly rebuild.
+  # Edits are reconciled by the nightly rebuild instead, so repeated
+  # edits cannot burn Models API requests and cache storage.
   update-posts-index:
     runs-on: [ubuntu-latest]
     permissions:
       contents: read
       models: read
-    if: github.event.action == 'opened' || github.event.action == 'edited'
+    if: github.event.action == 'opened'
 
     steps:
     - name: Checkout master branch

--- a/.github/workflows/zwave-js-bot_issue.yml
+++ b/.github/workflows/zwave-js-bot_issue.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout master branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Extract log file from issue body
       uses: actions/github-script@v9
@@ -179,7 +179,8 @@ jobs:
           const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
           return bot.ensureLogfileFeedback({github, context}, feedback);
 
-  # Answer questions that are covered by the documentation
+  # Answer questions that are covered by the documentation and/or
+  # suggest similar existing posts
   answer-from-docs:
     runs-on: [ubuntu-latest]
     permissions:
@@ -192,26 +193,80 @@ jobs:
 
     steps:
     - name: Checkout master branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Restore docs index
       id: restore-index
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: .docs-index
         key: docs-embeddings-v1-${{ hashFiles('docs/**/*.md') }}
         restore-keys: |
           docs-embeddings-v1-
 
+    - name: Restore posts index
+      id: restore-posts-index
+      uses: actions/cache/restore@v6
+      with:
+        path: .posts-index
+        # There is no exact key to match, the newest index is picked
+        # via the prefix
+        key: posts-embeddings-v1-
+        restore-keys: |
+          posts-embeddings-v1-
+
     - name: Answer from documentation
-      if: steps.restore-index.outputs.cache-matched-key != ''
+      if: steps.restore-index.outputs.cache-matched-key != '' || steps.restore-posts-index.outputs.cache-matched-key != ''
       uses: actions/github-script@v9
       env:
         MODELS_TOKEN: ${{ github.token }}
         DOCS_INDEX_PATH: .docs-index/index.json
-        DRY_RUN: ${{ vars.DOCS_ANSWER_DRY_RUN }}
+        POSTS_INDEX_PATH: .posts-index/index.json
       with:
         github-token: ${{ secrets.BOT_TOKEN }}
         script: |
           const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
           await bot.answerFromDocs({github, context});
+
+  # Add the new post to the posts index, so it can be suggested as a
+  # related post before the next nightly rebuild
+  update-posts-index:
+    runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
+      models: read
+    if: github.event.action == 'opened' || github.event.action == 'edited'
+
+    steps:
+    - name: Checkout master branch
+      uses: actions/checkout@v7
+
+    - name: Restore posts index
+      id: restore-posts-index
+      uses: actions/cache/restore@v6
+      with:
+        path: .posts-index
+        # There is no exact key to match, the newest index is picked
+        # via the prefix
+        key: posts-embeddings-v1-
+        restore-keys: |
+          posts-embeddings-v1-
+
+    - name: Add post to index
+      id: update
+      if: steps.restore-posts-index.outputs.cache-matched-key != ''
+      uses: actions/github-script@v9
+      env:
+        MODELS_TOKEN: ${{ github.token }}
+        POSTS_INDEX_PATH: .posts-index/index.json
+      with:
+        script: |
+          const bot = require(`${process.env.GITHUB_WORKSPACE}/.github/bot-scripts/index.cjs`);
+          return bot.updatePostsIndex({github, context});
+
+    - name: Save posts index
+      if: steps.update.outputs.result == 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: .posts-index
+        key: posts-embeddings-v1-${{ github.run_id }}


### PR DESCRIPTION
Follow-up to #8937: when a new issue or discussion arrives, the bot compares it against an embeddings index of existing posts (open issues, issues closed within the last year, question-category discussions) and lists strong matches as possible duplicates — in the same comment as the docs answer. The index is rebuilt nightly and updated incrementally as posts arrive; a daily eval guards retrieval quality via a tracking issue.

Also restores bot answers for discussions, which were lost with the old discussion workflow in #8938.