### PR TITLE
fix(cc): purge deleted users and credentials from cache in `persistValues`

### DIFF
--- a/packages/cc/src/cc/UserCredentialCC.ts
+++ b/packages/cc/src/cc/UserCredentialCC.ts
@@ -2360,7 +2360,44 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;
 
-		if (this.userId === 0) return true;
+		if (this.userId === 0) {
+			if (
+				this.reportType === UserCredentialUserReportType.UserDeleted
+			) {
+				const valueDB = this.getValueDB(ctx);
+				const cachedUsersAndCredentials = valueDB.findValues(
+					(vid) =>
+						vid.endpoint === this.endpointIndex
+						&& (
+							UserCredentialCCValues.userType.is(vid)
+							|| UserCredentialCCValues.userActive.is(vid)
+							|| UserCredentialCCValues.credentialRule.is(vid)
+							|| UserCredentialCCValues.expiringTimeoutMinutes.is(
+								vid,
+							)
+							|| UserCredentialCCValues.userName.is(vid)
+							|| UserCredentialCCValues.userModifierType.is(vid)
+							|| UserCredentialCCValues.userModifierNodeId.is(vid)
+							|| UserCredentialCCValues.userChecksum.is(vid)
+							|| UserCredentialCCValues.credential.is(vid)
+							|| UserCredentialCCValues.credentialOwner.is(vid)
+							|| UserCredentialCCValues.credentialModifierType.is(
+								vid,
+							)
+							|| UserCredentialCCValues
+								.credentialModifierNodeId.is(vid)
+						),
+				);
+				for (const value of cachedUsersAndCredentials) {
+					valueDB.removeValue(value);
+				}
+				this.removeValue(
+					ctx,
+					UserCredentialCCValues.allUsersChecksum,
+				);
+			}
+			return true;
+		}
 
 		// A UserModifyRejectedLocationEmpty report means we have a stale cache
 		// entry for a user that no longer exists on the device.

--- a/packages/cc/src/cc/UserCredentialCC.ts
+++ b/packages/cc/src/cc/UserCredentialCC.ts
@@ -2437,6 +2437,51 @@ export class UserCredentialCCUserReport extends UserCredentialCC {
 				ctx,
 				UserCredentialCCValues.userModifierNodeId(userId),
 			);
+			this.removeValue(
+				ctx,
+				UserCredentialCCValues.userChecksum(userId),
+			);
+			this.removeValue(
+				ctx,
+				UserCredentialCCValues.allUsersChecksum,
+			);
+
+			// Deleting a user also deletes all credentials assigned to them.
+			const valueDB = this.getValueDB(ctx);
+			const credentialOwners = valueDB.findValues(
+				(vid) =>
+					UserCredentialCCValues.credentialOwner.is(vid)
+					&& vid.endpoint === this.endpointIndex,
+			);
+			for (const { endpoint, propertyKey, value } of credentialOwners) {
+				if (value !== userId) continue;
+
+				const key = propertyKey as number;
+				const credentialType = key >>> 16;
+				const credentialSlot = key & 0xffff;
+				for (
+					const valueId of [
+						UserCredentialCCValues.credential(
+							credentialType,
+							credentialSlot,
+						),
+						UserCredentialCCValues.credentialOwner(
+							credentialType,
+							credentialSlot,
+						),
+						UserCredentialCCValues.credentialModifierType(
+							credentialType,
+							credentialSlot,
+						),
+						UserCredentialCCValues.credentialModifierNodeId(
+							credentialType,
+							credentialSlot,
+						),
+					]
+				) {
+					valueDB.removeValue(valueId.endpoint(endpoint));
+				}
+			}
 			return true;
 		}
 

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -870,11 +870,7 @@ export class AccessControlAPI extends FeatureAPI {
 				userId,
 			});
 			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
-			const status = u3cUserReportTypeToSetUserResult(raw?.reportType);
-			if (status === SetUserResult.OK) {
-				this.#purgeCachedCredentials(userId);
-			}
-			return status;
+			return u3cUserReportTypeToSetUserResult(raw?.reportType);
 		} else {
 			// User Code CC ties each user to their code, so clearing
 			// the code implicitly deletes the user and vice versa.
@@ -924,12 +920,8 @@ export class AccessControlAPI extends FeatureAPI {
 				operationType: UserCredentialOperationType.Delete,
 				userId: 0,
 			});
-			const status = u3cUserReportTypeToSetUserResult(raw?.reportType);
-			if (status === SetUserResult.OK) {
-				this.#purgeAllCachedUsersAndCredentials();
-			}
 			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
-			return status;
+			return u3cUserReportTypeToSetUserResult(raw?.reportType);
 		} else {
 			const api = this.#ucAPI();
 			const result = await api.clear(0);
@@ -1365,23 +1357,10 @@ export class AccessControlAPI extends FeatureAPI {
 				credentialType,
 				credentialSlot: 0,
 			});
-			const status = u3cCredentialReportTypeToSetCredentialResult(
+			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
+			return u3cCredentialReportTypeToSetCredentialResult(
 				raw?.reportType,
 			);
-			if (status === SetCredentialResult.OK) {
-				// A specific type maps to its property-key range; None purges all types
-				if (credentialType === UserCredentialType.None) {
-					this.#purgeCachedCredentials(userId);
-				} else {
-					this.#purgeCachedCredentials(
-						userId,
-						credentialPropertyKey(credentialType, 0),
-						credentialPropertyKey(credentialType + 1, 0),
-					);
-				}
-			}
-			if (raw) await this.endpoint.tryGetNode()?.handleCommand(raw);
-			return status;
 		} else {
 			// User Code CC
 			if (
@@ -1693,46 +1672,6 @@ export class AccessControlAPI extends FeatureAPI {
 			) {
 				valueDB.removeValue(valueId.endpoint(endpoint));
 			}
-		}
-	}
-
-	/** Removes all cached user and credential values from the value DB */
-	#purgeAllCachedUsersAndCredentials(): void {
-		const valueDB = this.endpoint.tryGetNode()?.valueDB;
-		if (!valueDB) return;
-
-		const maxUsers = this.getValue<number>(
-			UserCredentialCCValues.supportedUsers.endpoint(
-				this.endpoint.index,
-			),
-		) ?? 0;
-		for (let userId = 1; userId <= maxUsers; userId++) {
-			for (
-				const value of [
-					UserCredentialCCValues.userType(userId),
-					UserCredentialCCValues.userActive(userId),
-					UserCredentialCCValues.credentialRule(userId),
-					UserCredentialCCValues.expiringTimeoutMinutes(userId),
-					UserCredentialCCValues.userName(userId),
-					UserCredentialCCValues.userModifierType(userId),
-					UserCredentialCCValues.userModifierNodeId(userId),
-					UserCredentialCCValues.userChecksum(userId),
-				]
-			) {
-				valueDB.removeValue(value.endpoint(this.endpoint.index));
-			}
-		}
-
-		// Remove all credential values
-		const credentialValues = valueDB.findValues(
-			(vid) =>
-				UserCredentialCCValues.credential.is(vid)
-				|| UserCredentialCCValues.credentialOwner.is(vid)
-				|| UserCredentialCCValues.credentialModifierType.is(vid)
-				|| UserCredentialCCValues.credentialModifierNodeId.is(vid),
-		);
-		for (const vid of credentialValues) {
-			valueDB.removeValue(vid);
 		}
 	}
 

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -506,8 +506,34 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			const userEvent = createDeferredPromise<unknown>();
-			node.on("user deleted", (_node, args) => userEvent.resolve(args));
+			const userTypeValueId = UserCredentialCCValues.userType(3)
+				.endpoint(0);
+			const credentialValueId = UserCredentialCCValues.credential(
+				UserCredentialType.PINCode,
+				1,
+			).endpoint(0);
+			const credentialOwnerValueId = UserCredentialCCValues
+				.credentialOwner(UserCredentialType.PINCode, 1).endpoint(0);
+			node.valueDB.setValue(
+				userTypeValueId,
+				UserCredentialUserType.General,
+			);
+			node.valueDB.setValue(credentialValueId, "1234");
+			node.valueDB.setValue(credentialOwnerValueId, 3);
+
+			const userEvent = createDeferredPromise<{
+				args: unknown;
+				user: unknown;
+				credentials: unknown[];
+			}>();
+			node.on("user deleted", (_node, args) => {
+				userEvent.resolve({
+					args,
+					user: node.accessControl!.getUserCached(3),
+					credentials: node.accessControl!
+						.getCredentialsForUserCached(3),
+				});
+			});
 
 			const cc = new UserCredentialCCUserReport({
 				nodeId: mockController.ownNodeId,
@@ -526,8 +552,10 @@ integrationTest(
 				createMockZWaveRequestFrame(cc, { ackRequested: false }),
 			);
 
-			t.expect(await userEvent).toMatchObject({
-				userId: 3,
+			t.expect(await userEvent).toStrictEqual({
+				args: { userId: 3 },
+				user: undefined,
+				credentials: [],
 			});
 		},
 	},
@@ -1812,8 +1840,6 @@ integrationTest(
 			await node.accessControl!.deleteUser(1);
 			await deleted;
 
-			// User values are purged by the CC report handler,
-			// credentials must be purged by the AccessControl mixin
 			t.expect(node.accessControl!.getUserCached(1)).toBeUndefined();
 			t.expect(
 				node.accessControl!.getCredentialsForUserCached(1).length,

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -16,6 +16,7 @@ import {
 	UserCredentialCCCredentialSet,
 	UserCredentialCCUserReport,
 	UserCredentialCCUserSet,
+	UserCredentialCCValues,
 } from "@zwave-js/cc/UserCredentialCC";
 import { CommandClasses } from "@zwave-js/core";
 import { Bytes } from "@zwave-js/shared";
@@ -528,6 +529,115 @@ integrationTest(
 			t.expect(await userEvent).toMatchObject({
 				userId: 3,
 			});
+		},
+	},
+);
+
+integrationTest(
+	"Unsolicited UserReport with UserDeleted reportType and user ID 0 purges all cached users and credentials",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				ccCaps({
+					ccId: CommandClasses["User Credential"],
+					isSupported: true,
+					version: 1,
+					numberOfSupportedUsers: 10,
+					supportedCredentialRules: [UserCredentialRule.Single],
+					maxUserNameLength: 32,
+					supportsAllUsersChecksum: true,
+					supportsUserChecksum: true,
+					supportsAdminCode: false,
+					supportedCredentialTypes: new Map([
+						[UserCredentialType.PINCode, defaultPINCapability],
+					]),
+				}),
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const cachedValueIds = [
+				UserCredentialCCValues.allUsersChecksum.endpoint(0),
+				...([1, 2] as const).flatMap((userId) => [
+					UserCredentialCCValues.userType(userId).endpoint(0),
+					UserCredentialCCValues.userActive(userId).endpoint(0),
+					UserCredentialCCValues.credentialRule(userId).endpoint(0),
+					UserCredentialCCValues.expiringTimeoutMinutes(userId)
+						.endpoint(0),
+					UserCredentialCCValues.userName(userId).endpoint(0),
+					UserCredentialCCValues.userModifierType(userId).endpoint(0),
+					UserCredentialCCValues.userModifierNodeId(userId)
+						.endpoint(0),
+					UserCredentialCCValues.userChecksum(userId).endpoint(0),
+					UserCredentialCCValues.credential(
+						UserCredentialType.PINCode,
+						userId,
+					).endpoint(0),
+					UserCredentialCCValues.credentialOwner(
+						UserCredentialType.PINCode,
+						userId,
+					).endpoint(0),
+					UserCredentialCCValues.credentialModifierType(
+						UserCredentialType.PINCode,
+						userId,
+					).endpoint(0),
+					UserCredentialCCValues.credentialModifierNodeId(
+						UserCredentialType.PINCode,
+						userId,
+					).endpoint(0),
+				]),
+			];
+			for (const [index, valueId] of cachedValueIds.entries()) {
+				node.valueDB.setValue(valueId, index);
+			}
+			const otherEndpointValueIds = [
+				UserCredentialCCValues.allUsersChecksum.endpoint(1),
+				UserCredentialCCValues.userType(1).endpoint(1),
+				UserCredentialCCValues.credential(
+					UserCredentialType.PINCode,
+					1,
+				).endpoint(1),
+				UserCredentialCCValues.credentialOwner(
+					UserCredentialType.PINCode,
+					1,
+				).endpoint(1),
+			];
+			for (const [index, valueId] of otherEndpointValueIds.entries()) {
+				node.valueDB.setValue(valueId, index);
+			}
+
+			for (const valueId of cachedValueIds) {
+				t.expect(node.getValue(valueId)).toBeDefined();
+			}
+
+			const deleted = createDeferredPromise<void>();
+			node.once("user deleted", () => deleted.resolve());
+
+			const cc = new UserCredentialCCUserReport({
+				nodeId: mockController.ownNodeId,
+				reportType: UserCredentialUserReportType.UserDeleted,
+				modifierType: UserCredentialModifierType.ZWave,
+				modifierNodeId: 1,
+				userId: 0,
+				userType: UserCredentialUserType.General,
+				active: false,
+				credentialRule: UserCredentialRule.Single,
+				expiringTimeoutMinutes: 0,
+				nameEncoding: UserCredentialNameEncoding.ASCII,
+				userName: "",
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, { ackRequested: false }),
+			);
+			await deleted;
+
+			for (const valueId of cachedValueIds) {
+				t.expect(node.getValue(valueId)).toBeUndefined();
+			}
+			for (const valueId of otherEndpointValueIds) {
+				t.expect(node.getValue(valueId)).toBeDefined();
+			}
 		},
 	},
 );


### PR DESCRIPTION
There was an inconsistency with how bulk user deletion reports were handled before. Through the AccessControl API, those purged the cache if received within the 1s timeout. As unsolicited reports they didn't. This PR fixes it and wires almost all cache purging through the `persistValues` handlers.

The only exception is partial purging of stale entries while enumerating users or credentials.