### PR TITLE
fix(config): broken link to Honeywell T6 Pro manual

### DIFF
--- a/packages/config/config/devices/0x0039/th6320zw.json
+++ b/packages/config/config/devices/0x0039/th6320zw.json
@@ -189,6 +189,6 @@
 		"skipConfigurationInfoQuery": true
 	},
 	"metadata": {
-		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=Manuals/2893/33-00414-01-min.pdf"
+		"manual": "https://products.z-wavealliance.org/wp-content/uploads/products/51223/33-00294_A%20and%2033-00296-01.compressed.pdf"
 	}
 }


### PR DESCRIPTION
The link to the manual was broken, and now it's not