### PR TITLE
feat(bot): learn from reactions to automated doc replies

### DIFF
--- a/.github/bot-scripts/answerFromDocs.cjs
+++ b/.github/bot-scripts/answerFromDocs.cjs
@@ -3,11 +3,13 @@
 /// <reference path="types.d.ts" />
 
 const fs = require("node:fs/promises");
-const { retrieve } = require("./docsSearch.cjs");
+const { cosineSimilarity, retrieve } = require("./docsSearch.cjs");
 const { CHAT_MODEL, embed, modelsRequest } = require("./modelsApi.cjs");
 
 const DOCS_BASE_URL = "https://zwave-js.github.io/zwave-js/#";
 const DOCS_ANSWER_COMMENT_TAG = "<!-- DOCS_ANSWER_COMMENT_TAG -->";
+const DOCS_ANSWER_METADATA_TAG = "DOCS_ANSWER_METADATA";
+const DOCS_ANSWER_METADATA_VERSION = 1;
 
 // Discussion categories where questions are expected
 const QUESTION_CATEGORY_SLUGS = [
@@ -25,6 +27,10 @@ const MIN_SIMILARITY = 0.2;
 // Confidence thresholds for the different response styles
 const ANSWER_CONFIDENCE = 75;
 const LINKS_CONFIDENCE = 40;
+
+// Questions at least this similar to a previously downvoted answer
+// get a demoted response: full answer -> links only, links only -> silence
+const SUPPRESS_SIMILARITY = 0.9;
 
 // Limit the question size to keep the prompt within the token budget
 const MAX_QUESTION_LENGTH = 6000;
@@ -162,6 +168,38 @@ ${excerpts}`;
 }
 
 /**
+ * Determines how the answer to a question must be demoted based on
+ * its similarity to previously downvoted answers: a downvoted full
+ * answer allows links only, downvoted links mean staying silent
+ * @param {number[]} questionEmbedding
+ * @param {{model: string, suppressed: {embedding: number[], style: string, url: string}[]} | undefined} feedback
+ * @param {string} indexModel
+ * @returns {"allow" | "linksOnly" | "silent"}
+ */
+function checkSuppression(questionEmbedding, feedback, indexModel) {
+	// Embeddings from different models are not comparable
+	if (!feedback || feedback.model !== indexModel) return "allow";
+
+	/** @type {"allow" | "linksOnly" | "silent"} */
+	let result = "allow";
+	for (const entry of feedback.suppressed ?? []) {
+		const similarity = cosineSimilarity(
+			questionEmbedding,
+			entry.embedding,
+		);
+		if (similarity < SUPPRESS_SIMILARITY) continue;
+		console.log(
+			`Question is similar (${
+				similarity.toFixed(3)
+			}) to a downvoted answer: ${entry.url}`,
+		);
+		if (entry.style === "links") return "silent";
+		result = "linksOnly";
+	}
+	return result;
+}
+
+/**
  * Answers a user's question in an issue or discussion based on the documentation.
  *
  * Expects the following environment variables:
@@ -250,6 +288,31 @@ async function main(param) {
 		modelsToken,
 		index.model,
 	);
+
+	// Feedback guardrail: check the question against previously
+	// downvoted answers collected by collectDocsAnswerFeedback.cjs
+	let allowAnswer = true;
+	const feedbackPath = process.env.DOCS_FEEDBACK_PATH;
+	if (feedbackPath) {
+		/** @type {any} */
+		let feedback;
+		try {
+			feedback = JSON.parse(await fs.readFile(feedbackPath, "utf8"));
+		} catch {
+			console.log(`No feedback data found at ${feedbackPath}`);
+		}
+		const suppression = checkSuppression(
+			questionEmbedding,
+			feedback,
+			index.model,
+		);
+		if (suppression === "silent") {
+			console.log("Even doc links were downvoted, staying silent");
+			return;
+		}
+		allowAnswer = suppression === "allow";
+	}
+
 	const { results: ranked, bestSimilarity } = retrieve(
 		index,
 		questionEmbedding,
@@ -334,7 +397,10 @@ _I've tried to answer your question based on the documentation. If this doesn't 
 
 `;
 	const single = deduped.length === 1;
-	if (result.confidence >= ANSWER_CONFIDENCE && result.answer) {
+	const fullAnswer = allowAnswer
+		&& result.confidence >= ANSWER_CONFIDENCE
+		&& !!result.answer;
+	if (fullAnswer) {
 		body += `${result.answer}
 
 ${
@@ -352,12 +418,23 @@ ${links}`;
 
 ${links}`;
 	}
+	// Metadata for collectDocsAnswerFeedback.cjs to attribute
+	// reactions to doc sections without re-parsing the comment
+	const metadata = {
+		v: DOCS_ANSWER_METADATA_VERSION,
+		style: fullAnswer ? "answer" : "links",
+		confidence: result.confidence,
+		sections: deduped.map((chunk) => `${chunk.file}#${chunk.anchor}`),
+	};
+
 	body += `
 
 ---
 
 _This answer was generated automatically based on the documentation. AI can make mistakes, always check important info._
-${DOCS_ANSWER_COMMENT_TAG}`;
+_Was this helpful? React with 👍 or 👎 to let us know._
+${DOCS_ANSWER_COMMENT_TAG}
+<!-- ${DOCS_ANSWER_METADATA_TAG} ${JSON.stringify(metadata)} -->`;
 
 	if (dryRun) {
 		console.log("DRY RUN - would post the following comment:");
@@ -388,3 +465,9 @@ ${DOCS_ANSWER_COMMENT_TAG}`;
 
 module.exports = main;
 module.exports.judgeAnswer = judgeAnswer;
+module.exports.cleanQuestion = cleanQuestion;
+module.exports.checkSuppression = checkSuppression;
+module.exports.DOCS_ANSWER_COMMENT_TAG = DOCS_ANSWER_COMMENT_TAG;
+module.exports.DOCS_ANSWER_METADATA_TAG = DOCS_ANSWER_METADATA_TAG;
+module.exports.DOCS_ANSWER_METADATA_VERSION = DOCS_ANSWER_METADATA_VERSION;
+module.exports.DOCS_BASE_URL = DOCS_BASE_URL;

--- a/.github/bot-scripts/answerFromDocs.cjs
+++ b/.github/bot-scripts/answerFromDocs.cjs
@@ -183,11 +183,19 @@ function checkSuppression(questionEmbedding, feedback, indexModel) {
 	/** @type {"allow" | "linksOnly" | "silent"} */
 	let result = "allow";
 	for (const entry of feedback.suppressed ?? []) {
+		// The cache could be stale or corrupted. Skip malformed entries,
+		// a mismatched vector length would yield NaN below
+		if (
+			!Array.isArray(entry.embedding)
+			|| entry.embedding.length !== questionEmbedding.length
+		) {
+			continue;
+		}
 		const similarity = cosineSimilarity(
 			questionEmbedding,
 			entry.embedding,
 		);
-		if (similarity < SUPPRESS_SIMILARITY) continue;
+		if (!(similarity >= SUPPRESS_SIMILARITY)) continue;
 		console.log(
 			`Question is similar (${
 				similarity.toFixed(3)

--- a/.github/bot-scripts/collectDocsAnswerFeedback.cjs
+++ b/.github/bot-scripts/collectDocsAnswerFeedback.cjs
@@ -1,0 +1,444 @@
+// @ts-check
+
+// Collects reactions to the docs answer bot's comments in issues and
+// discussions and computes a weighted feedback score per answer.
+// Reactions are the source of truth, so each run rescans the last
+// FEEDBACK_WINDOW_DAYS and recomputes everything from scratch.
+//
+// Usage: node collectDocsAnswerFeedback.cjs <index-file> <feedback-out> <records-out>
+// Requires GITHUB_TOKEN and GITHUB_REPOSITORY in the environment.
+//
+// <feedback-out> receives the suppression list (downvoted questions with
+// embeddings) consumed by answerFromDocs.cjs, <records-out> the full
+// feedback records consumed by updateDocsFeedbackIssue.cjs.
+
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const {
+	cleanQuestion,
+	DOCS_ANSWER_COMMENT_TAG,
+	DOCS_ANSWER_METADATA_TAG,
+	DOCS_ANSWER_METADATA_VERSION,
+	DOCS_BASE_URL,
+} = require("./answerFromDocs.cjs");
+const { embed } = require("./modelsApi.cjs");
+const { authorizedUsers } = require("./users.cjs");
+
+const BOT_USER = "zwave-js-bot";
+const SCAN_WINDOW_DAYS = Number(process.env.FEEDBACK_WINDOW_DAYS || "180");
+
+// Maintainers know best whether an answer is correct,
+// the post's author knows best whether it helped
+const MAINTAINER_WEIGHT = 5;
+const AUTHOR_WEIGHT = 2;
+const DEFAULT_WEIGHT = 1;
+
+// A single drive-by downvote does not suppress future answers,
+// a maintainer downvote or the author plus one other person does
+const SUPPRESS_SCORE = -3;
+
+// Reaction contents in REST ("+1") and GraphQL ("THUMBS_UP") notation
+/** @type {Record<string, number>} */
+const REACTION_SIGNS = {
+	"+1": 1,
+	heart: 1,
+	hooray: 1,
+	rocket: 1,
+	"-1": -1,
+	confused: -1,
+	THUMBS_UP: 1,
+	HEART: 1,
+	HOORAY: 1,
+	ROCKET: 1,
+	THUMBS_DOWN: -1,
+	CONFUSED: -1,
+};
+
+const API_BASE = "https://api.github.com";
+
+/**
+ * @param {string} pathAndQuery
+ * @param {string} token
+ * @returns {Promise<any>}
+ */
+async function ghGet(pathAndQuery, token) {
+	const response = await fetch(`${API_BASE}${pathAndQuery}`, {
+		headers: {
+			Accept: "application/vnd.github+json",
+			Authorization: `Bearer ${token}`,
+			"X-GitHub-Api-Version": "2022-11-28",
+		},
+	});
+	if (!response.ok) {
+		throw new Error(
+			`GitHub API request ${pathAndQuery} failed with status ${response.status}: ${await response
+				.text()
+				.catch(() => "")}`,
+		);
+	}
+	return response.json();
+}
+
+/**
+ * @param {string} query
+ * @param {object} variables
+ * @param {string} token
+ * @returns {Promise<any>}
+ */
+async function ghGraphql(query, variables, token) {
+	const response = await fetch(`${API_BASE}/graphql`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	const result = await response.json();
+	if (!response.ok || result.errors) {
+		throw new Error(
+			`GitHub GraphQL request failed: ${
+				JSON.stringify(result.errors ?? result)
+			}`,
+		);
+	}
+	return result.data;
+}
+
+/**
+ * Extracts the metadata the bot embeds in its answer comments.
+ * Comments from before the metadata tag existed fall back to
+ * parsing the doc links from the comment body.
+ * @param {string} body
+ * @returns {{style: string, confidence: number | null, sections: string[]}}
+ */
+function parseAnswerMetadata(body) {
+	const match = body.match(
+		new RegExp(`<!-- ${DOCS_ANSWER_METADATA_TAG} (\\{.*?\\}) -->`),
+	);
+	if (match) {
+		try {
+			const metadata = JSON.parse(match[1]);
+			// Fields of unknown metadata versions may not mean the same
+			if (metadata.v === DOCS_ANSWER_METADATA_VERSION) {
+				return {
+					style: metadata.style ?? "answer",
+					confidence: metadata.confidence ?? null,
+					sections: metadata.sections ?? [],
+				};
+			}
+		} catch {
+			// Fall through to link parsing
+		}
+	}
+
+	/** @type {string[]} */
+	const sections = [];
+	const linkRegex = new RegExp(
+		`\\]\\(${DOCS_BASE_URL}/([^)?]*)(?:\\?id=([^)]*))?\\)`,
+		"g",
+	);
+	for (const link of body.matchAll(linkRegex)) {
+		// chunkUrl() strips (README|index).md, assume README.md for bare paths
+		const file = link[1].endsWith("/") || link[1] === ""
+			? `${link[1]}README.md`
+			: `${link[1]}.md`;
+		sections.push(`${file}#${link[2] ?? ""}`);
+	}
+	return { style: "answer", confidence: null, sections };
+}
+
+/**
+ * @param {string} login
+ * @param {string} postAuthor
+ */
+function reactionWeight(login, postAuthor) {
+	if (
+		authorizedUsers.some((u) => u.toLowerCase() === login.toLowerCase())
+	) {
+		return MAINTAINER_WEIGHT;
+	}
+	if (login.toLowerCase() === postAuthor.toLowerCase()) {
+		return AUTHOR_WEIGHT;
+	}
+	return DEFAULT_WEIGHT;
+}
+
+/**
+ * Turns raw reactions into weighted votes and a net score
+ * @param {{user: string, content: string}[]} reactions
+ * @param {string} postAuthor
+ */
+function scoreReactions(reactions, postAuthor) {
+	const votes = [];
+	let score = 0;
+	for (const { user, content } of reactions) {
+		const sign = REACTION_SIGNS[content];
+		if (!sign || !user || user.endsWith("[bot]")) continue;
+		const weight = reactionWeight(user, postAuthor);
+		votes.push({ user, content, weight: sign * weight });
+		score += sign * weight;
+	}
+	return { votes, score };
+}
+
+/**
+ * @typedef {object} FeedbackRecord
+ * @property {"issue" | "discussion"} type
+ * @property {string} postUrl
+ * @property {string} commentUrl
+ * @property {string} title
+ * @property {string} author
+ * @property {string} question
+ * @property {string} style
+ * @property {number | null} confidence
+ * @property {string[]} sections
+ * @property {{user: string, content: string, weight: number}[]} votes
+ * @property {number} score
+ */
+
+/**
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} since yyyy-mm-dd
+ * @param {string} token
+ * @returns {Promise<FeedbackRecord[]>}
+ */
+async function collectFromIssues(owner, repo, since, token) {
+	/** @type {FeedbackRecord[]} */
+	const records = [];
+
+	const query = encodeURIComponent(
+		`repo:${owner}/${repo} is:issue commenter:${BOT_USER} updated:>=${since}`,
+	);
+	/** @type {any[]} */
+	const issues = [];
+	for (let page = 1;; page++) {
+		const result = await ghGet(
+			`/search/issues?q=${query}&per_page=100&page=${page}`,
+			token,
+		);
+		issues.push(...result.items);
+		if (issues.length >= result.total_count || result.items.length === 0) {
+			break;
+		}
+	}
+
+	for (const issue of issues) {
+		/** @type {any[]} */
+		const comments = await ghGet(
+			`/repos/${owner}/${repo}/issues/${issue.number}/comments?per_page=100`,
+			token,
+		);
+		const answers = comments.filter((c) =>
+			c.user?.login === BOT_USER
+			&& c.body?.includes(DOCS_ANSWER_COMMENT_TAG)
+		);
+		for (const answer of answers) {
+			/** @type {{user: string, content: string}[]} */
+			let reactions = [];
+			if (answer.reactions?.total_count > 0) {
+				/** @type {any[]} */
+				const raw = await ghGet(
+					`/repos/${owner}/${repo}/issues/comments/${answer.id}/reactions?per_page=100`,
+					token,
+				);
+				reactions = raw.map((r) => ({
+					user: r.user?.login ?? "",
+					content: r.content,
+				}));
+			}
+			const author = issue.user?.login ?? "";
+			const { votes, score } = scoreReactions(reactions, author);
+			records.push({
+				type: "issue",
+				postUrl: issue.html_url,
+				commentUrl: answer.html_url,
+				title: issue.title,
+				author,
+				question: cleanQuestion(issue.title, issue.body ?? ""),
+				...parseAnswerMetadata(answer.body),
+				votes,
+				score,
+			});
+		}
+	}
+
+	return records;
+}
+
+/**
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} since yyyy-mm-dd
+ * @param {string} token
+ * @returns {Promise<FeedbackRecord[]>}
+ */
+async function collectFromDiscussions(owner, repo, since, token) {
+	/** @type {FeedbackRecord[]} */
+	const records = [];
+
+	const searchQuery =
+		`repo:${owner}/${repo} commenter:${BOT_USER} updated:>=${since}`;
+	let cursor = null;
+	for (;;) {
+		const data = await ghGraphql(
+			`
+			query search($searchQuery: String!, $cursor: String) {
+				search(type: DISCUSSION, query: $searchQuery, first: 25, after: $cursor) {
+					pageInfo { hasNextPage endCursor }
+					nodes {
+						... on Discussion {
+							title
+							body
+							url
+							author { login }
+							comments(first: 50) {
+								nodes {
+									body
+									url
+									author { login }
+									reactions(first: 100) {
+										nodes {
+											content
+											user { login }
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			`,
+			{ searchQuery, cursor },
+			token,
+		);
+
+		for (const discussion of data.search.nodes) {
+			const answers = (discussion.comments?.nodes ?? []).filter(
+				(/** @type {any} */ c) =>
+					c.author?.login === BOT_USER
+					&& c.body?.includes(DOCS_ANSWER_COMMENT_TAG),
+			);
+			for (const answer of answers) {
+				const reactions = (answer.reactions?.nodes ?? []).map(
+					(/** @type {any} */ r) => ({
+						user: r.user?.login ?? "",
+						content: r.content,
+					}),
+				);
+				const author = discussion.author?.login ?? "";
+				const { votes, score } = scoreReactions(reactions, author);
+				records.push({
+					type: "discussion",
+					postUrl: discussion.url,
+					commentUrl: answer.url,
+					title: discussion.title,
+					author,
+					question: cleanQuestion(
+						discussion.title,
+						discussion.body ?? "",
+					),
+					...parseAnswerMetadata(answer.body),
+					votes,
+					score,
+				});
+			}
+		}
+
+		if (!data.search.pageInfo.hasNextPage) break;
+		cursor = data.search.pageInfo.endCursor;
+	}
+
+	return records;
+}
+
+/**
+ * Collects all feedback on bot answers within the scan window
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} token
+ * @returns {Promise<FeedbackRecord[]>}
+ */
+async function collectFeedback(owner, repo, token) {
+	const since = new Date(Date.now() - SCAN_WINDOW_DAYS * 86_400_000)
+		.toISOString()
+		.slice(0, 10);
+	console.log(`Collecting feedback on bot answers since ${since}...`);
+
+	const records = [
+		...await collectFromIssues(owner, repo, since, token),
+		...await collectFromDiscussions(owner, repo, since, token),
+	];
+	console.log(
+		`Found ${records.length} bot answers, ${
+			records.filter((r) => r.votes.length > 0).length
+		} with feedback`,
+	);
+	return records;
+}
+
+async function main() {
+	const [indexFile, feedbackOut, recordsOut] = process.argv.slice(2);
+	if (!indexFile || !feedbackOut || !recordsOut) {
+		console.error(
+			"Usage: node collectDocsAnswerFeedback.cjs <index-file> <feedback-out> <records-out>",
+		);
+		process.exit(1);
+	}
+	const token = process.env.GITHUB_TOKEN;
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!token || !repository) {
+		console.error(
+			"GITHUB_TOKEN and GITHUB_REPOSITORY environment variables are required",
+		);
+		process.exit(1);
+	}
+	const [owner, repo] = repository.split("/");
+
+	const index = JSON.parse(await fs.readFile(indexFile, "utf8"));
+	const records = await collectFeedback(owner, repo, token);
+
+	await fs.mkdir(path.dirname(recordsOut), { recursive: true });
+	await fs.writeFile(recordsOut, JSON.stringify(records, undefined, "\t"));
+
+	// The suppression list makes answerFromDocs.cjs demote responses
+	// to questions similar to these. Embed with the same model as the
+	// docs index so the runtime similarity comparison is valid.
+	const downvoted = records.filter((r) => r.score <= SUPPRESS_SCORE);
+	const embeddings = downvoted.length > 0
+		? await embed(downvoted.map((r) => r.question), token, index.model)
+		: [];
+	const feedback = {
+		createdAt: new Date().toISOString(),
+		model: index.model,
+		suppressed: downvoted.map((r, i) => ({
+			question: r.question,
+			embedding: embeddings[i],
+			style: r.style,
+			score: r.score,
+			url: r.commentUrl,
+		})),
+	};
+	await fs.mkdir(path.dirname(feedbackOut), { recursive: true });
+	await fs.writeFile(feedbackOut, JSON.stringify(feedback));
+	console.log(
+		`Wrote ${downvoted.length} suppression entries to ${feedbackOut}`,
+	);
+}
+
+if (require.main === module) {
+	main().catch((e) => {
+		console.error(e);
+		process.exit(1);
+	});
+}
+
+module.exports = {
+	collectFeedback,
+	parseAnswerMetadata,
+	scoreReactions,
+	SUPPRESS_SCORE,
+	SCAN_WINDOW_DAYS,
+};

--- a/.github/bot-scripts/collectDocsAnswerFeedback.cjs
+++ b/.github/bot-scripts/collectDocsAnswerFeedback.cjs
@@ -134,20 +134,19 @@ function parseAnswerMetadata(body) {
 
 	/** @type {string[]} */
 	const sections = [];
-	const escapedBaseUrl = DOCS_BASE_URL.replace(
-		/[.*+?^${}()|[\]\\]/g,
-		"\\$&",
-	);
-	const linkRegex = new RegExp(
-		`\\]\\(${escapedBaseUrl}/([^)?]*)(?:\\?id=([^)]*))?\\)`,
-		"g",
-	);
-	for (const link of body.matchAll(linkRegex)) {
+	// Match any markdown link target and filter by string prefix
+	// so the URL never needs to be escaped into a regex
+	for (const [, target] of body.matchAll(/\]\(([^)\s]+)\)/g)) {
+		if (!target.startsWith(`${DOCS_BASE_URL}/`)) continue;
+		const [docPath, query] = target
+			.slice(DOCS_BASE_URL.length + 1)
+			.split("?");
+		const anchor = query?.match(/(?:^|&)id=([^&]*)/)?.[1] ?? "";
 		// chunkUrl() strips (README|index).md, assume README.md for bare paths
-		const file = link[1].endsWith("/") || link[1] === ""
-			? `${link[1]}README.md`
-			: `${link[1]}.md`;
-		sections.push(`${file}#${link[2] ?? ""}`);
+		const file = docPath.endsWith("/") || docPath === ""
+			? `${docPath}README.md`
+			: `${docPath}.md`;
+		sections.push(`${file}#${anchor}`);
 	}
 	return { style: "answer", confidence: null, sections };
 }

--- a/.github/bot-scripts/collectDocsAnswerFeedback.cjs
+++ b/.github/bot-scripts/collectDocsAnswerFeedback.cjs
@@ -134,8 +134,12 @@ function parseAnswerMetadata(body) {
 
 	/** @type {string[]} */
 	const sections = [];
+	const escapedBaseUrl = DOCS_BASE_URL.replace(
+		/[.*+?^${}()|[\]\\]/g,
+		"\\$&",
+	);
 	const linkRegex = new RegExp(
-		`\\]\\(${DOCS_BASE_URL}/([^)?]*)(?:\\?id=([^)]*))?\\)`,
+		`\\]\\(${escapedBaseUrl}/([^)?]*)(?:\\?id=([^)]*))?\\)`,
 		"g",
 	);
 	for (const link of body.matchAll(linkRegex)) {
@@ -226,10 +230,16 @@ async function collectFromIssues(owner, repo, since, token) {
 
 	for (const issue of issues) {
 		/** @type {any[]} */
-		const comments = await ghGet(
-			`/repos/${owner}/${repo}/issues/${issue.number}/comments?per_page=100`,
-			token,
-		);
+		const comments = [];
+		for (let page = 1;; page++) {
+			/** @type {any[]} */
+			const batch = await ghGet(
+				`/repos/${owner}/${repo}/issues/${issue.number}/comments?per_page=100&page=${page}`,
+				token,
+			);
+			comments.push(...batch);
+			if (batch.length < 100) break;
+		}
 		const answers = comments.filter((c) =>
 			c.user?.login === BOT_USER
 			&& c.body?.includes(DOCS_ANSWER_COMMENT_TAG)
@@ -289,11 +299,13 @@ async function collectFromDiscussions(owner, repo, since, token) {
 					pageInfo { hasNextPage endCursor }
 					nodes {
 						... on Discussion {
+							id
 							title
 							body
 							url
 							author { login }
-							comments(first: 50) {
+							comments(first: 100) {
+								pageInfo { hasNextPage endCursor }
 								nodes {
 									body
 									url
@@ -316,7 +328,41 @@ async function collectFromDiscussions(owner, repo, since, token) {
 		);
 
 		for (const discussion of data.search.nodes) {
-			const answers = (discussion.comments?.nodes ?? []).filter(
+			const comments = [...(discussion.comments?.nodes ?? [])];
+			// Fetch remaining comment pages of busy discussions
+			let commentsPage = discussion.comments?.pageInfo;
+			while (commentsPage?.hasNextPage) {
+				const more = await ghGraphql(
+					`
+					query moreComments($id: ID!, $cursor: String) {
+						node(id: $id) {
+							... on Discussion {
+								comments(first: 100, after: $cursor) {
+									pageInfo { hasNextPage endCursor }
+									nodes {
+										body
+										url
+										author { login }
+										reactions(first: 100) {
+											nodes {
+												content
+												user { login }
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					`,
+					{ id: discussion.id, cursor: commentsPage.endCursor },
+					token,
+				);
+				comments.push(...(more.node?.comments?.nodes ?? []));
+				commentsPage = more.node?.comments?.pageInfo;
+			}
+
+			const answers = comments.filter(
 				(/** @type {any} */ c) =>
 					c.author?.login === BOT_USER
 					&& c.body?.includes(DOCS_ANSWER_COMMENT_TAG),
@@ -410,21 +456,32 @@ async function main() {
 	const embeddings = downvoted.length > 0
 		? await embed(downvoted.map((r) => r.question), token, index.model)
 		: [];
-	const feedback = {
-		createdAt: new Date().toISOString(),
-		model: index.model,
-		suppressed: downvoted.map((r, i) => ({
+	const suppressed = downvoted
+		.map((r, i) => ({
 			question: r.question,
 			embedding: embeddings[i],
 			style: r.style,
 			score: r.score,
 			url: r.commentUrl,
-		})),
+		}))
+		// Guard against the embeddings response missing entries
+		.filter((e) => Array.isArray(e.embedding));
+	if (suppressed.length < downvoted.length) {
+		console.log(
+			`Dropped ${
+				downvoted.length - suppressed.length
+			} entries without embedding`,
+		);
+	}
+	const feedback = {
+		createdAt: new Date().toISOString(),
+		model: index.model,
+		suppressed,
 	};
 	await fs.mkdir(path.dirname(feedbackOut), { recursive: true });
 	await fs.writeFile(feedbackOut, JSON.stringify(feedback));
 	console.log(
-		`Wrote ${downvoted.length} suppression entries to ${feedbackOut}`,
+		`Wrote ${suppressed.length} suppression entries to ${feedbackOut}`,
 	);
 }
 

--- a/.github/bot-scripts/updateDocsFeedbackIssue.cjs
+++ b/.github/bot-scripts/updateDocsFeedbackIssue.cjs
@@ -1,0 +1,249 @@
+// @ts-check
+
+// Renders the collected feedback on docs answer bot comments into a
+// digest and maintains it as the body of a dedicated issue, giving
+// maintainers insight into which answers work and where the docs
+// need improvement. The body is rewritten in place on every run.
+//
+// Usage: node updateDocsFeedbackIssue.cjs <records-file>
+// Requires GITHUB_TOKEN and GITHUB_REPOSITORY in the environment.
+// With DRY_RUN=true, the rendered body is logged instead of posted.
+
+const fs = require("node:fs/promises");
+const {
+	SCAN_WINDOW_DAYS,
+	SUPPRESS_SCORE,
+} = require("./collectDocsAnswerFeedback.cjs");
+
+const ISSUE_TITLE = "📊 Docs answer bot feedback";
+const ISSUE_MARKER = "<!-- DOCS_FEEDBACK_ISSUE -->";
+// The label narrows the digest issue lookup to a handful of candidates,
+// searching by creator alone could exceed a single page of results
+const ISSUE_LABEL = "docs-feedback";
+
+// Keep suggested eval cases (and the issue body) readable
+const MAX_EVAL_QUESTION_LENGTH = 300;
+
+const API_BASE = "https://api.github.com";
+
+/**
+ * @param {string} method
+ * @param {string} pathAndQuery
+ * @param {object | undefined} body
+ * @param {string} token
+ * @returns {Promise<any>}
+ */
+async function ghRequest(method, pathAndQuery, body, token) {
+	const response = await fetch(`${API_BASE}${pathAndQuery}`, {
+		method,
+		headers: {
+			Accept: "application/vnd.github+json",
+			Authorization: `Bearer ${token}`,
+			"X-GitHub-Api-Version": "2022-11-28",
+		},
+		body: body && JSON.stringify(body),
+	});
+	if (!response.ok) {
+		throw new Error(
+			`GitHub API request ${method} ${pathAndQuery} failed with status ${response.status}: ${await response
+				.text()
+				.catch(() => "")}`,
+		);
+	}
+	return response.json();
+}
+
+/**
+ * Summarizes the votes as anonymous weighted counts
+ * @param {import("./collectDocsAnswerFeedback.cjs").FeedbackRecord} record
+ */
+function renderVotes(record) {
+	const up = record.votes.filter((v) => v.weight > 0);
+	const down = record.votes.filter((v) => v.weight < 0);
+	const parts = [];
+	if (up.length > 0) {
+		parts.push(
+			`${up.length}× 👍 (+${up.reduce((sum, v) => sum + v.weight, 0)})`,
+		);
+	}
+	if (down.length > 0) {
+		parts.push(
+			`${down.length}× 👎 (${
+				down.reduce((sum, v) => sum + v.weight, 0)
+			})`,
+		);
+	}
+	return parts.join(", ");
+}
+
+/**
+ * @param {import("./collectDocsAnswerFeedback.cjs").FeedbackRecord} record
+ */
+function renderRecord(record) {
+	const lines = [
+		`### [${record.title}](${record.postUrl}) — score ${
+			record.score > 0 ? "+" : ""
+		}${record.score}`,
+		`[Bot answer](${record.commentUrl})${
+			record.style === "links" ? " (links only)" : ""
+		}${
+			record.confidence != null
+				? `, confidence ${record.confidence}`
+				: ""
+		}`,
+		`Votes: ${renderVotes(record)}`,
+	];
+	if (record.sections.length > 0) {
+		lines.push(
+			`Linked sections: ${
+				record.sections.map((s) => `\`${s}\``).join(", ")
+			}`,
+		);
+	}
+	if (record.score <= SUPPRESS_SCORE) {
+		lines.push(
+			"🚫 Suppressed: similar questions currently get a demoted response",
+		);
+	}
+	return lines.join("\n");
+}
+
+/**
+ * Renders a ready-to-paste eval case for docsAnswersEvalCases.json
+ * @param {import("./collectDocsAnswerFeedback.cjs").FeedbackRecord} record
+ */
+function renderEvalCase(record) {
+	const evalCase = {
+		question: record.question.slice(0, MAX_EVAL_QUESTION_LENGTH),
+		expectedFiles: [
+			...new Set(record.sections.map((s) => s.split("#")[0])),
+		],
+	};
+	return `<details><summary>Suggested eval case</summary>
+
+\`\`\`json
+${JSON.stringify(evalCase, undefined, "\t")}
+\`\`\`
+
+</details>`;
+}
+
+/**
+ * @param {import("./collectDocsAnswerFeedback.cjs").FeedbackRecord[]} records
+ */
+function renderDigest(records) {
+	const withFeedback = records.filter((r) => r.votes.length > 0);
+	const good = withFeedback
+		.filter((r) => r.score > 0)
+		.sort((a, b) => b.score - a.score);
+	const bad = withFeedback
+		.filter((r) => r.score < 0)
+		.sort((a, b) => a.score - b.score);
+
+	const sections = [
+		ISSUE_MARKER,
+		`_Automatically generated from reactions to the bot's answers in issues and discussions over the last ${SCAN_WINDOW_DAYS} days. Maintainer votes count ×5, the question author's ×2. Last updated: ${
+			new Date().toISOString().slice(0, 10)
+		}_`,
+		`## Summary
+
+- ${records.length} answers posted, ${withFeedback.length} with feedback
+- ${good.length} rated helpful, ${bad.length} rated unhelpful`,
+	];
+
+	if (bad.length > 0) {
+		sections.push(
+			`## Needs attention
+
+Negative feedback usually means the linked documentation did not answer the question — these are candidates for docs improvements.
+
+${bad.map(renderRecord).join("\n\n")}`,
+		);
+	}
+
+	if (good.length > 0) {
+		sections.push(
+			`## Confirmed good
+
+These answers were rated helpful. Consider curating them into \`docsAnswersEvalCases.json\` to lock in the retrieval quality.
+
+${good.map((r) => `${renderRecord(r)}\n${renderEvalCase(r)}`).join("\n\n")}`,
+		);
+	}
+
+	return sections.join("\n\n");
+}
+
+/**
+ * Creates the digest issue or rewrites its body in place
+ * @param {import("./collectDocsAnswerFeedback.cjs").FeedbackRecord[]} records
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} token
+ */
+async function updateFeedbackIssue(records, owner, repo, token) {
+	const body = renderDigest(records);
+
+	if (process.env.DRY_RUN === "true") {
+		console.log("DRY RUN - would set the following issue body:");
+		console.log(body);
+		return;
+	}
+
+	// The marker identifies the digest issue regardless of its title
+	/** @type {any[]} */
+	const candidates = await ghRequest(
+		"GET",
+		`/repos/${owner}/${repo}/issues?labels=${ISSUE_LABEL}&state=all&per_page=100`,
+		undefined,
+		token,
+	);
+	const existing = candidates.find((i) => i.body?.includes(ISSUE_MARKER));
+
+	if (existing) {
+		await ghRequest(
+			"PATCH",
+			`/repos/${owner}/${repo}/issues/${existing.number}`,
+			{ body, state: "open" },
+			token,
+		);
+		console.log(`Updated feedback digest in issue #${existing.number}`);
+	} else {
+		const created = await ghRequest(
+			"POST",
+			`/repos/${owner}/${repo}/issues`,
+			{ title: ISSUE_TITLE, body, labels: [ISSUE_LABEL] },
+			token,
+		);
+		console.log(`Created feedback digest issue #${created.number}`);
+	}
+}
+
+async function main() {
+	const [recordsFile] = process.argv.slice(2);
+	if (!recordsFile) {
+		console.error("Usage: node updateDocsFeedbackIssue.cjs <records-file>");
+		process.exit(1);
+	}
+	const token = process.env.GITHUB_TOKEN;
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!token || !repository) {
+		console.error(
+			"GITHUB_TOKEN and GITHUB_REPOSITORY environment variables are required",
+		);
+		process.exit(1);
+	}
+	const [owner, repo] = repository.split("/");
+
+	const records = JSON.parse(await fs.readFile(recordsFile, "utf8"));
+	await updateFeedbackIssue(records, owner, repo, token);
+}
+
+if (require.main === module) {
+	main().catch((e) => {
+		console.error(e);
+		process.exit(1);
+	});
+}
+
+module.exports = { renderDigest, updateFeedbackIssue };

--- a/.github/bot-scripts/updateDocsFeedbackIssue.cjs
+++ b/.github/bot-scripts/updateDocsFeedbackIssue.cjs
@@ -54,6 +54,15 @@ async function ghRequest(method, pathAndQuery, body, token) {
 }
 
 /**
+ * Keeps user-controlled text from pinging people via @mentions
+ * by inserting a zero-width space after each @
+ * @param {string} text
+ */
+function neutralizeMentions(text) {
+	return text.replace(/@/g, "@\u200b");
+}
+
+/**
  * Summarizes the votes as anonymous weighted counts
  * @param {import("./collectDocsAnswerFeedback.cjs").FeedbackRecord} record
  */
@@ -81,7 +90,7 @@ function renderVotes(record) {
  */
 function renderRecord(record) {
 	const lines = [
-		`### [${record.title}](${record.postUrl}) — score ${
+		`### [${neutralizeMentions(record.title)}](${record.postUrl}) — score ${
 			record.score > 0 ? "+" : ""
 		}${record.score}`,
 		`[Bot answer](${record.commentUrl})${
@@ -192,12 +201,18 @@ async function updateFeedbackIssue(records, owner, repo, token) {
 
 	// The marker identifies the digest issue regardless of its title
 	/** @type {any[]} */
-	const candidates = await ghRequest(
-		"GET",
-		`/repos/${owner}/${repo}/issues?labels=${ISSUE_LABEL}&state=all&per_page=100`,
-		undefined,
-		token,
-	);
+	const candidates = [];
+	for (let page = 1;; page++) {
+		/** @type {any[]} */
+		const batch = await ghRequest(
+			"GET",
+			`/repos/${owner}/${repo}/issues?labels=${ISSUE_LABEL}&state=all&per_page=100&page=${page}`,
+			undefined,
+			token,
+		);
+		candidates.push(...batch);
+		if (batch.length < 100) break;
+	}
 	const existing = candidates.find((i) => i.body?.includes(ISSUE_MARKER));
 
 	if (existing) {

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -133,3 +133,49 @@ jobs:
               state: "closed",
             });
           }
+
+  # Learn from reactions to the bot's answers: update the feedback
+  # digest issue and build the suppression list for the answer bot
+  feedback:
+    needs: build-index
+    runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
+      models: read
+      issues: write
+      discussions: read
+
+    steps:
+    - name: Checkout master branch
+      uses: actions/checkout@v6
+
+    - name: Restore docs index
+      id: restore-index
+      uses: actions/cache/restore@v4
+      with:
+        path: .docs-index
+        key: docs-embeddings-v1-${{ hashFiles('docs/**/*.md') }}
+        restore-keys: |
+          docs-embeddings-v1-
+
+    - name: Collect feedback on bot answers
+      if: steps.restore-index.outputs.cache-matched-key != ''
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: node .github/bot-scripts/collectDocsAnswerFeedback.cjs .docs-index/index.json .docs-feedback/feedback.json .docs-feedback/records.json
+
+    - name: Update feedback digest issue
+      if: steps.restore-index.outputs.cache-matched-key != ''
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        DRY_RUN: ${{ vars.DOCS_ANSWER_DRY_RUN }}
+      run: node .github/bot-scripts/updateDocsFeedbackIssue.cjs .docs-feedback/records.json
+
+    # A per-run key means every nightly run saves a fresh entry,
+    # the answer bot restores the latest one by prefix
+    - name: Save suppression list for the answer bot
+      if: steps.restore-index.outputs.cache-matched-key != ''
+      uses: actions/cache/save@v4
+      with:
+        path: .docs-feedback/feedback.json
+        key: docs-feedback-v1-${{ github.run_id }}

--- a/.github/workflows/zwave-js-bot_issue.yml
+++ b/.github/workflows/zwave-js-bot_issue.yml
@@ -203,12 +203,23 @@ jobs:
         restore-keys: |
           docs-embeddings-v1-
 
+    # Downvoted answers collected by the docs-embeddings workflow.
+    # A missing cache just means no suppression is applied.
+    - name: Restore answer feedback
+      uses: actions/cache/restore@v4
+      with:
+        path: .docs-feedback/feedback.json
+        key: docs-feedback-v1-
+        restore-keys: |
+          docs-feedback-v1-
+
     - name: Answer from documentation
       if: steps.restore-index.outputs.cache-matched-key != ''
       uses: actions/github-script@v9
       env:
         MODELS_TOKEN: ${{ github.token }}
         DOCS_INDEX_PATH: .docs-index/index.json
+        DOCS_FEEDBACK_PATH: .docs-feedback/feedback.json
         DRY_RUN: ${{ vars.DOCS_ANSWER_DRY_RUN }}
       with:
         github-token: ${{ secrets.BOT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ test/*_logrotate.json
 test/zwavejs_*.log
 .DS_Store
 .docs-index/
+.docs-feedback/


### PR DESCRIPTION
The bot now learns from 👍/👎 reactions to its docs answers (follow-up to #8937).

### How it works

- Answer comments now invite reactions and embed hidden metadata (style, confidence, linked sections)
- A nightly job in `docs-embeddings.yml` rescans all bot answers from the last 180 days and scores their reactions — maintainer votes count ×5, the question author's ×2, others ×1. No stored state: reactions are the source of truth, so removing a reaction heals immediately
- The results are published to a label-tracked, always-open digest issue (rewritten in place, no user mentions): downvoted answers as docs-improvement candidates, upvoted ones with ready-to-paste eval cases for `docsAnswersEvalCases.json`
- Answers with score ≤ −3 form a suppression list (question embeddings, passed via `actions/cache`): new questions ≥ 0.9 cosine similarity to a downvoted one get a demoted response — full answer → links only, links only → silence. Suppressions age out with the scan window, giving improved docs another chance