### PR TITLE
build: run bootstrap tasks serially to avoid clobbering build outputs

### DIFF
--- a/maintenance/bootstrap.sh
+++ b/maintenance/bootstrap.sh
@@ -6,7 +6,10 @@ echo "🏗️  Preparing repository..."
 echo ""
 yarn
 yarn node maintenance/patch-typescript.js
-yarn turbo run bootstrap
+# Run serially: the bootstrap scripts each build the shared project references
+# (core, shared, config) themselves, and concurrent builds clobber each other's
+# declaration outputs. Sequential runs skip them as up-to-date instead.
+yarn turbo run bootstrap --concurrency=1
 echo "✅ Repository ready"
 
 # Do not install VSCode extension on CI

--- a/maintenance/bootstrap.sh
+++ b/maintenance/bootstrap.sh
@@ -6,9 +6,8 @@ echo "🏗️  Preparing repository..."
 echo ""
 yarn
 yarn node maintenance/patch-typescript.js
-# Run serially: the bootstrap scripts each build the shared project references
-# (core, shared, config) themselves, and concurrent builds clobber each other's
-# declaration outputs. Sequential runs skip them as up-to-date instead.
+# Run bootstrap tasks serially because they depend on building shared references,
+# which would unnecessarily be rebuilt in parallel.
 yarn turbo run bootstrap --concurrency=1
 echo "✅ Repository ready"
 


### PR DESCRIPTION
Fixes the intermittent `Prepare testing environment` failures in CI, e.g. [run 30345964141](https://github.com/zwave-js/zwave-js/actions/runs/30345964141/job/90232112290) on a branch whose diff only touched `.github/`:

```
../core/src/security/Manager.ts:3:31 - error TS2305: Module '"@zwave-js/shared"' has no exported member 'Timer'.
src/rules/auto-unsigned.ts:1:55 - error TS2307: Cannot find module '@zwave-js/core' or its corresponding type declarations.
ERROR  @zwave-js/eslint-plugin#bootstrap: command (.../packages/eslint-plugin) yarn run bootstrap exited (2)
```

## Cause

The `bootstrap` task in `turbo.json` has no `dependsOn`, so every package's bootstrap runs concurrently. Three packages have a `bootstrap` script, and two of them build the shared project references themselves:

| Package | Script | Builds as references |
| --- | --- | --- |
| `@zwave-js/eslint-plugin` | `tsgo -b tsconfig.build.json` | `core`, `shared` |
| `@zwave-js/mcp-server-dev` | `tsgo -b` | `config`, `core`, `shared`, `maintenance` |
| `@zwave-js/transformers` | `tsgo -b tsconfig.build.json` | — |

Stracing both builds in parallel from a clean worktree shows **474 identical output paths written by both processes**, every one opened `O_CREAT|O_TRUNC` with zero `rename` calls — so writes happen in place and a concurrent reader can observe a truncated file.

That explains the exact error text. `packages/shared/src/index.ts` re-exports `./Timers.js`, so a `Timers.d.ts` that has not been written yet makes `index.d.ts` resolve with no `Timer`/`setTimer` export, rather than failing as a missing module.

## Fix

Run the bootstrap tasks serially. The later builds then find the shared references up to date and skip them entirely instead of rebuilding them — verified by `Timers.d.ts` keeping its mtime across a subsequent `mcp-server-dev` bootstrap.

`"dependsOn": ["^bootstrap"]` was considered and does not work here: `turbo run bootstrap --dry=json` reports empty `dependencies` for all 16 bootstrap tasks, because `core`, `shared` and `config` have no `bootstrap` script for `^bootstrap` to resolve to. It also would not order `eslint-plugin` against `mcp-server-dev`, which are siblings.

## Cost

Clean-state bootstrap on 32 cores: **1.30s parallel → 2.08s serial**. Total CPU time drops from 6.48s to 5.40s, since the duplicated `core`/`shared` compile disappears.

## Verification

- Straced under the fix: each shared output file has exactly one writing PID.
- Three consecutive `CI=1 yarn bootstrap` runs from a clean worktree succeed, followed by a successful `yarn build`.

`bootstrap.sh` is the only entry point affected. `yarn lint:zwave`'s `dependsOn: ["bootstrap"]` is unprefixed, so it only pulls in `@zwave-js/config#bootstrap`, which has no script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)