### PR TITLE
build: actually install the git hooks, ignore false-positive project reference

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -24,6 +24,9 @@ runs:
 
     - name: Install dependencies
       shell: bash
+      # Skip installing the git hooks, so jobs that commit are not subject to them
+      env:
+        HUSKY: 0
       run: |
         yarn install --immutable
         yarn bootstrap

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -40,6 +40,9 @@ jobs:
 
       - name: Install dependencies
         shell: bash
+        # Skip installing the git hooks, so jobs that commit are not subject to them
+        env:
+          HUSKY: 0
         run: |
           yarn install --immutable
           yarn bootstrap

--- a/.github/workflows/nightly-config-publish.yml
+++ b/.github/workflows/nightly-config-publish.yml
@@ -66,6 +66,9 @@ jobs:
 
     - name: Install dependencies
       if: steps.detect-changes.outputs.HAS_CHANGES == 'true'
+      # Skip installing the git hooks, so jobs that commit are not subject to them
+      env:
+        HUSKY: 0
       run: |
         yarn install --immutable
         yarn bootstrap

--- a/maintenance/tsconfig-references-plugin.cjs
+++ b/maintenance/tsconfig-references-plugin.cjs
@@ -1,0 +1,26 @@
+"use strict";
+
+const { plugin: workspacesPlugin } = require(
+	"@monorepo-utils/workspaces-to-typescript-project-references/lib/manager/workspaces",
+);
+
+// Workspace dependencies that must not become project references, keyed by the
+// consuming package. These are built by `yarn bootstrap` instead.
+const ignoredDependencies = {
+	// Codegen replaces the `validateArgs` imports with generated local helpers,
+	// so the compiled src_gen directory never references the transformers
+	"@zwave-js/cc": ["@zwave-js/transformers"],
+};
+
+exports.plugin = (options) => {
+	const inner = workspacesPlugin(options);
+	return {
+		...inner,
+		getDependencies(packageJSON) {
+			const ignored = ignoredDependencies[packageJSON.name] ?? [];
+			return inner
+				.getDependencies(packageJSON)
+				.filter((dep) => !ignored.includes(dep.name));
+		},
+	};
+};

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "release": "release-script",
     "release:all": "release-script --publish-all",
     "bootstrap": "./maintenance/bootstrap.sh",
-    "prepare": "husky",
+    "postinstall": "husky",
     "config": "yarn ts packages/config/maintenance/importConfig.ts",
     "docs": "docsify serve docs",
     "docs:generate": "yarn docs:generate-examples && yarn docs:generate-imports && yarn docs:generate-cc-apis",
@@ -156,8 +156,8 @@
     "extract-api": "FORCE_COLOR=1 yarn turbo run extract-api",
     "accept-api": "yarn extract-api -- --local",
     "monopack": "yarn exec monopack",
-    "check-references": "workspaces-to-typescript-project-references --check --tsconfigPath tsconfig.build.json",
-    "sync-references": "workspaces-to-typescript-project-references --tsconfigPath tsconfig.build.json && yarn fmt > /dev/null"
+    "check-references": "workspaces-to-typescript-project-references --check --tsconfigPath tsconfig.build.json --plugin maintenance/tsconfig-references-plugin.cjs",
+    "sync-references": "workspaces-to-typescript-project-references --tsconfigPath tsconfig.build.json --plugin maintenance/tsconfig-references-plugin.cjs && yarn fmt > /dev/null"
   },
   "readme": "README.md",
   "config": {


### PR DESCRIPTION
The hooks in `.husky` have not been running. Root `package.json` wires husky up as `"prepare": "husky"`, and Yarn Berry does not run the `prepare` lifecycle script, so husky's installer was never invoked: `core.hooksPath` is unset, `.git/hooks` holds only samples, and `.husky/_/` has never existed. Moving it to `postinstall` fixes that — Yarn does run that one for the root workspace.

## The `packages/cc` false positive

With the hooks active, `yarn check-references` fails on a pre-existing mismatch. `packages/cc/package.json` declares `@zwave-js/transformers` as a workspace devDependency, and `workspaces-to-typescript-project-references` derives the expected `references` array from a package's workspace dependencies, so it wants a project reference for it.

That reference is not wanted. #8576 replaced `ts-patch` with the two-stage codegen+build process and removed it deliberately: codegen rewrites the `@validateArgs()` decorators into generated local helpers, so `packages/cc/src_gen` — the only input of `packages/cc/tsconfig.build.json` — contains zero imports of `@zwave-js/transformers`. The devDependency is still correct, since `packages/cc/src` uses it before codegen runs, but the package is a `yarn bootstrap` prerequisite rather than a project reference.

The tool has no ignore option, so `maintenance/tsconfig-references-plugin.cjs` wraps its built-in workspaces plugin and drops that one edge. `yarn sync-references` leaves every `tsconfig.build.json` untouched with the plugin in place.

## Verification

- Removed `.husky/_` and the install state, then ran `yarn install`: Yarn reports `@zwave-js/repo@workspace:. must be built because it never has been before`, recreates `.husky/_`, and sets `core.hooksPath=.husky/_`.
- A commit now runs both hooks — `pre-commit` (`check-references` + lint-staged) and `commit-msg` (commitlint rejected a bad subject).
- Deleting the `../core/tsconfig.build.json` reference from `packages/eslint-plugin/tsconfig.build.json` makes `pre-commit` block the commit, so genuine mismatches are still caught.
- `yarn check-references` exits 0 on an otherwise unmodified tree.

Note that Yarn only re-runs `postinstall` when it considers the workspace in need of a rebuild, not on every `yarn install`. That covers the fresh-clone and `yarn bootstrap` paths, which is when the hooks need wiring up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)