### PR TITLE
fix(bot): balance braces in the getComments GraphQL query

### DIFF
--- a/.github/bot-scripts/answerFromDocs.cjs
+++ b/.github/bot-scripts/answerFromDocs.cjs
@@ -76,6 +76,7 @@ async function alreadyAnswered({ github, context }, post, isDiscussion) {
 							}
 						}
 					}
+				}
 				`,
 				{ discussionId: post.node_id, cursor },
 			);


### PR DESCRIPTION
## Description

The `getComments` query in `alreadyAnswered` is missing its outermost closing brace (6 `{` vs. 5 `}`), so every already-answered check for discussions fails with a GraphQL parse error. Found while porting the answer bot to zwave-js-ui, whose copy of this query is balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)