### PR TITLE
feat: add high-level API for interacting with indicators

### DIFF
--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -948,6 +948,8 @@ Z-Wave JS provides a high-level API for controlling the indicators of a device, 
 The indicators API is accessed via the `indicators` property on endpoints and nodes. The property is `undefined` when the endpoint does not support the **Indicator CC**, so use it as the support check:
 
 ```ts
+import { Indicator } from "@zwave-js/core";
+
 if (endpoint.indicators) {
 	await endpoint.indicators.set(Indicator["Button 1 indication"], {
 		on: true,

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -940,3 +940,164 @@ enum UserCredentialLearnStatus {
 	InvalidModifyOperationType = 0xff,
 }
 ```
+
+## Indicators
+
+Z-Wave JS provides a high-level API for controlling the indicators of a device, e.g. LEDs, an LCD backlight or a buzzer. It abstracts away the complexity of the **Indicator CC**, where the functionality of each indicator is split into multiple properties that need to be set in groups.
+
+The indicators API is accessed via the `indicators` property on endpoints and nodes. The property is `undefined` when the endpoint does not support the **Indicator CC**, so use it as the support check:
+
+```ts
+if (endpoint.indicators) {
+	await endpoint.indicators.set(Indicator["Button 1 indication"], {
+		on: true,
+	});
+}
+```
+
+The state of an indicator is represented as a whole:
+
+<!-- #import IndicatorState from "@zwave-js/cc" -->
+
+```ts
+interface IndicatorState {
+	/** Whether the indicator is on or off */
+	on?: boolean;
+	/** The level of a multilevel indicator (0-99) */
+	level?: number;
+	blink?: IndicatorBlink;
+	/** Timeout after which the indicator will be turned off. When setting, a string in the form `12h18m17.59s` is also accepted. */
+	timeout?: IndicatorTimeout | string;
+	/** The volume of an audible indicator (0-100). 0 means off/mute. */
+	soundLevel?: number;
+}
+```
+
+<!-- #import IndicatorBlink from "@zwave-js/cc" -->
+
+```ts
+interface IndicatorBlink {
+	/** Duration of one on/off period in seconds (0.1-25.5) */
+	period: number;
+	/** Number of on/off periods (1-254). `undefined` means the indicator blinks until turned off. */
+	cycles?: number;
+	/** On time within an on/off period in seconds. `undefined` means symmetric (on time equals off time). */
+	onTime?: number;
+}
+```
+
+<!-- #import IndicatorTimeout from "@zwave-js/cc" -->
+
+```ts
+interface IndicatorTimeout {
+	/** Whole hours (0-255) */
+	hours?: number;
+	/** Whole minutes (0-255) */
+	minutes?: number;
+	/** Whole and 1/100th seconds (0-59.99) */
+	seconds?: number;
+}
+```
+
+> [!NOTE] Nodes that only support V1 of the **Indicator CC** expose a single unspecified indicator with the ID `0`, which can only be turned on and off.
+
+### Querying indicator capabilities
+
+#### `getSupportedCached`
+
+```ts
+getSupportedCached(): IndicatorCapabilities[]
+```
+
+Returns the capabilities of all indicators the endpoint supports. This method uses cached information from the most recent interview.
+
+<!-- #import IndicatorCapabilities from "zwave-js" -->
+
+```ts
+interface IndicatorCapabilities {
+	/** The ID of the indicator. 0 is the unspecified indicator of a V1 node. */
+	indicatorId: number;
+	/** A user-friendly label describing the indicator */
+	label: string;
+	/** Whether the indicator can be turned on and off */
+	supportsOnOff: boolean;
+	/** Whether the indicator can be set to a level between 0 and 99 */
+	supportsLevel: boolean;
+	/** Whether the indicator can blink */
+	supportsBlinking: boolean;
+	/** Whether the indicator can be turned off automatically after a timeout */
+	supportsTimeout: boolean;
+	/** Whether the volume of the indicator can be changed */
+	supportsSoundLevel: boolean;
+}
+```
+
+The `Node Identify` indicator is not included; it is controlled exclusively through the [`identify`](#identify) method.
+
+#### `getCapabilitiesCached`
+
+```ts
+getCapabilitiesCached(indicatorId: number): IndicatorCapabilities | undefined
+```
+
+Returns the capabilities of the given indicator, or `undefined` if it is not supported. This method uses cached information from the most recent interview.
+
+### Reading and changing the indicator state
+
+#### `get`
+
+```ts
+get(indicatorId: number): Promise<IndicatorState | undefined>
+```
+
+Queries the current state of the given indicator.
+
+> [!NOTE] This communicates with the node to retrieve fresh information.
+
+#### `getCached`
+
+```ts
+getCached(indicatorId: number): IndicatorState | undefined
+```
+
+Returns the last known state of the given indicator, or `undefined` if it is not known. This method uses cached information.
+
+#### `set`
+
+```ts
+set(indicatorId: number, state: IndicatorState): Promise<SupervisionResult | undefined>
+```
+
+Changes the state of the given indicator. All necessary properties are sent to the device in a single command.
+
+> [!WARNING] The state is applied as a whole: all aspects not included in the state are turned off. For example, setting only `level` stops an ongoing blinking pattern and clears a previously set timeout. This matches the required behavior of supporting devices.
+
+Aspects of the state that the indicator does not support at all are rejected with a `ZWaveError`, with one exception: `on` and `level` are converted automatically between binary and multilevel indicators.
+
+#### `identify`
+
+```ts
+identify(): Promise<SupervisionResult | undefined>
+```
+
+Instructs the node to identify itself, e.g. by blinking an LED. Supported by nodes implementing version 3 or higher of the **Indicator CC**.
+
+### Indicator events
+
+#### `"indicator updated"`
+
+```ts
+(endpoint: Endpoint, args: IndicatorUpdatedArgs) => void
+```
+
+Emitted on the `ZWaveNode` instance when a device reports a changed indicator state, e.g. after it was changed locally. The `args` object contains the updated state along with the indicator ID:
+
+<!-- #import IndicatorUpdatedArgs from "zwave-js" -->
+
+```ts
+interface IndicatorUpdatedArgs extends Omit<IndicatorState, "timeout"> {
+	/** The ID of the updated indicator. 0 is the unspecified indicator of a V1 node. */
+	indicatorId: number;
+	timeout?: IndicatorTimeout;
+}
+```

--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -49,7 +49,12 @@ import {
 	useSupervision,
 } from "../lib/CommandClassDecorators.js";
 import { V } from "../lib/Values.js";
-import { IndicatorCommand, type IndicatorTimeout } from "../lib/_Types.js";
+import {
+	type IndicatorBlink,
+	IndicatorCommand,
+	type IndicatorState,
+	type IndicatorTimeout,
+} from "../lib/_Types.js";
 import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
 
 function isManufacturerDefinedIndicator(indicatorId: number): boolean {
@@ -133,6 +138,294 @@ function indicatorObjectsToTimeout(
 	};
 }
 
+function rawIndicatorValue(value: number | boolean): number {
+	return value === true ? 0xff : value === false ? 0x00 : value;
+}
+
+function timeoutToIndicatorObjects(
+	indicatorId: number,
+	timeout: IndicatorTimeout,
+	supportedPropertyIDs: readonly number[] | undefined,
+): IndicatorObject[] {
+	const objects: IndicatorObject[] = [];
+	const hours = timeout.hours ?? 0;
+	const minutes = timeout.minutes ?? 0;
+	const seconds = Math.floor(timeout.seconds ?? 0);
+	const hundredths = Math.round(((timeout.seconds ?? 0) % 1) * 100);
+
+	if (hours) {
+		if (!supportedPropertyIDs?.includes(0x0a)) {
+			throw new ZWaveError(
+				`The indicator ${indicatorId} does not support setting the timeout in hours`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		objects.push({
+			indicatorId,
+			propertyId: 0x0a,
+			value: hours,
+		});
+	}
+
+	if (minutes) {
+		if (!supportedPropertyIDs?.includes(0x06)) {
+			throw new ZWaveError(
+				`The indicator ${indicatorId} does not support setting the timeout in minutes`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		objects.push({
+			indicatorId,
+			propertyId: 0x06,
+			value: minutes,
+		});
+	}
+
+	if (seconds) {
+		if (!supportedPropertyIDs?.includes(0x07)) {
+			throw new ZWaveError(
+				`The indicator ${indicatorId} does not support setting the timeout in seconds`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		objects.push({
+			indicatorId,
+			propertyId: 0x07,
+			value: seconds,
+		});
+	}
+
+	if (hundredths) {
+		if (!supportedPropertyIDs?.includes(0x08)) {
+			throw new ZWaveError(
+				`The indicator ${indicatorId} does not support setting the timeout in 1/100 seconds`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		objects.push({
+			indicatorId,
+			propertyId: 0x08,
+			value: hundredths,
+		});
+	}
+
+	return objects;
+}
+
+/**
+ * Converts the indicator objects of a single indicator ID into a complete map
+ * from property ID to raw value.
+ * @publicAPI
+ */
+export function indicatorObjectsToPropertyMap(
+	values: IndicatorObject[],
+	supportedPropertyIDs: readonly number[] | undefined,
+): Record<number, number> {
+	const ret: Record<number, number> = {};
+	if (supportedPropertyIDs?.length) {
+		// Properties not included in a command are assumed to be 0. Also some
+		// devices report properties they do not actually support - ignore those.
+		for (const propertyId of supportedPropertyIDs) {
+			ret[propertyId] = 0;
+		}
+		for (const value of values) {
+			if (supportedPropertyIDs.includes(value.propertyId)) {
+				ret[value.propertyId] = rawIndicatorValue(value.value);
+			}
+		}
+	} else {
+		// Without knowing the supported properties, preserve the report as-is
+		for (const value of values) {
+			ret[value.propertyId] = rawIndicatorValue(value.value);
+		}
+	}
+	return ret;
+}
+
+/**
+ * Converts a complete property map of an indicator into its normalized state
+ * @publicAPI
+ */
+export function indicatorPropertyMapToState(
+	map: Record<number, number>,
+	supportedPropertyIDs: readonly number[],
+): IndicatorState {
+	const supports = (propertyId: number) =>
+		supportedPropertyIDs.length
+			? supportedPropertyIDs.includes(propertyId)
+			: propertyId in map;
+
+	const ret: IndicatorState = {};
+
+	if (supports(0x02 /* Binary */)) {
+		ret.on = map[0x02] > 0;
+	} else if (supports(0x01 /* Multilevel */)) {
+		ret.on = map[0x01] > 0;
+	}
+	if (supports(0x01 /* Multilevel */)) {
+		ret.level = Math.min(map[0x01] ?? 0, 99);
+	}
+
+	if (
+		supports(0x03 /* On/Off Period */)
+		&& supports(0x04 /* On/Off Cycles */)
+		&& map[0x03] > 0
+	) {
+		const blink: IndicatorBlink = {
+			period: map[0x03] / 10,
+		};
+		if (map[0x04] > 0 && map[0x04] < 0xff) blink.cycles = map[0x04];
+		if (supports(0x05 /* On time */) && map[0x05] > 0) {
+			blink.onTime = map[0x05] / 10;
+		}
+		ret.blink = blink;
+	}
+
+	const timeout: IndicatorTimeout = {};
+	if (map[0x0a]) timeout.hours = map[0x0a];
+	if (map[0x06]) timeout.minutes = map[0x06];
+	const seconds = clamp(map[0x07] ?? 0, 0, 59)
+		+ clamp(map[0x08] ?? 0, 0, 99) / 100;
+	if (seconds) timeout.seconds = seconds;
+	if (Object.keys(timeout).length > 0) ret.timeout = timeout;
+
+	if (supports(0x09 /* Sound level */)) {
+		ret.soundLevel = map[0x09];
+	}
+
+	return ret;
+}
+
+/**
+ * Converts the normalized state of an indicator into indicator objects for a
+ * Set command. The state is applied as a whole: the device resets all
+ * properties not included in the resulting objects to 0.
+ * @publicAPI
+ */
+export function indicatorStateToObjects(
+	indicatorId: number,
+	state: IndicatorState,
+	supportedPropertyIDs: readonly number[],
+): IndicatorObject[] {
+	const supports = (propertyId: number) =>
+		supportedPropertyIDs.includes(propertyId);
+	const unsupported = (what: string): ZWaveError =>
+		new ZWaveError(
+			`The indicator ${indicatorId} does not support ${what}`,
+			ZWaveErrorCodes.Argument_Invalid,
+		);
+
+	const ret: IndicatorObject[] = [];
+
+	// Binary and Multilevel are mutually exclusive property groups,
+	// so only one of them is sent
+	if (state.on === false) {
+		if (supports(0x02 /* Binary */)) {
+			ret.push({ indicatorId, propertyId: 0x02, value: 0x00 });
+		} else if (supports(0x01 /* Multilevel */)) {
+			ret.push({ indicatorId, propertyId: 0x01, value: 0x00 });
+		} else {
+			throw unsupported("being turned on or off");
+		}
+	} else if (state.level != undefined) {
+		if (supports(0x01 /* Multilevel */)) {
+			ret.push({
+				indicatorId,
+				propertyId: 0x01,
+				value: clamp(state.level, 0, 99),
+			});
+		} else if (supports(0x02 /* Binary */)) {
+			ret.push({
+				indicatorId,
+				propertyId: 0x02,
+				value: state.level > 0 ? 0xff : 0x00,
+			});
+		} else {
+			throw unsupported("setting a level");
+		}
+	} else if (state.on) {
+		if (supports(0x02 /* Binary */)) {
+			ret.push({ indicatorId, propertyId: 0x02, value: 0xff });
+		} else if (supports(0x01 /* Multilevel */)) {
+			ret.push({ indicatorId, propertyId: 0x01, value: 0xff });
+		} else {
+			throw unsupported("being turned on or off");
+		}
+	}
+
+	if (state.blink) {
+		if (
+			!supports(0x03 /* On/Off Period */)
+			|| !supports(0x04 /* On/Off Cycles */)
+		) {
+			throw unsupported("blinking");
+		}
+		ret.push({
+			indicatorId,
+			propertyId: 0x03,
+			value: clamp(Math.round(state.blink.period * 10), 1, 255),
+		});
+		ret.push({
+			indicatorId,
+			propertyId: 0x04,
+			value: state.blink.cycles != undefined
+				? clamp(state.blink.cycles, 1, 254)
+				: 0xff,
+		});
+		if (state.blink.onTime != undefined) {
+			if (!supports(0x05 /* On time */)) {
+				throw unsupported("asymmetric on/off periods");
+			}
+			ret.push({
+				indicatorId,
+				propertyId: 0x05,
+				value: clamp(Math.round(state.blink.onTime * 10), 0, 255),
+			});
+		}
+	}
+
+	if (state.timeout != undefined) {
+		let timeout = state.timeout;
+		if (typeof timeout === "string") {
+			const parsed = parseIndicatorTimeoutString(timeout);
+			if (!parsed) {
+				throw new ZWaveError(
+					`The timeout string "${timeout}" is not valid`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			timeout = parsed;
+		}
+		ret.push(
+			...timeoutToIndicatorObjects(
+				indicatorId,
+				timeout,
+				supportedPropertyIDs,
+			),
+		);
+	}
+
+	if (state.soundLevel != undefined) {
+		if (!supports(0x09 /* Sound level */)) {
+			throw unsupported("setting a sound level");
+		}
+		ret.push({
+			indicatorId,
+			propertyId: 0x09,
+			value: clamp(state.soundLevel, 0, 100),
+		});
+	}
+
+	if (!ret.length) {
+		throw new ZWaveError(
+			`The given state for indicator ${indicatorId} is empty`,
+			ZWaveErrorCodes.Argument_Invalid,
+		);
+	}
+
+	return ret;
+}
+
 export const IndicatorCCValues = V.defineCCValues(CommandClasses.Indicator, {
 	...V.staticProperty("supportedIndicatorIds", undefined, {
 		internal: true,
@@ -168,6 +461,16 @@ export const IndicatorCCValues = V.defineCCValues(CommandClasses.Indicator, {
 			&& typeof propertyKey === "number",
 		undefined,
 		{ internal: true },
+	),
+	...V.dynamicPropertyAndKeyWithName(
+		"indicatorState",
+		"indicatorState",
+		(indicatorId: number) => indicatorId,
+		({ property, propertyKey }) =>
+			property === "indicatorState"
+			&& typeof propertyKey === "number",
+		undefined,
+		{ internal: true, minVersion: 2 },
 	),
 	...V.dynamicPropertyAndKeyWithName(
 		"valueV2",
@@ -646,69 +949,13 @@ export class IndicatorCCAPI extends CCAPI {
 			indicatorId,
 		);
 
-		const objects: IndicatorObject[] = [];
-		if (timeout) {
-			const hours = timeout.hours ?? 0;
-			const minutes = timeout.minutes ?? 0;
-			const seconds = Math.floor(timeout.seconds ?? 0);
-			const hundredths = Math.round(((timeout.seconds ?? 0) % 1) * 100);
-
-			if (hours) {
-				if (!supportedPropertyIDs?.includes(0x0a)) {
-					throw new ZWaveError(
-						`The indicator ${indicatorId} does not support setting the timeout in hours`,
-						ZWaveErrorCodes.Argument_Invalid,
-					);
-				}
-				objects.push({
-					indicatorId,
-					propertyId: 0x0a,
-					value: hours,
-				});
-			}
-
-			if (minutes) {
-				if (!supportedPropertyIDs?.includes(0x06)) {
-					throw new ZWaveError(
-						`The indicator ${indicatorId} does not support setting the timeout in minutes`,
-						ZWaveErrorCodes.Argument_Invalid,
-					);
-				}
-				objects.push({
-					indicatorId,
-					propertyId: 0x06,
-					value: minutes,
-				});
-			}
-
-			if (seconds) {
-				if (!supportedPropertyIDs?.includes(0x07)) {
-					throw new ZWaveError(
-						`The indicator ${indicatorId} does not support setting the timeout in seconds`,
-						ZWaveErrorCodes.Argument_Invalid,
-					);
-				}
-				objects.push({
-					indicatorId,
-					propertyId: 0x07,
-					value: seconds,
-				});
-			}
-
-			if (hundredths) {
-				if (!supportedPropertyIDs?.includes(0x08)) {
-					throw new ZWaveError(
-						`The indicator ${indicatorId} does not support setting the timeout in 1/100 seconds`,
-						ZWaveErrorCodes.Argument_Invalid,
-					);
-				}
-				objects.push({
-					indicatorId,
-					propertyId: 0x08,
-					value: hundredths,
-				});
-			}
-		}
+		const objects: IndicatorObject[] = timeout
+			? timeoutToIndicatorObjects(
+				indicatorId,
+				timeout,
+				supportedPropertyIDs,
+			)
+			: [];
 
 		if (!objects.length) {
 			objects.push(
@@ -1224,13 +1471,32 @@ export class IndicatorCCReport extends IndicatorCC {
 				}
 			}
 		} else if (this.values) {
-			// Store the simple values first
+			const groupedValues = groupByIndicatorId(this.values);
+
+			// Persist the full per-indicator state before setIndicatorValue
+			// converts the raw values to booleans in place
+			for (const [indicatorId, values] of groupedValues) {
+				if (indicatorId === Indicator["Node Identify"]) continue;
+				const supportedPropertyIDs = this.getValue<number[]>(
+					ctx,
+					IndicatorCCValues.supportedPropertyIDs(indicatorId),
+				);
+				this.setValue(
+					ctx,
+					IndicatorCCValues.indicatorState(indicatorId),
+					indicatorObjectsToPropertyMap(
+						values,
+						supportedPropertyIDs,
+					),
+				);
+			}
+
+			// Store the simple values
 			for (const value of this.values) {
 				this.setIndicatorValue(ctx, value);
 			}
 
 			// Then group values into the convenience properties
-			const groupedValues = groupByIndicatorId(this.values);
 			for (const [indicatorId, values] of groupedValues) {
 				// Some devices report all properties it supports in every report,
 				// even if it does not support all properties for the given indicator ID.

--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -148,10 +148,13 @@ function timeoutToIndicatorObjects(
 	supportedPropertyIDs: readonly number[] | undefined,
 ): IndicatorObject[] {
 	const objects: IndicatorObject[] = [];
-	const hours = timeout.hours ?? 0;
-	const minutes = timeout.minutes ?? 0;
-	const seconds = Math.floor(timeout.seconds ?? 0);
-	const hundredths = Math.round(((timeout.seconds ?? 0) % 1) * 100);
+	const hours = clamp(timeout.hours ?? 0, 0, 255);
+	const minutes = clamp(timeout.minutes ?? 0, 0, 255);
+	// Round to 2 decimals first, so seconds like 12.999 carry over into
+	// whole seconds instead of producing 100 hundredths
+	const totalSeconds = clamp(roundTo(timeout.seconds ?? 0, 2), 0, 59.99);
+	const seconds = Math.floor(totalSeconds);
+	const hundredths = Math.round((totalSeconds % 1) * 100);
 
 	if (hours) {
 		if (!supportedPropertyIDs?.includes(0x0a)) {

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -3669,6 +3669,45 @@ export const IndicatorCCValues = Object.freeze({
 			} as const satisfies CCValueOptions,
 		},
 	),
+	indicatorState: Object.assign(
+		(indicatorId: number) => {
+			const property = "indicatorState";
+			const propertyKey = indicatorId;
+
+			return {
+				id: {
+					commandClass: CommandClasses.Indicator,
+					property,
+					propertyKey,
+				} as const,
+				endpoint: (endpoint: number = 0) => ({
+					commandClass: CommandClasses.Indicator,
+					endpoint,
+					property: property,
+					propertyKey: propertyKey,
+				} as const),
+				get meta() {
+					return ValueMetadata.Any;
+				},
+			};
+		},
+		{
+			is: (valueId: ValueID): boolean => {
+				return valueId.commandClass === CommandClasses.Indicator
+					&& (({ property, propertyKey }) =>
+						property === "indicatorState"
+						&& typeof propertyKey === "number")(valueId);
+			},
+			options: {
+				internal: true,
+				minVersion: 2,
+				secret: false,
+				stateful: true,
+				supportsEndpoints: true,
+				autoCreate: true,
+			} as const satisfies CCValueOptions,
+		},
+	),
 	valueV2: Object.assign(
 		(indicatorId: number, propertyId: number) => {
 			const property = indicatorId;

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -603,6 +603,9 @@ import {
 	IndicatorCCSupportedGet,
 	IndicatorCCSupportedReport,
 	IndicatorCCValues,
+	indicatorObjectsToPropertyMap,
+	indicatorPropertyMapToState,
+	indicatorStateToObjects,
 } from "./IndicatorCC.js";
 export {
 	IndicatorCC,
@@ -614,6 +617,9 @@ export {
 	IndicatorCCSupportedGet,
 	IndicatorCCSupportedReport,
 	IndicatorCCValues,
+	indicatorObjectsToPropertyMap,
+	indicatorPropertyMapToState,
+	indicatorStateToObjects,
 };
 export type {
 	IrrigationCCSystemConfigReportOptions,
@@ -2026,6 +2032,9 @@ export function registerCCs(): void {
 	void InclusionControllerCC;
 	void InclusionControllerCCComplete;
 	void InclusionControllerCCInitiate;
+	void indicatorObjectsToPropertyMap;
+	void indicatorPropertyMapToState;
+	void indicatorStateToObjects;
 	void IndicatorCCValues;
 	void IndicatorCC;
 	void IndicatorCCSet;

--- a/packages/cc/src/lib/_Types.ts
+++ b/packages/cc/src/lib/_Types.ts
@@ -972,6 +972,29 @@ export type IndicatorMetadata = ValueMetadata & {
 	};
 };
 
+/** Describes how an indicator should blink */
+export interface IndicatorBlink {
+	/** Duration of one on/off period in seconds (0.1-25.5) */
+	period: number;
+	/** Number of on/off periods (1-254). `undefined` means the indicator blinks until turned off. */
+	cycles?: number;
+	/** On time within an on/off period in seconds. `undefined` means symmetric (on time equals off time). */
+	onTime?: number;
+}
+
+/** The normalized state of an indicator */
+export interface IndicatorState {
+	/** Whether the indicator is on or off */
+	on?: boolean;
+	/** The level of a multilevel indicator (0-99) */
+	level?: number;
+	blink?: IndicatorBlink;
+	/** Timeout after which the indicator will be turned off. When setting, a string in the form `12h18m17.59s` is also accepted. */
+	timeout?: IndicatorTimeout | string;
+	/** The volume of an audible indicator (0-100). 0 means off/mute. */
+	soundLevel?: number;
+}
+
 export enum IrrigationCommand {
 	SystemInfoGet = 0x01,
 	SystemInfoReport = 0x02,

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -35,3 +35,5 @@ export type {
 	UserData,
 } from "./lib/node/feature-apis/AccessControl.js";
 export { FeatureAPI } from "./lib/node/feature-apis/FeatureAPI.js";
+export { IndicatorsAPI } from "./lib/node/feature-apis/Indicators.js";
+export type { IndicatorCapabilities } from "./lib/node/feature-apis/Indicators.js";

--- a/packages/zwave-js/src/lib/node/CCHandlers/IndicatorCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/IndicatorCC.ts
@@ -3,15 +3,88 @@ import type {
 	IndicatorCCGet,
 	IndicatorCCSet,
 	IndicatorCCSupportedGet,
+	IndicatorTimeout,
 	PersistValuesContext,
 } from "@zwave-js/cc";
 import {
+	type IndicatorCCReport,
+	IndicatorCCValues,
+	indicatorPropertyMapToState,
+} from "@zwave-js/cc/IndicatorCC";
+import {
 	CommandClasses,
 	EncapsulationFlags,
+	Indicator,
 	type LogNode,
 } from "@zwave-js/core";
 import type { ZWaveController } from "../../controller/Controller.js";
 import type { ZWaveNode } from "../Node.js";
+import type { IndicatorUpdatedArgs } from "../_Types.js";
+
+export function handleIndicatorReport(
+	node: ZWaveNode,
+	command: IndicatorCCReport,
+): void {
+	const endpoint = node.getEndpoint(command.endpointIndex) ?? node;
+
+	if (command.values) {
+		const indicatorIds = new Set(
+			command.values.map((v) => v.indicatorId),
+		);
+		for (const indicatorId of indicatorIds) {
+			if (indicatorId === Indicator["Node Identify"]) continue;
+
+			// The report was persisted before this handler runs, so emitting
+			// from the cached state keeps the event in sync with getCached()
+			const map = node.getValue<Record<number, number>>(
+				IndicatorCCValues.indicatorState(indicatorId).endpoint(
+					command.endpointIndex,
+				),
+			);
+			if (!map) continue;
+
+			const supportedPropertyIDs = node.getValue<number[]>(
+				IndicatorCCValues.supportedPropertyIDs(indicatorId).endpoint(
+					command.endpointIndex,
+				),
+			) ?? [];
+			const { timeout, ...state } = indicatorPropertyMapToState(
+				map,
+				supportedPropertyIDs,
+			);
+			const args: IndicatorUpdatedArgs = { indicatorId, ...state };
+			if (timeout != undefined) {
+				args.timeout = timeout as IndicatorTimeout;
+			}
+			node.emit("indicator updated", endpoint, args);
+		}
+	} else if (command.indicator0Value != undefined) {
+		// V1 reports from nodes supporting V2 indicators are ignored during
+		// persistence, so ignore them here as well
+		const supportedIndicatorIds = node.getValue<number[]>(
+			IndicatorCCValues.supportedIndicatorIds.endpoint(
+				command.endpointIndex,
+			),
+		);
+		const supportsV2Indicators = !!supportedIndicatorIds?.some((id) =>
+			!!node.getValue<number[]>(
+				IndicatorCCValues.supportedPropertyIDs(id).endpoint(
+					command.endpointIndex,
+				),
+			)?.length
+		);
+		if (supportsV2Indicators) return;
+
+		node.emit(
+			"indicator updated",
+			endpoint,
+			{
+				indicatorId: 0,
+				on: command.indicator0Value > 0,
+			} satisfies IndicatorUpdatedArgs,
+		);
+	}
+}
 
 export function handleIndicatorSupportedGet(
 	ctx: PersistValuesContext & LogNode,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -6,6 +6,7 @@ import {
 	DeviceResetLocallyCCNotification,
 	IndicatorCCDescriptionGet,
 	IndicatorCCGet,
+	IndicatorCCReport,
 	IndicatorCCSet,
 	IndicatorCCSupportedGet,
 	MultiChannelAssociationCCGet,
@@ -210,6 +211,7 @@ import { getDefaultHailHandlerStore, handleHail } from "./CCHandlers/HailCC.js";
 import {
 	handleIndicatorDescriptionGet,
 	handleIndicatorGet,
+	handleIndicatorReport,
 	handleIndicatorSet,
 	handleIndicatorSupportedGet,
 } from "./CCHandlers/IndicatorCC.js";
@@ -3025,6 +3027,8 @@ protocol version:      ${this.protocolVersion}`;
 				this,
 				command,
 			);
+		} else if (command instanceof IndicatorCCReport) {
+			return handleIndicatorReport(this, command);
 		} else if (command instanceof PowerlevelCCSet) {
 			return handlePowerlevelSet(this.driver, this, command);
 		} else if (command instanceof PowerlevelCCGet) {

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -4,6 +4,8 @@ import type {
 	EntryControlEventTypes,
 	FirmwareUpdateProgress,
 	FirmwareUpdateResult,
+	IndicatorState,
+	IndicatorTimeout,
 	MultilevelSwitchCommand,
 	Powerlevel,
 	PowerlevelTestStatus,
@@ -279,6 +281,12 @@ export interface CredentialLearnCompletedArgs {
 	success: boolean;
 }
 
+export interface IndicatorUpdatedArgs extends Omit<IndicatorState, "timeout"> {
+	/** The ID of the updated indicator. 0 is the unspecified indicator of a V1 node. */
+	indicatorId: number;
+	timeout?: IndicatorTimeout;
+}
+
 export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 	notification: ZWaveNotificationCallback;
 	"interview failed": ZWaveInterviewFailedCallback;
@@ -317,6 +325,10 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 		endpoint: Endpoint,
 		args: CredentialLearnCompletedArgs,
 	) => void;
+	"indicator updated": (
+		endpoint: Endpoint,
+		args: IndicatorUpdatedArgs,
+	) => void;
 }
 
 export type ZWaveNodeEvents = Extract<keyof ZWaveNodeEventCallbacks, string>;
@@ -348,6 +360,7 @@ export const zWaveNodeEvents = [
 	"credential deleted",
 	"credential learn progress",
 	"credential learn completed",
+	"indicator updated",
 ] as const satisfies readonly ZWaveNodeEvents[];
 
 /** Represents the result of one health check round of a node's lifeline */

--- a/packages/zwave-js/src/lib/node/endpoint-mixins/index.ts
+++ b/packages/zwave-js/src/lib/node/endpoint-mixins/index.ts
@@ -1,5 +1,6 @@
 import { CommandClasses } from "@zwave-js/core";
 import { AccessControlAPI } from "../feature-apis/AccessControl.js";
+import { IndicatorsAPI } from "../feature-apis/Indicators.js";
 import { EndpointBase } from "./00_Base.js";
 
 export class FeatureAPIsMixin extends EndpointBase {
@@ -19,6 +20,21 @@ export class FeatureAPIsMixin extends EndpointBase {
 		}
 		this._accessControl ??= new AccessControlAPI(this);
 		return this._accessControl;
+	}
+
+	private _indicators?: IndicatorsAPI;
+
+	/**
+	 * High-level API for controlling the indicators of a device, e.g. LEDs or
+	 * a buzzer. Returns `undefined` if the endpoint does not support the
+	 * **Indicator CC**.
+	 */
+	public get indicators(): IndicatorsAPI | undefined {
+		if (!this.supportsCC(CommandClasses.Indicator)) {
+			return undefined;
+		}
+		this._indicators ??= new IndicatorsAPI(this);
+		return this._indicators;
 	}
 }
 

--- a/packages/zwave-js/src/lib/node/feature-apis/Indicators.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/Indicators.ts
@@ -1,0 +1,281 @@
+import { type IndicatorState } from "@zwave-js/cc";
+import {
+	type IndicatorCCAPI,
+	IndicatorCCValues,
+	indicatorObjectsToPropertyMap,
+	indicatorPropertyMapToState,
+	indicatorStateToObjects,
+} from "@zwave-js/cc/IndicatorCC";
+import {
+	Indicator,
+	type SupervisionResult,
+	ZWaveError,
+	ZWaveErrorCodes,
+	supervisedCommandSucceeded,
+} from "@zwave-js/core";
+import { getEnumMemberName } from "@zwave-js/shared";
+import { clamp } from "alcalzone-shared/math";
+import { isArray } from "alcalzone-shared/typeguards";
+import { FeatureAPI } from "./FeatureAPI.js";
+
+export interface IndicatorCapabilities {
+	/** The ID of the indicator. 0 is the unspecified indicator of a V1 node. */
+	indicatorId: number;
+	/** A user-friendly label describing the indicator */
+	label: string;
+	/** Whether the indicator can be turned on and off */
+	supportsOnOff: boolean;
+	/** Whether the indicator can be set to a level between 0 and 99 */
+	supportsLevel: boolean;
+	/** Whether the indicator can blink */
+	supportsBlinking: boolean;
+	/** Whether the indicator can be turned off automatically after a timeout */
+	supportsTimeout: boolean;
+	/** Whether the volume of the indicator can be changed */
+	supportsSoundLevel: boolean;
+}
+
+export class IndicatorsAPI extends FeatureAPI {
+	/**
+	 * Returns the capabilities of all indicators the endpoint supports.
+	 * This method uses cached information from the interview.
+	 */
+	public getSupportedCached(): IndicatorCapabilities[] {
+		if (!this.#supportsV2Indicators()) {
+			return [{
+				indicatorId: 0,
+				label: "Default",
+				supportsOnOff: true,
+				supportsLevel: false,
+				supportsBlinking: false,
+				supportsTimeout: false,
+				supportsSoundLevel: false,
+			}];
+		}
+
+		return this.#supportedIndicatorIds()
+			.filter((id) => id !== Indicator["Node Identify"])
+			.map((id) => this.#getCapabilities(id));
+	}
+
+	/**
+	 * Returns the capabilities of the given indicator, or `undefined` if it is
+	 * not supported. This method uses cached information from the interview.
+	 */
+	public getCapabilitiesCached(
+		indicatorId: number,
+	): IndicatorCapabilities | undefined {
+		return this.getSupportedCached().find(
+			(caps) => caps.indicatorId === indicatorId,
+		);
+	}
+
+	/**
+	 * Queries the current state of the given indicator.
+	 * This communicates with the node.
+	 */
+	public async get(
+		indicatorId: number,
+	): Promise<IndicatorState | undefined> {
+		if (!this.#supportsV2Indicators()) {
+			this.#assertDefaultIndicator(indicatorId);
+			const value = await this.#api().get();
+			if (typeof value !== "number") return undefined;
+			return { on: value > 0 };
+		}
+
+		this.#assertSupportedIndicator(indicatorId);
+		const values = await this.#api().get(indicatorId);
+		if (values == undefined) return undefined;
+		if (!isArray(values)) return { on: values > 0 };
+
+		const supportedPropertyIDs = this.#supportedPropertyIDs(indicatorId);
+		const map = indicatorObjectsToPropertyMap(
+			values,
+			supportedPropertyIDs,
+		);
+		return indicatorPropertyMapToState(map, supportedPropertyIDs);
+	}
+
+	/**
+	 * Returns the last known state of the given indicator, or `undefined` if
+	 * it is not known. This method uses cached information.
+	 */
+	public getCached(indicatorId: number): IndicatorState | undefined {
+		if (!this.#supportsV2Indicators()) {
+			if (indicatorId !== 0) return undefined;
+			const value = this.getValue<number>(
+				IndicatorCCValues.valueV1.endpoint(this.endpoint.index),
+			);
+			if (value == undefined) return undefined;
+			return { on: value > 0 };
+		}
+
+		const map = this.getValue<Record<number, number>>(
+			IndicatorCCValues.indicatorState(indicatorId).endpoint(
+				this.endpoint.index,
+			),
+		);
+		if (!map) return undefined;
+		return indicatorPropertyMapToState(
+			map,
+			this.#supportedPropertyIDs(indicatorId),
+		);
+	}
+
+	/**
+	 * Changes the state of the given indicator. The state is applied as a
+	 * whole: all aspects not included in the state are turned off, matching
+	 * the required behavior of supporting devices.
+	 * This communicates with the node.
+	 */
+	public async set(
+		indicatorId: number,
+		state: IndicatorState,
+	): Promise<SupervisionResult | undefined> {
+		if (!this.#supportsV2Indicators()) {
+			this.#assertDefaultIndicator(indicatorId);
+			return this.#setV1(state);
+		}
+
+		this.#assertSupportedIndicator(indicatorId);
+		const supportedPropertyIDs = this.#supportedPropertyIDs(indicatorId);
+		const objects = indicatorStateToObjects(
+			indicatorId,
+			state,
+			supportedPropertyIDs,
+		);
+
+		const result = await this.#api().set(objects);
+		if (result == undefined || supervisedCommandSucceeded(result)) {
+			// No report will follow, so persist the new state ourselves
+			this.endpoint.tryGetNode()?.valueDB.setValue(
+				IndicatorCCValues.indicatorState(indicatorId).endpoint(
+					this.endpoint.index,
+				),
+				indicatorObjectsToPropertyMap(objects, supportedPropertyIDs),
+			);
+		}
+		return result;
+	}
+
+	/**
+	 * Instructs the node to identify itself, e.g. by blinking an LED.
+	 * Supported by nodes implementing version 3 or higher of the Indicator CC.
+	 * This communicates with the node.
+	 */
+	public async identify(): Promise<SupervisionResult | undefined> {
+		return this.#api().identify();
+	}
+
+	async #setV1(
+		state: IndicatorState,
+	): Promise<SupervisionResult | undefined> {
+		if (
+			state.blink
+			|| state.timeout != undefined
+			|| state.soundLevel != undefined
+		) {
+			throw new ZWaveError(
+				`This node only supports turning the indicator on or off`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
+		let value: number;
+		if (state.on === false) {
+			value = 0x00;
+		} else if (state.level != undefined) {
+			value = clamp(state.level, 0, 99);
+		} else if (state.on) {
+			value = 0xff;
+		} else {
+			throw new ZWaveError(
+				`The given indicator state is empty`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
+		const result = await this.#api().set(value);
+		if (result == undefined || supervisedCommandSucceeded(result)) {
+			// No report will follow, so persist the new state ourselves
+			this.endpoint.tryGetNode()?.valueDB.setValue(
+				IndicatorCCValues.valueV1.endpoint(this.endpoint.index),
+				value,
+			);
+		}
+		return result;
+	}
+
+	#api(): IndicatorCCAPI {
+		return this.endpoint.commandClasses
+			.Indicator as unknown as IndicatorCCAPI;
+	}
+
+	#supportedIndicatorIds(): number[] {
+		return this.getValue<number[]>(
+			IndicatorCCValues.supportedIndicatorIds.endpoint(
+				this.endpoint.index,
+			),
+		) ?? [];
+	}
+
+	#supportedPropertyIDs(indicatorId: number): number[] {
+		return this.getValue<number[]>(
+			IndicatorCCValues.supportedPropertyIDs(indicatorId).endpoint(
+				this.endpoint.index,
+			),
+		) ?? [];
+	}
+
+	#supportsV2Indicators(): boolean {
+		return this.#supportedIndicatorIds().some(
+			(indicatorId) => this.#supportedPropertyIDs(indicatorId).length > 0,
+		);
+	}
+
+	#getCapabilities(indicatorId: number): IndicatorCapabilities {
+		const propertyIDs = this.#supportedPropertyIDs(indicatorId);
+		// Manufacturer-defined indicators may have a custom description
+		const label = this.getValue<string>(
+			IndicatorCCValues.indicatorDescription(indicatorId).endpoint(
+				this.endpoint.index,
+			),
+		) || getEnumMemberName(Indicator, indicatorId);
+
+		return {
+			indicatorId,
+			label,
+			supportsOnOff: propertyIDs.includes(0x02)
+				|| propertyIDs.includes(0x01),
+			supportsLevel: propertyIDs.includes(0x01),
+			supportsBlinking: propertyIDs.includes(0x03)
+				&& propertyIDs.includes(0x04),
+			supportsTimeout: [0x0a, 0x06, 0x07, 0x08].some((id) =>
+				propertyIDs.includes(id)
+			),
+			supportsSoundLevel: propertyIDs.includes(0x09),
+		};
+	}
+
+	#assertDefaultIndicator(indicatorId: number): void {
+		if (indicatorId !== 0) {
+			throw new ZWaveError(
+				`This node only supports the default indicator with ID 0`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+	}
+
+	#assertSupportedIndicator(indicatorId: number): void {
+		if (
+			indicatorId === Indicator["Node Identify"]
+			|| !this.#supportedIndicatorIds().includes(indicatorId)
+		) {
+			throw new ZWaveError(
+				`Indicator ${indicatorId} cannot be controlled through this API`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+	}
+}

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Indicator.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Indicator.ts
@@ -3,6 +3,7 @@ import {
 	IndicatorCCDescriptionReport,
 	IndicatorCCGet,
 	IndicatorCCReport,
+	IndicatorCCSet,
 	IndicatorCCSupportedGet,
 	IndicatorCCSupportedReport,
 	type IndicatorObject,
@@ -17,11 +18,11 @@ const defaultCapabilities: IndicatorCCCapabilities = {
 	indicators: {},
 };
 
-// const STATE_KEY_PREFIX = "Indicator_";
-// const StateKeys = {
-// 	value: (indicatorId: number, propertyId: number) =>
-// 		`${STATE_KEY_PREFIX}value_${indicatorId}_${propertyId}`,
-// } as const;
+const STATE_KEY_PREFIX = "Indicator_";
+const StateKeys = {
+	value: (indicatorId: number, propertyId: number) =>
+		`${STATE_KEY_PREFIX}value_${indicatorId}_${propertyId}`,
+} as const;
 
 const respondToIndicatorGet: MockNodeBehavior = {
 	handleCC(controller, self, receivedCC) {
@@ -44,9 +45,11 @@ const respondToIndicatorGet: MockNodeBehavior = {
 
 				const indicatorObjects: IndicatorObject[] = supportedProperties
 					.map((propertyId) => {
-						const value =
-							capabilities.getValue?.(indicatorId, propertyId)
-								?? 0;
+						const value = self.state.get(
+							StateKeys.value(indicatorId, propertyId),
+						) as number
+							?? capabilities.getValue?.(indicatorId, propertyId)
+							?? 0;
 						return {
 							indicatorId,
 							propertyId,
@@ -60,7 +63,9 @@ const respondToIndicatorGet: MockNodeBehavior = {
 				});
 			} else {
 				// V1
-				const value = capabilities.getValue?.(0, 0) ?? 0;
+				const value = self.state.get(StateKeys.value(0, 0)) as number
+					?? capabilities.getValue?.(0, 0)
+					?? 0;
 				cc = new IndicatorCCReport({
 					nodeId: controller.ownNodeId,
 					value,
@@ -72,45 +77,65 @@ const respondToIndicatorGet: MockNodeBehavior = {
 	},
 };
 
-// const respondToIndicatorSet: MockNodeBehavior = {
-// 	handleCC(controller, self, receivedCC) {
-// 		if (receivedCC instanceof IndicatorCCSet) {
-// 			const capabilities = {
-// 				...defaultCapabilities,
-// 				...self.getCCCapabilities(
-// 					CommandClasses.Indicator,
-// 					receivedCC.endpointIndex,
-// 				),
-// 			};
-// 			const parameter = receivedCC.parameter;
-// 			const paramInfo = capabilities.parameters.find(
-// 				(p) => p["#"] === parameter,
-// 			);
-// 			// Do nothing if the parameter is not supported
-// 			if (!paramInfo) return { action: "fail" };
+const respondToIndicatorSet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof IndicatorCCSet) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses.Indicator,
+					receivedCC.endpointIndex,
+				),
+			};
 
-// 			if (receivedCC.resetToDefault) {
-// 				self.state.delete(StateKeys.value(parameter));
-// 				return { action: "ok" };
-// 			}
+			if (receivedCC.values) {
+				// V2+
+				const affectedIndicatorIds = new Set(
+					receivedCC.values
+						.map((v) => v.indicatorId)
+						.filter((id) => id in capabilities.indicators),
+				);
 
-// 			const value = receivedCC.value!;
+				// Properties not included in the command are assumed to be 0
+				for (const indicatorId of affectedIndicatorIds) {
+					const supportedProperties =
+						capabilities.indicators[indicatorId]?.properties ?? [];
+					for (const propertyId of supportedProperties) {
+						self.state.set(
+							StateKeys.value(indicatorId, propertyId),
+							0,
+						);
+					}
+				}
 
-// 			// Do nothing if the value is out of range
-// 			if (paramInfo.minValue != undefined && value < paramInfo.minValue) {
-// 				return { action: "fail" };
-// 			} else if (
-// 				paramInfo.maxValue != undefined
-// 				&& value > paramInfo.maxValue
-// 			) {
-// 				return { action: "fail" };
-// 			}
+				// Then apply the received values, ignoring unsupported objects
+				for (const value of receivedCC.values) {
+					const supportedProperties = capabilities
+						.indicators[value.indicatorId]?.properties;
+					if (!supportedProperties?.includes(value.propertyId)) {
+						continue;
+					}
+					self.state.set(
+						StateKeys.value(value.indicatorId, value.propertyId),
+						value.value === true
+							? 0xff
+							: value.value === false
+							? 0x00
+							: value.value,
+					);
+				}
+			} else if (receivedCC.indicator0Value != undefined) {
+				// V1
+				self.state.set(
+					StateKeys.value(0, 0),
+					receivedCC.indicator0Value,
+				);
+			}
 
-// 			self.state.set(StateKeys.value(parameter), value);
-// 			return { action: "ok" };
-// 		}
-// 	},
-// };
+			return { action: "ok" };
+		}
+	},
+};
 
 const respondToIndicatorSupportedGet: MockNodeBehavior = {
 	handleCC(controller, self, receivedCC) {
@@ -209,7 +234,7 @@ const respondToIndicatorDescriptionGet: MockNodeBehavior = {
 
 export const IndicatorCCBehaviors = [
 	respondToIndicatorGet,
-	// respondToIndicatorSet,
+	respondToIndicatorSet,
 	respondToIndicatorSupportedGet,
 	respondToIndicatorDescriptionGet,
 ];

--- a/packages/zwave-js/src/lib/test/cc/IndicatorCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/IndicatorCC.test.ts
@@ -6,7 +6,12 @@ import {
 	IndicatorCCSet,
 	IndicatorCommand,
 } from "@zwave-js/cc";
-import { IndicatorCCValues } from "@zwave-js/cc/IndicatorCC";
+import {
+	IndicatorCCValues,
+	indicatorObjectsToPropertyMap,
+	indicatorPropertyMapToState,
+	indicatorStateToObjects,
+} from "@zwave-js/cc/IndicatorCC";
 import { CommandClasses } from "@zwave-js/core";
 import { createTestingHost } from "@zwave-js/host";
 import { Bytes } from "@zwave-js/shared";
@@ -165,6 +170,129 @@ test("deserializing an unsupported command should return an unspecified version 
 		{ sourceNodeId: 1 } as any,
 	) as IndicatorCC;
 	t.expect(cc.constructor).toBe(IndicatorCC);
+});
+
+test("indicatorObjectsToPropertyMap assumes missing supported properties to be 0", (t) => {
+	const map = indicatorObjectsToPropertyMap(
+		[
+			{ indicatorId: 0x30, propertyId: 0x01, value: 50 },
+			// Reported, but not actually supported
+			{ indicatorId: 0x30, propertyId: 0x09, value: 10 },
+		],
+		[0x01, 0x03, 0x04],
+	);
+	t.expect(map).toStrictEqual({
+		[0x01]: 50,
+		[0x03]: 0,
+		[0x04]: 0,
+	});
+});
+
+test("indicatorObjectsToPropertyMap preserves the report as-is when the supported properties are unknown", (t) => {
+	const map = indicatorObjectsToPropertyMap(
+		[
+			{ indicatorId: 0x30, propertyId: 0x02, value: true },
+			{ indicatorId: 0x30, propertyId: 0x07, value: 30 },
+		],
+		undefined,
+	);
+	t.expect(map).toStrictEqual({
+		[0x02]: 0xff,
+		[0x07]: 30,
+	});
+});
+
+test("indicatorPropertyMapToState normalizes all functionality", (t) => {
+	const state = indicatorPropertyMapToState(
+		{
+			[0x01]: 50,
+			[0x03]: 15,
+			[0x04]: 0xff,
+			[0x05]: 5,
+			[0x0a]: 1,
+			[0x06]: 30,
+			[0x07]: 12,
+			[0x08]: 50,
+			[0x09]: 80,
+		},
+		[0x01, 0x03, 0x04, 0x05, 0x0a, 0x06, 0x07, 0x08, 0x09],
+	);
+	t.expect(state).toStrictEqual({
+		on: true,
+		level: 50,
+		blink: {
+			// 0xff cycles means infinite, so the property is omitted
+			period: 1.5,
+			onTime: 0.5,
+		},
+		timeout: {
+			hours: 1,
+			minutes: 30,
+			seconds: 12.5,
+		},
+		soundLevel: 80,
+	});
+});
+
+test("indicatorPropertyMapToState prefers the Binary property for the on state", (t) => {
+	const state = indicatorPropertyMapToState(
+		{
+			[0x02]: 0,
+		},
+		[0x02],
+	);
+	t.expect(state).toStrictEqual({ on: false });
+});
+
+test("indicatorStateToObjects converts a state into a single group of indicator objects", (t) => {
+	const objects = indicatorStateToObjects(
+		0x30,
+		{
+			level: 100,
+			blink: { period: 1.5, cycles: 3 },
+			timeout: "30s",
+		},
+		[0x01, 0x03, 0x04, 0x05, 0x06, 0x07],
+	);
+	t.expect(objects).toStrictEqual([
+		// 100 is clamped to the maximum multilevel value
+		{ indicatorId: 0x30, propertyId: 0x01, value: 99 },
+		{ indicatorId: 0x30, propertyId: 0x03, value: 15 },
+		{ indicatorId: 0x30, propertyId: 0x04, value: 3 },
+		{ indicatorId: 0x30, propertyId: 0x07, value: 30 },
+	]);
+});
+
+test("indicatorStateToObjects falls back to the supported property of the Binary/Multilevel group", (t) => {
+	t.expect(
+		indicatorStateToObjects(0x43, { level: 50 }, [0x02]),
+	).toStrictEqual([
+		{ indicatorId: 0x43, propertyId: 0x02, value: 0xff },
+	]);
+	t.expect(
+		indicatorStateToObjects(0x30, { on: true }, [0x01]),
+	).toStrictEqual([
+		{ indicatorId: 0x30, propertyId: 0x01, value: 0xff },
+	]);
+	// on: false overrides a level
+	t.expect(
+		indicatorStateToObjects(0x30, { on: false, level: 50 }, [0x01]),
+	).toStrictEqual([
+		{ indicatorId: 0x30, propertyId: 0x01, value: 0x00 },
+	]);
+});
+
+test("indicatorStateToObjects rejects unsupported functionality and empty states", (t) => {
+	t.expect(() =>
+		indicatorStateToObjects(0x43, { blink: { period: 1 } }, [0x02])
+	).toThrow("does not support blinking");
+	t.expect(() => indicatorStateToObjects(0x43, { soundLevel: 50 }, [0x02]))
+		.toThrow("does not support setting a sound level");
+	t.expect(() => indicatorStateToObjects(0x43, { timeout: "1x" }, [0x02]))
+		.toThrow("is not valid");
+	t.expect(() => indicatorStateToObjects(0x43, {}, [0x02])).toThrow(
+		"is empty",
+	);
 });
 
 test("the value IDs should be translated properly", (t) => {

--- a/packages/zwave-js/src/lib/test/cc/IndicatorCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/IndicatorCC.test.ts
@@ -282,6 +282,30 @@ test("indicatorStateToObjects falls back to the supported property of the Binary
 	]);
 });
 
+test("indicatorStateToObjects normalizes timeout seconds with more than 2 decimals", (t) => {
+	// 12.999 seconds must carry over to 13 whole seconds instead of
+	// producing an out-of-range 100 hundredths
+	t.expect(
+		indicatorStateToObjects(
+			0x30,
+			{ timeout: { seconds: 12.999 } },
+			[0x07, 0x08],
+		),
+	).toStrictEqual([
+		{ indicatorId: 0x30, propertyId: 0x07, value: 13 },
+	]);
+	t.expect(
+		indicatorStateToObjects(
+			0x30,
+			{ timeout: { seconds: 60 } },
+			[0x07, 0x08],
+		),
+	).toStrictEqual([
+		{ indicatorId: 0x30, propertyId: 0x07, value: 59 },
+		{ indicatorId: 0x30, propertyId: 0x08, value: 99 },
+	]);
+});
+
 test("indicatorStateToObjects rejects unsupported functionality and empty states", (t) => {
 	t.expect(() =>
 		indicatorStateToObjects(0x43, { blink: { period: 1 } }, [0x02])

--- a/packages/zwave-js/src/lib/test/node/indicators.test.ts
+++ b/packages/zwave-js/src/lib/test/node/indicators.test.ts
@@ -1,0 +1,474 @@
+import { type IndicatorObject } from "@zwave-js/cc";
+import { IndicatorCCReport, IndicatorCCSet } from "@zwave-js/cc/IndicatorCC";
+import { CommandClasses } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	ccCaps,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { createDeferredPromise } from "alcalzone-shared/deferred-promise";
+import { integrationTest } from "../integrationTestSuite.js";
+
+function findIndicatorObject(
+	values: IndicatorObject[],
+	propertyId: number,
+): number | boolean | undefined {
+	return values.find((v) => v.propertyId === propertyId)?.value;
+}
+
+// =============================================================================
+// Capabilities
+// =============================================================================
+
+integrationTest(
+	"Indicator capabilities are derived from the supported properties",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses.Indicator,
+					version: 3,
+					indicators: {
+						// LCD backlight: Multilevel, blinking, timeout
+						[0x30]: {
+							properties: [0x01, 0x03, 0x04, 0x05, 0x06, 0x07],
+						},
+						// Button 1 indication: Binary only
+						[0x43]: { properties: [0x02] },
+						// Node Identify
+						[0x50]: { properties: [0x03, 0x04, 0x05] },
+					},
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const supported = node.indicators!.getSupportedCached();
+
+			// Node Identify must not be exposed
+			t.expect(supported.map((c) => c.indicatorId)).toStrictEqual([
+				0x30,
+				0x43,
+			]);
+
+			t.expect(supported[0]).toStrictEqual({
+				indicatorId: 0x30,
+				label: "LCD backlight",
+				supportsOnOff: true,
+				supportsLevel: true,
+				supportsBlinking: true,
+				supportsTimeout: true,
+				supportsSoundLevel: false,
+			});
+			t.expect(supported[1]).toStrictEqual({
+				indicatorId: 0x43,
+				label: "Button 1 indication",
+				supportsOnOff: true,
+				supportsLevel: false,
+				supportsBlinking: false,
+				supportsTimeout: false,
+				supportsSoundLevel: false,
+			});
+
+			t.expect(node.indicators!.getCapabilitiesCached(0x43))
+				.toStrictEqual(supported[1]);
+			t.expect(node.indicators!.getCapabilitiesCached(0x50))
+				.toBeUndefined();
+		},
+	},
+);
+
+integrationTest(
+	"The indicators API is not available without Indicator CC support",
+	{
+		nodeCapabilities: {
+			commandClasses: [CommandClasses.Version],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			t.expect(node.indicators).toBeUndefined();
+		},
+	},
+);
+
+integrationTest(
+	"Manufacturer-defined indicators use their description as the label",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses.Indicator,
+					version: 4,
+					indicators: {
+						[0x80]: {
+							properties: [0x02],
+							manufacturerSpecificDescription: "Ring light",
+						},
+					},
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const caps = node.indicators!.getCapabilitiesCached(0x80);
+			t.expect(caps?.label).toBe("Ring light");
+		},
+	},
+);
+
+// =============================================================================
+// Reading the indicator state
+// =============================================================================
+
+integrationTest(
+	"get() and getCached() return the normalized indicator state",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses.Indicator,
+					version: 3,
+					indicators: {
+						[0x30]: {
+							properties: [0x01, 0x03, 0x04, 0x05, 0x06, 0x07],
+						},
+					},
+					getValue: (indicatorId, propertyId) => {
+						switch (propertyId) {
+							case 0x01:
+								return 50;
+							// Blink with a 1 second period, 3 cycles
+							case 0x03:
+								return 10;
+							case 0x04:
+								return 3;
+							// Turn off after 30 seconds
+							case 0x07:
+								return 30;
+							default:
+								return 0;
+						}
+					},
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const expected = {
+				on: true,
+				level: 50,
+				blink: {
+					period: 1,
+					cycles: 3,
+				},
+				timeout: {
+					seconds: 30,
+				},
+			};
+
+			const state = await node.indicators!.get(0x30);
+			t.expect(state).toStrictEqual(expected);
+
+			t.expect(node.indicators!.getCached(0x30)).toStrictEqual(expected);
+		},
+	},
+);
+
+// =============================================================================
+// Changing the indicator state
+// =============================================================================
+
+integrationTest(
+	"set() sends all indicator properties in a single command",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses.Indicator,
+					version: 3,
+					indicators: {
+						[0x30]: {
+							properties: [0x01, 0x03, 0x04, 0x05, 0x06, 0x07],
+						},
+					},
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			mockNode.clearReceivedControllerFrames();
+
+			await node.indicators!.set(0x30, {
+				level: 50,
+				blink: { period: 1.5 },
+				timeout: "30s",
+			});
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof IndicatorCCSet
+					&& frame.payload.values != undefined
+					&& frame.payload.values.length === 4
+					&& findIndicatorObject(frame.payload.values, 0x01) === 50
+					&& findIndicatorObject(frame.payload.values, 0x03) === 15
+					&& findIndicatorObject(frame.payload.values, 0x04) === 0xff
+					&& findIndicatorObject(frame.payload.values, 0x07) === 30,
+				{
+					errorMessage:
+						"Should have sent a single Indicator Set with level, blink and timeout properties",
+				},
+			);
+
+			// The device resets all properties that were not part of a Set
+			await node.indicators!.set(0x30, { level: 20 });
+			const state = await node.indicators!.get(0x30);
+			t.expect(state).toStrictEqual({
+				on: true,
+				level: 20,
+			});
+		},
+	},
+);
+
+integrationTest(
+	"set() validates the state against the indicator capabilities",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses.Indicator,
+					version: 3,
+					indicators: {
+						[0x30]: {
+							properties: [0x01, 0x03, 0x04, 0x05, 0x06, 0x07],
+						},
+						[0x43]: { properties: [0x02] },
+					},
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// A level for a Binary-only indicator falls back to on/off
+			await node.indicators!.set(0x43, { level: 50 });
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof IndicatorCCSet
+					&& frame.payload.values != undefined
+					&& frame.payload.values.length === 1
+					&& frame.payload.values[0].propertyId === 0x02
+					&& frame.payload.values[0].value === 0xff,
+				{
+					errorMessage:
+						"Should have fallen back to the Binary property",
+				},
+			);
+
+			// Unsupported functionality is rejected
+			await t.expect(
+				node.indicators!.set(0x43, { blink: { period: 1 } }),
+			).rejects.toThrow("does not support blinking");
+
+			// An empty state is rejected
+			await t.expect(node.indicators!.set(0x30, {})).rejects.toThrow(
+				"is empty",
+			);
+
+			// Unsupported indicators are rejected
+			await t.expect(
+				node.indicators!.set(0x44, { on: true }),
+			).rejects.toThrow("cannot be controlled");
+		},
+	},
+);
+
+integrationTest(
+	"A successful supervised set() updates the cached state",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				CommandClasses.Supervision,
+				ccCaps({
+					ccId: CommandClasses.Indicator,
+					version: 3,
+					indicators: {
+						[0x30]: {
+							properties: [0x01, 0x03, 0x04, 0x05, 0x06, 0x07],
+						},
+					},
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			await node.indicators!.set(0x30, {
+				level: 33,
+				timeout: { minutes: 2 },
+			});
+
+			t.expect(node.indicators!.getCached(0x30)).toStrictEqual({
+				on: true,
+				level: 33,
+				timeout: {
+					minutes: 2,
+				},
+			});
+		},
+	},
+);
+
+// =============================================================================
+// Events
+// =============================================================================
+
+integrationTest(
+	"An unsolicited report emits the indicator updated event",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses.Indicator,
+					version: 3,
+					indicators: {
+						[0x30]: {
+							properties: [0x01, 0x03, 0x04, 0x05, 0x06, 0x07],
+						},
+						[0x50]: { properties: [0x03, 0x04, 0x05] },
+					},
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const updates: unknown[] = [];
+			node.on("indicator updated", (_endpoint, args) => {
+				updates.push(args);
+			});
+
+			// Reports for the Node Identify indicator must not emit events
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(
+					new IndicatorCCReport({
+						nodeId: mockController.ownNodeId,
+						values: [
+							{ indicatorId: 0x50, propertyId: 0x03, value: 8 },
+							{ indicatorId: 0x50, propertyId: 0x04, value: 3 },
+						],
+					}),
+					{ ackRequested: false },
+				),
+			);
+
+			// A partial report resets the missing properties
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(
+					new IndicatorCCReport({
+						nodeId: mockController.ownNodeId,
+						values: [
+							{ indicatorId: 0x30, propertyId: 0x01, value: 60 },
+						],
+					}),
+					{ ackRequested: false },
+				),
+			);
+
+			await wait(100);
+
+			t.expect(updates).toStrictEqual([{
+				indicatorId: 0x30,
+				on: true,
+				level: 60,
+			}]);
+
+			// The event payload matches the cached state
+			t.expect(node.indicators!.getCached(0x30)).toStrictEqual({
+				on: true,
+				level: 60,
+			});
+		},
+	},
+);
+
+// =============================================================================
+// V1 nodes
+// =============================================================================
+
+integrationTest(
+	"V1 nodes expose a single default indicator",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses.Indicator,
+					version: 1,
+					indicators: {},
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			t.expect(node.indicators!.getSupportedCached()).toStrictEqual([{
+				indicatorId: 0,
+				label: "Default",
+				supportsOnOff: true,
+				supportsLevel: false,
+				supportsBlinking: false,
+				supportsTimeout: false,
+				supportsSoundLevel: false,
+			}]);
+
+			await node.indicators!.set(0, { on: true });
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof IndicatorCCSet
+					&& frame.payload.indicator0Value === 0xff,
+				{
+					errorMessage: "Should have sent a V1 Indicator Set",
+				},
+			);
+
+			t.expect(await node.indicators!.get(0)).toStrictEqual({
+				on: true,
+			});
+
+			// Other functionality is rejected
+			await t.expect(
+				node.indicators!.set(0, { blink: { period: 1 } }),
+			).rejects.toThrow("on or off");
+			await t.expect(
+				node.indicators!.set(1, { on: true }),
+			).rejects.toThrow("default indicator");
+
+			// V1 reports emit the indicator updated event
+			const update = createDeferredPromise<unknown>();
+			node.once("indicator updated", (_endpoint, args) => {
+				update.resolve(args);
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(
+					new IndicatorCCReport({
+						nodeId: mockController.ownNodeId,
+						value: 0,
+					}),
+					{ ackRequested: false },
+				),
+			);
+			t.expect(await update).toStrictEqual({
+				indicatorId: 0,
+				on: false,
+			});
+		},
+	},
+);


### PR DESCRIPTION
Fixes #8147

Indicator CC values are a bad fit for how the CC is used: properties must be written in groups (a Set omitting a property resets it to `0x00` on the device), the Binary/Multilevel split is a device detail, and blink/timeout semantics span multiple property IDs. Following the Access Control precedent, this adds a high-level `endpoint.indicators` feature API that models each indicator's functionality instead of raw indicator/property IDs.

### Public API

```ts
if (endpoint.indicators) {
	await endpoint.indicators.set(Indicator["Button 1 indication"], {
		on: true,
		timeout: "30s",
	});
}
```

- `getSupportedCached()` / `getCapabilitiesCached(id)` — per-indicator capability flags (`supportsOnOff`, `supportsLevel`, `supportsBlinking`, `supportsTimeout`, `supportsSoundLevel`) derived from the supported property IDs. Labels come from the `Indicator` enum, or the V4 description for manufacturer-defined indicators.
- `get(id)` / `getCached(id)` — the normalized `IndicatorState` (`on`, `level`, `blink`, `timeout`, `soundLevel`)
- `set(id, state)` — translates the state into a **single** Indicator Set frame with full-state-replacement semantics: aspects not included are turned off, matching the device behavior required by the spec. `on`/`level` are converted automatically between Binary and Multilevel indicators; unsupported aspects are rejected.
- `identify()` — delegates to the existing CC API. The Node Identify indicator (0x50) is hidden from all other surfaces.
- V1 nodes expose a single default indicator with ID 0 that can be turned on and off.

### Internals

- New internal `indicatorState(indicatorId)` CC value caching the complete property map per indicator. Properties missing from a report are assumed 0 as required by the spec (previously a TODO in `IndicatorCCReport`).
- New `"indicator updated"` node event, emitted from the freshly persisted state when an (unsolicited) Indicator Report is received, so the event payload always matches `getCached()`.
- Supervised or optimistic sets update the cache directly since no report follows.
- The mock Indicator CC now implements Set with the spec's reset-then-apply behavior, enabling the new integration tests.

The existing CC values are untouched; removing them in favor of this API is a later breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)