### PR TITLE
feat(core): implement ChaCha20-Poly1305 in the browser crypto primitives

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -98,6 +98,7 @@
   },
   "dependencies": {
     "@alcalzone/jsonl-db": "^4.0.2",
+    "@noble/ciphers": "^2.2.0",
     "@zwave-js/shared": "workspace:*",
     "alcalzone-shared": "^5.0.0",
     "ansi-colors": "^4.1.3",

--- a/packages/core/src/crypto/primitives/primitives.browser.ts
+++ b/packages/core/src/crypto/primitives/primitives.browser.ts
@@ -1,3 +1,4 @@
+import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
 import { Bytes, type BytesView } from "@zwave-js/shared";
 import type { CryptoPrimitives, KeyPair } from "@zwave-js/shared/bindings";
 import type { webcrypto } from "node:crypto";
@@ -434,9 +435,10 @@ async function digest(
 	algorithm: "md5" | "sha-1" | "sha-256",
 	data: BytesView,
 ): Promise<BytesView> {
-	// The WebCrypto API does not support MD5, but we don't actually care.
-	// MD5 is only used for hashing cached device configurations, and if anyone
-	// is going to use these methods, they should be on a new installation anyways.
+	// Substitute SHA-256 for the MD5 the WebCrypto API lacks. md5 is only reachable
+	// through DeviceConfig.getHash(0), which is only used for a 16-byte unprefixed
+	// cached hash written by a pre-hash-v1 Node build. The resulting length mismatch
+	// makes the node re-interview once and rewrite the hash at the current version.
 	if (algorithm === "md5") {
 		algorithm = "sha-256";
 	}
@@ -459,31 +461,44 @@ async function hmacSHA256(
 	return new Uint8Array(signature);
 }
 
-// ChaCha20-Poly1305 is not supported in the browser environment.
-// Web Crypto API does not provide ChaCha20-Poly1305.
-// These functions will throw if called; a proper solution needs to be implemented.
+const POLY1305_TAG_LENGTH = 16;
 
+// No shipping browser exposes ChaCha20-Poly1305 through the Web Crypto API,
+// so the pure JS implementation from @noble/ciphers is used instead
 async function encryptChaCha20Poly1305(
-	_key: BytesView,
-	_nonce: BytesView,
-	_additionalData: BytesView,
-	_plaintext: BytesView,
+	key: BytesView,
+	nonce: BytesView,
+	additionalData: BytesView,
+	plaintext: BytesView,
 ): Promise<{ ciphertext: BytesView; authTag: BytesView }> {
-	throw new Error(
-		"ChaCha20-Poly1305 is not supported in the browser environment",
-	);
+	const output = chacha20poly1305(key, nonce, additionalData)
+		.encrypt(plaintext);
+
+	// noble appends the Poly1305 tag to the ciphertext
+	const ciphertext = output.slice(0, -POLY1305_TAG_LENGTH);
+	const authTag = output.slice(-POLY1305_TAG_LENGTH);
+
+	return { ciphertext, authTag };
 }
 
 async function decryptChaCha20Poly1305(
-	_key: BytesView,
-	_nonce: BytesView,
-	_additionalData: BytesView,
-	_ciphertext: BytesView,
-	_authTag: BytesView,
+	key: BytesView,
+	nonce: BytesView,
+	additionalData: BytesView,
+	ciphertext: BytesView,
+	authTag: BytesView,
 ): Promise<{ plaintext: BytesView; authOK: boolean }> {
-	throw new Error(
-		"ChaCha20-Poly1305 is not supported in the browser environment",
-	);
+	// noble expects the Poly1305 tag to be part of the ciphertext
+	const input = Bytes.concat([ciphertext, authTag]);
+
+	try {
+		const plaintext = chacha20poly1305(key, nonce, additionalData)
+			.decrypt(input);
+		return { plaintext, authOK: true };
+	} catch {
+		// noble throws when the tag does not match
+		return { plaintext: new Uint8Array(), authOK: false };
+	}
 }
 
 async function generateECDHKeyPair(): Promise<KeyPair> {

--- a/packages/core/src/crypto/primitives/primitives.browser.ts
+++ b/packages/core/src/crypto/primitives/primitives.browser.ts
@@ -463,8 +463,6 @@ async function hmacSHA256(
 
 const POLY1305_TAG_LENGTH = 16;
 
-// No shipping browser exposes ChaCha20-Poly1305 through the Web Crypto API,
-// so the pure JS implementation from @noble/ciphers is used instead
 async function encryptChaCha20Poly1305(
 	key: BytesView,
 	nonce: BytesView,

--- a/packages/core/src/crypto/primitives/primitives.test.ts
+++ b/packages/core/src/crypto/primitives/primitives.test.ts
@@ -22,6 +22,8 @@ for (
 		encryptAES128OFB,
 		encryptAES128CCM,
 		decryptAES128CCM,
+		encryptChaCha20Poly1305,
+		decryptChaCha20Poly1305,
 		randomBytes,
 	}: CryptoPrimitives = (await import(primitives)).primitives;
 
@@ -360,6 +362,105 @@ for (
 
 		assertBufferEquals(t.expect, actual.plaintext, expectedPlaintext);
 		t.expect(actual.authOK).toBe(expectedAuthOK);
+	});
+
+	// Test vectors taken from RFC 8439, section 2.8.2
+	const chachaKey = Bytes.from(
+		"808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f",
+		"hex",
+	);
+	const chachaNonce = Bytes.from("070000004041424344454647", "hex");
+	const chachaAAD = Bytes.from("50515253c0c1c2c3c4c5c6c7", "hex");
+	const chachaPlaintext = Bytes.from(
+		"4c616469657320616e642047656e746c656d656e206f662074686520636c617373206f66202739393a204966204920636f756c64206f6666657220796f75206f6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73637265656e20776f756c642062652069742e",
+		"hex",
+	);
+	const chachaCiphertext = Bytes.from(
+		"d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d63dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b3692ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc3ff4def08e4b7a9de576d26586cec64b6116",
+		"hex",
+	);
+	const chachaAuthTag = Bytes.from(
+		"1ae10b594f09e26a7e902ecbd0600691",
+		"hex",
+	);
+
+	test(`${primitives} -> encryptChaCha20Poly1305() -> should work correctly`, async (t) => {
+		const actual = await encryptChaCha20Poly1305(
+			chachaKey,
+			chachaNonce,
+			chachaAAD,
+			chachaPlaintext,
+		);
+
+		assertBufferEquals(t.expect, actual.ciphertext, chachaCiphertext);
+		assertBufferEquals(t.expect, actual.authTag, chachaAuthTag);
+	});
+
+	test(`${primitives} -> decryptChaCha20Poly1305() -> should work correctly`, async (t) => {
+		const actual = await decryptChaCha20Poly1305(
+			chachaKey,
+			chachaNonce,
+			chachaAAD,
+			chachaCiphertext,
+			chachaAuthTag,
+		);
+
+		assertBufferEquals(t.expect, actual.plaintext, chachaPlaintext);
+		t.expect(actual.authOK).toBe(true);
+	});
+
+	test(`${primitives} -> decryptChaCha20Poly1305() -> should fail authentication when the auth tag was corrupted`, async (t) => {
+		const corruptedAuthTag = chachaAuthTag.slice();
+		corruptedAuthTag[0] ^= 0xff;
+
+		const actual = await decryptChaCha20Poly1305(
+			chachaKey,
+			chachaNonce,
+			chachaAAD,
+			chachaCiphertext,
+			corruptedAuthTag,
+		);
+
+		assertBufferEquals(t.expect, actual.plaintext, new Uint8Array());
+		t.expect(actual.authOK).toBe(false);
+	});
+
+	test(`${primitives} -> decryptChaCha20Poly1305() -> should fail authentication when the additional data was changed`, async (t) => {
+		const actual = await decryptChaCha20Poly1305(
+			chachaKey,
+			chachaNonce,
+			chachaAAD.subarray(0, -1),
+			chachaCiphertext,
+			chachaAuthTag,
+		);
+
+		assertBufferEquals(t.expect, actual.plaintext, new Uint8Array());
+		t.expect(actual.authOK).toBe(false);
+	});
+
+	test(`${primitives} -> encryptChaCha20Poly1305() / decryptChaCha20Poly1305() -> should be able to en- and decrypt the same data`, async (t) => {
+		const plaintextIn =
+			"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam";
+		const key = randomBytes(32);
+		const nonce = randomBytes(12);
+		const additionalData = randomBytes(8);
+
+		const { ciphertext, authTag } = await encryptChaCha20Poly1305(
+			key,
+			nonce,
+			additionalData,
+			Bytes.from(plaintextIn),
+		);
+		const { plaintext, authOK } = await decryptChaCha20Poly1305(
+			key,
+			nonce,
+			additionalData,
+			ciphertext,
+			authTag,
+		);
+
+		t.expect(authOK).toBe(true);
+		t.expect(Bytes.view(plaintext).toString()).toBe(plaintextIn);
 	});
 }
 

--- a/packages/eslint-plugin/src/rules/no-forbidden-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-forbidden-imports.ts
@@ -12,6 +12,7 @@ const whitelistedImports = new Set([
 	"nrf-intel-hex",
 	"triple-beam",
 	"@andrewbranch/untar.js",
+	"@noble/ciphers/chacha.js",
 	"alcalzone-shared/arrays",
 	"alcalzone-shared/async",
 	"alcalzone-shared/comparable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,6 +1701,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/ciphers@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@noble/ciphers@npm:2.2.0"
+  checksum: 10/d75348aa682b41ad3e24cdd0a56c6d9ca033fb629ab93f37d6690be41c4882359b27598a11af0f5439ba82df4f9e3875dea1f875064310f68fef63cf24e3481a
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -3405,6 +3412,7 @@ __metadata:
   resolution: "@zwave-js/core@workspace:packages/core"
   dependencies:
     "@alcalzone/jsonl-db": "npm:^4.0.2"
+    "@noble/ciphers": "npm:^2.2.0"
     "@types/node": "npm:^20.19.35"
     "@types/semver": "npm:^7.7.1"
     "@types/sinon": "npm:^21.0.0"


### PR DESCRIPTION
The browser crypto primitives threw when asked for ChaCha20-Poly1305, so the ESPHome Noise transport could not be used on non-Node runtimes (QuickJS/txiki.js, Deno, Bun, browsers). No shipping browser exposes ChaCha20-Poly1305 through the Web Crypto API, so a JS implementation is the only portable option.

- `encryptChaCha20Poly1305` / `decryptChaCha20Poly1305` in `primitives.browser.ts` now use `@noble/ciphers`, imported from the narrow `chacha.js` subpath so no AES, Salsa or FF1 code is pulled in. The package has no runtime dependencies.
- The tag is split off the ciphertext on encrypt, and a tag mismatch is reported as `{ plaintext: <empty>, authOK: false }`, matching `decryptAES128CCM`.
- `@noble/ciphers/chacha.js` is whitelisted in the `no-forbidden-imports` lint rule as browser-safe.

Verified: the cross-implementation `primitives.test.ts` now covers both ChaCha primitives for the browser and Node implementations against the RFC 8439 section 2.8.2 vector, plus round-trip, corrupted-tag and modified-AAD cases (46 tests pass). `yarn check:browser` and `yarn lint:ts` pass.