### PR TITLE
docs: clarify firmware version range guidance for config authoring

### DIFF
--- a/.agents/instructions/config-files.md
+++ b/.agents/instructions/config-files.md
@@ -73,9 +73,11 @@ When authoring and reviewing configuration files, consistency is key for maintai
 ### Firmware Version
 
 - Should be as wide as possible, by default "0.0" to "255.255"
+- A single firmware version reported in an issue, interview, log, or the "Firmware Version" field of a device request is only the version of the reporter's unit. It is not a range boundary. Never copy it into `min` or `max`; keep the default "0.0" to "255.255".
 - Only specify a narrower range if
   - there are multiple revisions of a device that only differ in firmware version
   - changes in a firmware version are significant enough that using conditional parameters would introduce too much complexity
+- Narrowing requires evidence of such a split (e.g. a changelog or multiple existing configs). Absent that evidence, use the full default range even when a specific version is known.
 
 ## Configuration Parameters
 

--- a/.agents/skills/author-config-from-web/SKILL.md
+++ b/.agents/skills/author-config-from-web/SKILL.md
@@ -15,7 +15,9 @@ Before starting any work, ensure the user has provided all required information:
 4. **Website URL** containing configuration parameter details
 5. **Firmware Version Range** (optional)
 
-If any required information is missing, ask the user to provide it before proceeding. Unless explicitly specified otherwise use the default firmware version range of "0.0" to "255.255".
+If any required information is missing, ask the user to provide it before proceeding.
+
+Always use the default firmware version range of "0.0" to "255.255", unless the user provides an actual _range_ that marks a known split between device revisions. A single firmware version (e.g. the version of one reporter's unit) is not a range: do not put it in `min` or `max`, keep the default instead. See the Firmware Version rules in `.agents/instructions/config-files.md`.
 
 # Primary Tasks
 


### PR DESCRIPTION
## What

Sharpen the config-authoring guidance so a single firmware version is never used to narrow the top-level `firmwareVersion` range.

In #8960 an AI-authored config took the literal firmware version from the device-request issue (`10.13.6`) and put it in `min`, instead of defaulting to `0.0`–`255.255`. The existing rule stated the default but didn't call out the specific trap: the "Firmware Version" field of an issue (or an interview/log) is just the reporter's unit, not a range boundary.

## Changes

- **`.agents/instructions/config-files.md`** — Firmware Version section now states a single reported version is the reporter's unit, must never go in `min`/`max`, and narrowing requires evidence of a revision split.
- **`.agents/skills/author-config-from-web/SKILL.md`** — the "Firmware Version Range" input guidance clarifies that a single version is not a range; default to `0.0`–`255.255`.

## Verification

Reproduced the original bug with a subagent following the skill and feeding `10.13.6` into the firmware-range slot → produced `min: "10.13.6"`. After the wording change, the same prompt yields `0.0`–`255.255`.

Confirmed the change does **not** break the update-existing-device flow: deleted the firmware-4.70 params from `zen77.json`, then asked a subagent to update the device to firmware 4.70 from the Zooz changelog. It re-added params 35/36/37 gated with `$if firmwareVersion >= 4.70 && firmwareVersion < 10.0` and left the top-level range at `0.0`–`255.255` — i.e. the version is still used for `$if` conditionals, just not for the range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)