### PR TITLE
fix(cc): purge stale credentials from cache while querying

### DIFF
--- a/packages/mcp-server-dev/src/tools/resolveParam.ts
+++ b/packages/mcp-server-dev/src/tools/resolveParam.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
 	DeviceConfig,
+	type ParamInformation,
 	clearTemplateCache,
 	readJsonWithTemplate,
 } from "@zwave-js/config";
@@ -38,7 +39,7 @@ export async function resolveParamsForFirmware(
 	parameter: number,
 	valueBitMask: number | undefined,
 	firmwareVersion: string,
-) {
+): Promise<ParamInformation[]> {
 	const raw = parseJsonC(await readFile(filename, "utf8"));
 	const firstDevice = (raw?.devices as any[] | undefined)?.[0];
 	const deviceId = {

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -1683,6 +1683,50 @@ export class AccessControlAPI extends FeatureAPI {
 		}
 	}
 
+	/**
+	 * Removes cached credentials orphaned within the exclusive composite-key
+	 * range `(from, to)` of a U3C enumeration walk. Credentials enumerate in
+	 * ascending (type, slot) order, encoded as `(type << 16) | slot`, and the
+	 * node's next-credential pointer only advances to credentials that still
+	 * exist, so any cached entry the walk skipped over was deleted on the
+	 * device. For a user-scoped walk only that user's cached entries are
+	 * reconciled; a walk across all users (userId 0) reconciles every entry.
+	 */
+	#reconcileCredentialGap_U3C(
+		userId: number,
+		from: number,
+		to: number,
+	): void {
+		const valueDB = this.endpoint.tryGetNode()?.valueDB;
+		if (!valueDB) return;
+
+		const credentialOwners = valueDB.findValues(
+			(vid) =>
+				UserCredentialCCValues.credentialOwner.is(vid)
+				&& vid.endpoint === this.endpoint.index,
+		);
+		for (const { endpoint, propertyKey, value } of credentialOwners) {
+			const key = propertyKey as number;
+			if (key <= from || key >= to) continue;
+			// A user-scoped walk skips other users' credentials, so their
+			// presence in the gap is not evidence of deletion.
+			if (userId !== 0 && value !== userId) continue;
+
+			const type = key >>> 16;
+			const slot = key & 0xffff;
+			for (
+				const valueId of [
+					UserCredentialCCValues.credential(type, slot),
+					UserCredentialCCValues.credentialOwner(type, slot),
+					UserCredentialCCValues.credentialModifierType(type, slot),
+					UserCredentialCCValues.credentialModifierNodeId(type, slot),
+				]
+			) {
+				valueDB.removeValue(valueId.endpoint(endpoint));
+			}
+		}
+	}
+
 	/** Removes all cached user and credential values from the value DB */
 	#purgeAllCachedUsersAndCredentials(): void {
 		const valueDB = this.endpoint.tryGetNode()?.valueDB;
@@ -1803,6 +1847,15 @@ export class AccessControlAPI extends FeatureAPI {
 		let queryType = startType;
 		let querySlot = startSlot;
 
+		const composite = (type: UserCredentialType, slot: number) =>
+			(type << 16) | slot;
+		// The scope's upper bound: the end of the filtered type, or past every
+		// possible credential for an unfiltered walk (type is a byte, slot a
+		// 16-bit value).
+		const scopeEnd = filterType != undefined
+			? composite(filterType + 1, 0)
+			: 0x100_0000;
+
 		// U3C credential enumeration behaves like a cursor walk.
 		// The initial (userId, type, slot) triple may be exact or wildcarded,
 		// and each report returns both the matching credential and a pointer to
@@ -1815,6 +1868,17 @@ export class AccessControlAPI extends FeatureAPI {
 			);
 			if (result) await this.endpoint.tryGetNode()?.handleCommand(result);
 			const credential = this.#mapCredentialData(result);
+			// An empty report (present, but no credential) on the first request
+			// means the node holds nothing in the walked scope, so drop every
+			// cached credential there. A missing response proves nothing and must
+			// leave the cache untouched.
+			if (result && !credential && credentials.length === 0) {
+				this.#reconcileCredentialGap_U3C(
+					userId,
+					composite(startType, startSlot),
+					scopeEnd,
+				);
+			}
 			// No credential means the walk is exhausted or the current selector did
 			// not resolve to a valid entry on this node.
 			if (!result || !credential) break;
@@ -1824,16 +1888,32 @@ export class AccessControlAPI extends FeatureAPI {
 				break;
 			}
 
+			// The first in-scope result proves nothing exists between the walk's
+			// start and here, so drop any cached credential in that gap.
+			if (credentials.length === 0) {
+				this.#reconcileCredentialGap_U3C(
+					userId,
+					composite(startType, startSlot),
+					composite(credential.type, credential.slot),
+				);
+			}
+
 			credentials.push(credential);
 
 			const nextType = result.nextCredentialType
 				?? UserCredentialType.None;
 			const nextSlot = result.nextCredentialSlot ?? 0;
-			// A zero next pointer marks the end of the node's credential sequence.
+			// A zero next pointer marks the end of the node's credential sequence,
+			// so every cached credential above this result is orphaned.
 			if (
 				nextType === UserCredentialType.None
 				&& nextSlot === 0
 			) {
+				this.#reconcileCredentialGap_U3C(
+					userId,
+					composite(credential.type, credential.slot),
+					scopeEnd,
+				);
 				break;
 			}
 			// Per CC:0083.01.0C.11.024/.025, the next pointer advances to the next
@@ -1841,12 +1921,29 @@ export class AccessControlAPI extends FeatureAPI {
 			// type-filtered walks, stop before following that pointer into a
 			// different type.
 			if (filterType != undefined && nextType !== filterType) {
+				// A pointer into a later type proves no more credentials of the
+				// filtered type exist after this result, so its tail is orphaned.
+				if (nextType > filterType) {
+					this.#reconcileCredentialGap_U3C(
+						userId,
+						composite(credential.type, credential.slot),
+						scopeEnd,
+					);
+				}
 				break;
 			}
 			// Guard against buggy nodes that repeat the same cursor forever.
 			if (nextType === queryType && nextSlot === querySlot) {
 				break;
 			}
+
+			// Any cached credential the node skipped between this result and the
+			// next pointer no longer exists, so drop it from the cache.
+			this.#reconcileCredentialGap_U3C(
+				userId,
+				composite(credential.type, credential.slot),
+				composite(nextType, nextSlot),
+			);
 
 			queryType = nextType;
 			querySlot = nextSlot;

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -13,6 +13,7 @@ import { type UserCodeCCAPI, UserCodeCCValues } from "@zwave-js/cc/UserCodeCC";
 import {
 	type UserCredentialCCAPI,
 	type UserCredentialCCAssociationReport,
+	UserCredentialCCCredentialReport,
 	type UserCredentialCCUserReport,
 	UserCredentialCCValues,
 	normalizeCredentialData,
@@ -87,10 +88,6 @@ export interface DeleteCredentialsOptions {
 	 */
 	credentialType?: UserCredentialType;
 }
-
-type UserCredentialGetResult = Awaited<
-	ReturnType<UserCredentialCCAPI["getCredential"]>
->;
 
 /** Result of an addUser call */
 export interface AddUserResult {
@@ -1683,23 +1680,30 @@ export class AccessControlAPI extends FeatureAPI {
 		}
 	}
 
-	// Drop cached credentials with composite keys in the exclusive range (from, to)
+	/**
+	 * Drop all cached cached credentials that match the given filter
+	 * @param userId The user ID to match, or 0 to match all users
+	 * @param fromKey The lower bound of the property key range to match (inclusive)
+	 * @param toKey The upper bound of the property key range to match (exclusive)
+	 */
 	#reconcileCredentialGap_U3C(
 		userId: number,
-		from: number,
-		to: number,
+		fromKey: number,
+		toKey: number,
 	): void {
 		const valueDB = this.endpoint.tryGetNode()?.valueDB;
 		if (!valueDB) return;
 
+		// Determine the ownership of all credentials
 		const credentialOwners = valueDB.findValues(
 			(vid) =>
 				UserCredentialCCValues.credentialOwner.is(vid)
 				&& vid.endpoint === this.endpoint.index,
 		);
+		// And delete them if they lie in the half-open range [fromKey, toKey) (and optionally belong to the given user)
 		for (const { endpoint, propertyKey, value } of credentialOwners) {
 			const key = propertyKey as number;
-			if (key <= from || key >= to) continue;
+			if (key < fromKey || key >= toKey) continue;
 			// Skip other users' entries because they aren't visited by this walk
 			if (userId !== 0 && value !== userId) continue;
 
@@ -1811,7 +1815,7 @@ export class AccessControlAPI extends FeatureAPI {
 	}
 
 	#mapCredentialData(
-		result: UserCredentialGetResult,
+		result: UserCredentialCCCredentialReport | undefined,
 	): CredentialData | undefined {
 		if (!result?.credentialSlot) return undefined;
 		return {
@@ -1838,11 +1842,11 @@ export class AccessControlAPI extends FeatureAPI {
 		let queryType = startType;
 		let querySlot = startSlot;
 
-		const composite = (type: UserCredentialType, slot: number) =>
+		const propertyKey = (type: UserCredentialType, slot: number) =>
 			(type << 16) | slot;
 		const scopeEnd = filterType != undefined
-			? composite(filterType + 1, 0)
-			: 0x100_0000;
+			? propertyKey(filterType + 1, 0)
+			: propertyKey(0xff + 1, 0);
 
 		// U3C credential enumeration behaves like a cursor walk.
 		// The initial (userId, type, slot) triple may be exact or wildcarded,
@@ -1856,11 +1860,12 @@ export class AccessControlAPI extends FeatureAPI {
 			);
 			if (result) await this.endpoint.tryGetNode()?.handleCommand(result);
 			const credential = this.#mapCredentialData(result);
-			// Explicit empty report on the first request — reconcile the entire scope
+			// Empty report on the first request - there are no credentials for this user and type.
+			// Purge them all.
 			if (result && !credential && credentials.length === 0) {
 				this.#reconcileCredentialGap_U3C(
 					userId,
-					composite(startType, startSlot),
+					propertyKey(startType, startSlot),
 					scopeEnd,
 				);
 			}
@@ -1873,12 +1878,12 @@ export class AccessControlAPI extends FeatureAPI {
 				break;
 			}
 
-			// Reconcile the leading gap before the first result
+			// Purge all cached stale credentials before the first result
 			if (credentials.length === 0) {
 				this.#reconcileCredentialGap_U3C(
 					userId,
-					composite(startType, startSlot),
-					composite(credential.type, credential.slot),
+					propertyKey(startType, startSlot),
+					propertyKey(credential.type, credential.slot),
 				);
 			}
 
@@ -1888,14 +1893,14 @@ export class AccessControlAPI extends FeatureAPI {
 				?? UserCredentialType.None;
 			const nextSlot = result.nextCredentialSlot ?? 0;
 			// A zero next pointer marks the end of the node's credential sequence,
-			// so reconcile the trailing gap past the last result
+			// so purge all stale credentials after the last result
 			if (
 				nextType === UserCredentialType.None
 				&& nextSlot === 0
 			) {
 				this.#reconcileCredentialGap_U3C(
 					userId,
-					composite(credential.type, credential.slot),
+					propertyKey(credential.type, credential.slot + 1),
 					scopeEnd,
 				);
 				break;
@@ -1905,11 +1910,11 @@ export class AccessControlAPI extends FeatureAPI {
 			// type-filtered walks, stop before following that pointer into a
 			// different type.
 			if (filterType != undefined && nextType !== filterType) {
-				// Reconcile the filtered type's tail when the pointer crosses into a later type
+				// Purge the filtered type's tail when the pointer crosses into a later type
 				if (nextType > filterType) {
 					this.#reconcileCredentialGap_U3C(
 						userId,
-						composite(credential.type, credential.slot),
+						propertyKey(credential.type, credential.slot + 1),
 						scopeEnd,
 					);
 				}
@@ -1922,8 +1927,8 @@ export class AccessControlAPI extends FeatureAPI {
 
 			this.#reconcileCredentialGap_U3C(
 				userId,
-				composite(credential.type, credential.slot),
-				composite(nextType, nextSlot),
+				propertyKey(credential.type, credential.slot + 1),
+				propertyKey(nextType, nextSlot),
 			);
 
 			queryType = nextType;

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -198,6 +198,14 @@ function u3cAssociationStatusToAssignCredentialResult(
 	}
 }
 
+/** Packs a credential type and slot into the value DB property key */
+function credentialPropertyKey(
+	type: UserCredentialType,
+	slot: number,
+): number {
+	return UserCredentialCCValues.credential(type, slot).id.propertyKey;
+}
+
 const NON_PIN_CHARS = /[^0-9]/;
 
 /**
@@ -1361,7 +1369,16 @@ export class AccessControlAPI extends FeatureAPI {
 				raw?.reportType,
 			);
 			if (status === SetCredentialResult.OK) {
-				this.#purgeCachedCredentials(userId, credentialType);
+				// A specific type maps to its property-key range; None purges all types
+				if (credentialType === UserCredentialType.None) {
+					this.#purgeCachedCredentials(userId);
+				} else {
+					this.#purgeCachedCredentials(
+						userId,
+						credentialPropertyKey(credentialType, 0),
+						credentialPropertyKey(credentialType + 1, 0),
+					);
+				}
 			}
 			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
 			return status;
@@ -1637,59 +1654,16 @@ export class AccessControlAPI extends FeatureAPI {
 	}
 
 	/**
-	 * Removes cached credential values from the value DB for the given filters.
-	 * Use userId 0 to match all users, and UserCredentialType.None to match all
-	 * credential types.
-	 */
-	#purgeCachedCredentials(
-		userId: number,
-		credentialType: UserCredentialType = UserCredentialType.None,
-	): void {
-		const valueDB = this.endpoint.tryGetNode()?.valueDB;
-		if (!valueDB) return;
-		const credentialOwners = valueDB.findValues(
-			(vid) =>
-				UserCredentialCCValues.credentialOwner.is(vid)
-				&& vid.endpoint === this.endpoint.index,
-		);
-		for (const { endpoint, propertyKey, value } of credentialOwners) {
-			// Bulk delete reports use wildcard filters instead of enumerating each
-			// removed credential, so match against the requested owner/type here.
-			if (userId !== 0 && value !== userId) continue;
-
-			const key = propertyKey as number;
-			const type = key >>> 16;
-			const slot = key & 0xffff;
-			if (
-				credentialType !== UserCredentialType.None
-				&& type !== credentialType
-			) {
-				continue;
-			}
-
-			for (
-				const valueId of [
-					UserCredentialCCValues.credential(type, slot),
-					UserCredentialCCValues.credentialOwner(type, slot),
-					UserCredentialCCValues.credentialModifierType(type, slot),
-					UserCredentialCCValues.credentialModifierNodeId(type, slot),
-				]
-			) {
-				valueDB.removeValue(valueId.endpoint(endpoint));
-			}
-		}
-	}
-
-	/**
-	 * Drop all cached cached credentials that match the given filter
+	 * Removes cached credential values from the value DB that belong to the given
+	 * user and fall within the given property-key range.
 	 * @param userId The user ID to match, or 0 to match all users
 	 * @param fromKey The lower bound of the property key range to match (inclusive)
 	 * @param toKey The upper bound of the property key range to match (exclusive)
 	 */
-	#reconcileCredentialGap_U3C(
+	#purgeCachedCredentials(
 		userId: number,
-		fromKey: number,
-		toKey: number,
+		fromKey = 0,
+		toKey = Number.POSITIVE_INFINITY,
 	): void {
 		const valueDB = this.endpoint.tryGetNode()?.valueDB;
 		if (!valueDB) return;
@@ -1842,11 +1816,9 @@ export class AccessControlAPI extends FeatureAPI {
 		let queryType = startType;
 		let querySlot = startSlot;
 
-		const propertyKey = (type: UserCredentialType, slot: number) =>
-			(type << 16) | slot;
 		const scopeEnd = filterType != undefined
-			? propertyKey(filterType + 1, 0)
-			: propertyKey(0xff + 1, 0);
+			? credentialPropertyKey(filterType + 1, 0)
+			: credentialPropertyKey(0xff + 1, 0);
 
 		// U3C credential enumeration behaves like a cursor walk.
 		// The initial (userId, type, slot) triple may be exact or wildcarded,
@@ -1863,9 +1835,9 @@ export class AccessControlAPI extends FeatureAPI {
 			// Empty report on the first request - there are no credentials for this user and type.
 			// Purge them all.
 			if (result && !credential && credentials.length === 0) {
-				this.#reconcileCredentialGap_U3C(
+				this.#purgeCachedCredentials(
 					userId,
-					propertyKey(startType, startSlot),
+					credentialPropertyKey(startType, startSlot),
 					scopeEnd,
 				);
 			}
@@ -1880,10 +1852,10 @@ export class AccessControlAPI extends FeatureAPI {
 
 			// Purge all cached stale credentials before the first result
 			if (credentials.length === 0) {
-				this.#reconcileCredentialGap_U3C(
+				this.#purgeCachedCredentials(
 					userId,
-					propertyKey(startType, startSlot),
-					propertyKey(credential.type, credential.slot),
+					credentialPropertyKey(startType, startSlot),
+					credentialPropertyKey(credential.type, credential.slot),
 				);
 			}
 
@@ -1898,9 +1870,9 @@ export class AccessControlAPI extends FeatureAPI {
 				nextType === UserCredentialType.None
 				&& nextSlot === 0
 			) {
-				this.#reconcileCredentialGap_U3C(
+				this.#purgeCachedCredentials(
 					userId,
-					propertyKey(credential.type, credential.slot + 1),
+					credentialPropertyKey(credential.type, credential.slot + 1),
 					scopeEnd,
 				);
 				break;
@@ -1912,9 +1884,9 @@ export class AccessControlAPI extends FeatureAPI {
 			if (filterType != undefined && nextType !== filterType) {
 				// Purge the filtered type's tail when the pointer crosses into a later type
 				if (nextType > filterType) {
-					this.#reconcileCredentialGap_U3C(
+					this.#purgeCachedCredentials(
 						userId,
-						propertyKey(credential.type, credential.slot + 1),
+						credentialPropertyKey(credential.type, credential.slot + 1),
 						scopeEnd,
 					);
 				}
@@ -1925,10 +1897,10 @@ export class AccessControlAPI extends FeatureAPI {
 				break;
 			}
 
-			this.#reconcileCredentialGap_U3C(
+			this.#purgeCachedCredentials(
 				userId,
-				propertyKey(credential.type, credential.slot + 1),
-				propertyKey(nextType, nextSlot),
+				credentialPropertyKey(credential.type, credential.slot + 1),
+				credentialPropertyKey(nextType, nextSlot),
 			);
 
 			queryType = nextType;

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -13,7 +13,7 @@ import { type UserCodeCCAPI, UserCodeCCValues } from "@zwave-js/cc/UserCodeCC";
 import {
 	type UserCredentialCCAPI,
 	type UserCredentialCCAssociationReport,
-	UserCredentialCCCredentialReport,
+	type UserCredentialCCCredentialReport,
 	type UserCredentialCCUserReport,
 	UserCredentialCCValues,
 	normalizeCredentialData,

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -1887,7 +1887,8 @@ export class AccessControlAPI extends FeatureAPI {
 			const nextType = result.nextCredentialType
 				?? UserCredentialType.None;
 			const nextSlot = result.nextCredentialSlot ?? 0;
-			// Reconcile the trailing gap past the last result
+			// A zero next pointer marks the end of the node's credential sequence,
+			// so reconcile the trailing gap past the last result
 			if (
 				nextType === UserCredentialType.None
 				&& nextSlot === 0

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -1886,7 +1886,10 @@ export class AccessControlAPI extends FeatureAPI {
 				if (nextType > filterType) {
 					this.#purgeCachedCredentials(
 						userId,
-						credentialPropertyKey(credential.type, credential.slot + 1),
+						credentialPropertyKey(
+							credential.type,
+							credential.slot + 1,
+						),
 						scopeEnd,
 					);
 				}

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -1683,6 +1683,7 @@ export class AccessControlAPI extends FeatureAPI {
 		}
 	}
 
+	// Drop cached credentials with composite keys in the exclusive range (from, to)
 	#reconcileCredentialGap_U3C(
 		userId: number,
 		from: number,

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -1683,15 +1683,6 @@ export class AccessControlAPI extends FeatureAPI {
 		}
 	}
 
-	/**
-	 * Removes cached credentials orphaned within the exclusive composite-key
-	 * range `(from, to)` of a U3C enumeration walk. Credentials enumerate in
-	 * ascending (type, slot) order, encoded as `(type << 16) | slot`, and the
-	 * node's next-credential pointer only advances to credentials that still
-	 * exist, so any cached entry the walk skipped over was deleted on the
-	 * device. For a user-scoped walk only that user's cached entries are
-	 * reconciled; a walk across all users (userId 0) reconciles every entry.
-	 */
 	#reconcileCredentialGap_U3C(
 		userId: number,
 		from: number,
@@ -1708,8 +1699,7 @@ export class AccessControlAPI extends FeatureAPI {
 		for (const { endpoint, propertyKey, value } of credentialOwners) {
 			const key = propertyKey as number;
 			if (key <= from || key >= to) continue;
-			// A user-scoped walk skips other users' credentials, so their
-			// presence in the gap is not evidence of deletion.
+			// Skip other users' entries because they aren't visited by this walk
 			if (userId !== 0 && value !== userId) continue;
 
 			const type = key >>> 16;
@@ -1849,9 +1839,6 @@ export class AccessControlAPI extends FeatureAPI {
 
 		const composite = (type: UserCredentialType, slot: number) =>
 			(type << 16) | slot;
-		// The scope's upper bound: the end of the filtered type, or past every
-		// possible credential for an unfiltered walk (type is a byte, slot a
-		// 16-bit value).
 		const scopeEnd = filterType != undefined
 			? composite(filterType + 1, 0)
 			: 0x100_0000;
@@ -1868,10 +1855,7 @@ export class AccessControlAPI extends FeatureAPI {
 			);
 			if (result) await this.endpoint.tryGetNode()?.handleCommand(result);
 			const credential = this.#mapCredentialData(result);
-			// An empty report (present, but no credential) on the first request
-			// means the node holds nothing in the walked scope, so drop every
-			// cached credential there. A missing response proves nothing and must
-			// leave the cache untouched.
+			// Explicit empty report on the first request — reconcile the entire scope
 			if (result && !credential && credentials.length === 0) {
 				this.#reconcileCredentialGap_U3C(
 					userId,
@@ -1888,8 +1872,7 @@ export class AccessControlAPI extends FeatureAPI {
 				break;
 			}
 
-			// The first in-scope result proves nothing exists between the walk's
-			// start and here, so drop any cached credential in that gap.
+			// Reconcile the leading gap before the first result
 			if (credentials.length === 0) {
 				this.#reconcileCredentialGap_U3C(
 					userId,
@@ -1903,8 +1886,7 @@ export class AccessControlAPI extends FeatureAPI {
 			const nextType = result.nextCredentialType
 				?? UserCredentialType.None;
 			const nextSlot = result.nextCredentialSlot ?? 0;
-			// A zero next pointer marks the end of the node's credential sequence,
-			// so every cached credential above this result is orphaned.
+			// Reconcile the trailing gap past the last result
 			if (
 				nextType === UserCredentialType.None
 				&& nextSlot === 0
@@ -1921,8 +1903,7 @@ export class AccessControlAPI extends FeatureAPI {
 			// type-filtered walks, stop before following that pointer into a
 			// different type.
 			if (filterType != undefined && nextType !== filterType) {
-				// A pointer into a later type proves no more credentials of the
-				// filtered type exist after this result, so its tail is orphaned.
+				// Reconcile the filtered type's tail when the pointer crosses into a later type
 				if (nextType > filterType) {
 					this.#reconcileCredentialGap_U3C(
 						userId,
@@ -1937,8 +1918,6 @@ export class AccessControlAPI extends FeatureAPI {
 				break;
 			}
 
-			// Any cached credential the node skipped between this result and the
-			// next pointer no longer exists, so drop it from the cache.
 			this.#reconcileCredentialGap_U3C(
 				userId,
 				composite(credential.type, credential.slot),

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -1892,3 +1892,464 @@ integrationTest(
 		},
 	},
 );
+
+// =============================================================================
+// getAllCredentials / getCredentialsByType / getCredentialsForUser reconcile
+// the cache against the node's enumeration walk
+// =============================================================================
+
+integrationTest(
+	"getAllCredentials purges leading, interior, and trailing orphaned credentials",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const userCreated = createDeferredPromise<void>();
+			node.once("user added", () => userCreated.resolve());
+			await node.accessControl!.setUser(1, {
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Alice",
+			});
+			await userCreated;
+
+			for (const slot of [1, 2, 3, 4, 5]) {
+				const added = createDeferredPromise<void>();
+				node.once("credential added", () => added.resolve());
+				await node.accessControl!.setCredential(
+					1,
+					UserCredentialType.PINCode,
+					slot,
+					`000${slot}`,
+				);
+				await added;
+			}
+			t.expect(node.accessControl!.getAllCredentialsCached().length).toBe(
+				5,
+			);
+
+			// Delete slots 1 (leading), 3 (interior) and 5 (trailing) directly on
+			// the device so the driver's cache is stale.
+			for (const slot of [1, 3, 5]) {
+				mockNode.state.delete(
+					`UserCredential_cred_${UserCredentialType.PINCode}_${slot}`,
+				);
+			}
+
+			const fresh = await node.accessControl!.getAllCredentials();
+			t.expect(fresh.map((c) => c.slot).sort()).toStrictEqual([2, 4]);
+
+			t.expect(
+				node.accessControl!.getAllCredentialsCached().map((c) => c.slot)
+					.sort(),
+			).toStrictEqual([2, 4]);
+			for (const slot of [1, 3, 5]) {
+				t.expect(
+					node.accessControl!.getCredentialCached(
+						UserCredentialType.PINCode,
+						slot,
+					),
+				).toBeUndefined();
+			}
+		},
+	},
+);
+
+integrationTest(
+	"getAllCredentials purges orphans across a credential type boundary",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+						[UserCredentialType.Password, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const userCreated = createDeferredPromise<void>();
+			node.once("user added", () => userCreated.resolve());
+			await node.accessControl!.setUser(1, {
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Alice",
+			});
+			await userCreated;
+
+			for (
+				const [type, slot] of [
+					[UserCredentialType.PINCode, 1],
+					[UserCredentialType.PINCode, 2],
+					[UserCredentialType.Password, 1],
+					[UserCredentialType.Password, 2],
+				] as const
+			) {
+				const added = createDeferredPromise<void>();
+				node.once("credential added", () => added.resolve());
+				await node.accessControl!.setCredential(
+					1,
+					type,
+					slot,
+					`000${slot}`,
+				);
+				await added;
+			}
+
+			// Delete the tail of the PIN type and the lead-in of the Password type.
+			mockNode.state.delete(
+				`UserCredential_cred_${UserCredentialType.PINCode}_2`,
+			);
+			mockNode.state.delete(
+				`UserCredential_cred_${UserCredentialType.Password}_1`,
+			);
+
+			const fresh = await node.accessControl!.getAllCredentials();
+			t.expect(fresh.map((c) => `${c.type}:${c.slot}`)).toStrictEqual([
+				`${UserCredentialType.PINCode}:1`,
+				`${UserCredentialType.Password}:2`,
+			]);
+
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.PINCode,
+					2,
+				),
+			).toBeUndefined();
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.Password,
+					1,
+				),
+			).toBeUndefined();
+		},
+	},
+);
+
+integrationTest(
+	"getCredentialsForUser purges only the queried user's orphaned credentials",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			for (const userId of [1, 2]) {
+				const uc = createDeferredPromise<void>();
+				node.once("user added", () => uc.resolve());
+				await node.accessControl!.setUser(userId, {
+					active: true,
+					userType: UserCredentialUserType.General,
+					userName: `U${userId}`,
+				});
+				await uc;
+			}
+
+			// user 1 owns slots 1 and 3; user 2 owns slot 2, sitting in user 1's gap.
+			for (
+				const [userId, slot] of [[1, 1], [2, 2], [1, 3]] as const
+			) {
+				const added = createDeferredPromise<void>();
+				node.once("credential added", () => added.resolve());
+				await node.accessControl!.setCredential(
+					userId,
+					UserCredentialType.PINCode,
+					slot,
+					`000${slot}`,
+				);
+				await added;
+			}
+
+			// Delete user 1's slot 3 on the device only.
+			mockNode.state.delete(
+				`UserCredential_cred_${UserCredentialType.PINCode}_3`,
+			);
+
+			const fresh = await node.accessControl!.getCredentialsForUser(1);
+			t.expect(fresh.map((c) => c.slot)).toStrictEqual([1]);
+
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.PINCode,
+					3,
+				),
+			).toBeUndefined();
+			// User 2's credential in the gap must survive.
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.PINCode,
+					2,
+				),
+			).toMatchObject({ userId: 2, slot: 2 });
+		},
+	},
+);
+
+integrationTest(
+	"getCredentialsByType purges the filtered type's tail past a type boundary",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+						[UserCredentialType.Password, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const userCreated = createDeferredPromise<void>();
+			node.once("user added", () => userCreated.resolve());
+			await node.accessControl!.setUser(1, {
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Alice",
+			});
+			await userCreated;
+
+			for (
+				const [type, slot] of [
+					[UserCredentialType.PINCode, 1],
+					[UserCredentialType.PINCode, 2],
+					[UserCredentialType.PINCode, 3],
+					[UserCredentialType.Password, 1],
+				] as const
+			) {
+				const added = createDeferredPromise<void>();
+				node.once("credential added", () => added.resolve());
+				await node.accessControl!.setCredential(
+					1,
+					type,
+					slot,
+					`000${slot}`,
+				);
+				await added;
+			}
+
+			// Delete the last PIN credential; the walk then crosses into Password.
+			mockNode.state.delete(
+				`UserCredential_cred_${UserCredentialType.PINCode}_3`,
+			);
+
+			const fresh = await node.accessControl!.getCredentialsByType(
+				UserCredentialType.PINCode,
+			);
+			t.expect(fresh.map((c) => c.slot)).toStrictEqual([1, 2]);
+
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.PINCode,
+					3,
+				),
+			).toBeUndefined();
+			// The later type is out of scope and must be left untouched.
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.Password,
+					1,
+				),
+			).toMatchObject({ slot: 1 });
+		},
+	},
+);
+
+integrationTest(
+	"getCredentialsForUser with a type purges that type's tail past a type boundary",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+						[UserCredentialType.Password, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const userCreated = createDeferredPromise<void>();
+			node.once("user added", () => userCreated.resolve());
+			await node.accessControl!.setUser(1, {
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Alice",
+			});
+			await userCreated;
+
+			for (
+				const [type, slot] of [
+					[UserCredentialType.PINCode, 1],
+					[UserCredentialType.PINCode, 2],
+					[UserCredentialType.Password, 1],
+				] as const
+			) {
+				const added = createDeferredPromise<void>();
+				node.once("credential added", () => added.resolve());
+				await node.accessControl!.setCredential(
+					1,
+					type,
+					slot,
+					`000${slot}`,
+				);
+				await added;
+			}
+
+			mockNode.state.delete(
+				`UserCredential_cred_${UserCredentialType.PINCode}_2`,
+			);
+
+			const fresh = await node.accessControl!.getCredentialsForUser(
+				1,
+				UserCredentialType.PINCode,
+			);
+			t.expect(fresh.map((c) => c.slot)).toStrictEqual([1]);
+
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.PINCode,
+					2,
+				),
+			).toBeUndefined();
+			t.expect(
+				node.accessControl!.getCredentialCached(
+					UserCredentialType.Password,
+					1,
+				),
+			).toMatchObject({ slot: 1 });
+		},
+	},
+);
+
+integrationTest(
+	"getAllCredentials clears the cache when the node reports no credentials",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: false,
+					supportsUserChecksum: false,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const userCreated = createDeferredPromise<void>();
+			node.once("user added", () => userCreated.resolve());
+			await node.accessControl!.setUser(1, {
+				active: true,
+				userType: UserCredentialUserType.General,
+				userName: "Alice",
+			});
+			await userCreated;
+
+			for (const slot of [1, 2]) {
+				const added = createDeferredPromise<void>();
+				node.once("credential added", () => added.resolve());
+				await node.accessControl!.setCredential(
+					1,
+					UserCredentialType.PINCode,
+					slot,
+					`000${slot}`,
+				);
+				await added;
+			}
+			t.expect(node.accessControl!.getAllCredentialsCached().length).toBe(
+				2,
+			);
+
+			// All credentials removed on the device; the node now reports empty.
+			for (const slot of [1, 2]) {
+				mockNode.state.delete(
+					`UserCredential_cred_${UserCredentialType.PINCode}_${slot}`,
+				);
+			}
+
+			const fresh = await node.accessControl!.getAllCredentials();
+			t.expect(fresh).toStrictEqual([]);
+			t.expect(node.accessControl!.getAllCredentialsCached())
+				.toStrictEqual(
+					[],
+				);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -1955,11 +1955,12 @@ integrationTest(
 			}
 
 			const fresh = await node.accessControl!.getAllCredentials();
-			t.expect(fresh.map((c) => c.slot).sort()).toStrictEqual([2, 4]);
+			t.expect(fresh.map((c) => c.slot).toSorted((a, b) => a - b))
+				.toStrictEqual([2, 4]);
 
 			t.expect(
 				node.accessControl!.getAllCredentialsCached().map((c) => c.slot)
-					.sort(),
+					.toSorted((a, b) => a - b),
 			).toStrictEqual([2, 4]);
 			for (const slot of [1, 3, 5]) {
 				t.expect(

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -1893,11 +1893,6 @@ integrationTest(
 	},
 );
 
-// =============================================================================
-// getAllCredentials / getCredentialsByType / getCredentialsForUser reconcile
-// the cache against the node's enumeration walk
-// =============================================================================
-
 integrationTest(
 	"getAllCredentials purges leading, interior, and trailing orphaned credentials",
 	{


### PR DESCRIPTION
User Credential CC would only purge cache entries when a credential was reported to be deleted, or modifying failed because of an empty slot. Querying all credentials did not clear stale cache entries.

With this PR, `getAllCredentials`, `getCredentialsByType`, `getCredentialsForUser` now drop cached credentials that are found to no longer exist (at the beginning, between the current and the next reported slot, and at the end of the list). When filtered by type, only the corresponding slots are purged, even if the reports would indicate gaps at the beginning of the next type.