### PR TITLE
refactor(shared): provide setImmediate instead of using the Node global

### DIFF
--- a/packages/serial/src/plumbing/SerialModeSwitch.ts
+++ b/packages/serial/src/plumbing/SerialModeSwitch.ts
@@ -1,4 +1,4 @@
-import { Bytes, type BytesView, getenv } from "@zwave-js/shared";
+import { Bytes, type BytesView, getenv, setImmediate } from "@zwave-js/shared";
 import { bootloaderMenuPreamble } from "../parsers/BootloaderParsers.js";
 import { ZWaveSerialMode } from "../serialport/definitions.js";
 

--- a/packages/shared/src/Timers.test.ts
+++ b/packages/shared/src/Timers.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, test, vi } from "vitest";
+import * as nativeTimers from "./Timers.js";
+
+/**
+ * Re-imports the module with the given globals removed, so the tests also cover
+ * the MessageChannel and setTimeout fallbacks used on non-Node runtimes.
+ */
+async function importWithout(
+	...globals: string[]
+): Promise<typeof import("./Timers.js")> {
+	vi.resetModules();
+	for (const name of globals) {
+		vi.stubGlobal(name, undefined);
+	}
+	try {
+		return await import("./Timers.js");
+	} finally {
+		vi.unstubAllGlobals();
+	}
+}
+
+const variants: [
+	name: string,
+	load: () => Promise<
+		typeof import("./Timers.js")
+	>,
+][] = [
+	["native setImmediate", () => Promise.resolve(nativeTimers)],
+	["MessageChannel fallback", () => importWithout("setImmediate")],
+	[
+		"setTimeout fallback",
+		() => importWithout("setImmediate", "MessageChannel"),
+	],
+];
+
+afterEach(() => {
+	vi.resetModules();
+});
+
+for (const [variant, load] of variants) {
+	test(`${variant}: invokes the callback asynchronously`, async (t) => {
+		const timers = await load();
+		let called = false;
+		timers.setImmediate(() => {
+			called = true;
+		});
+		t.expect(called).toBe(false);
+
+		await new Promise<void>((resolve) => timers.setImmediate(resolve));
+		t.expect(called).toBe(true);
+	});
+
+	test(`${variant}: forwards additional arguments to the callback`, async (t) => {
+		const timers = await load();
+		const actual = await new Promise<[number, string]>((resolve) => {
+			timers.setImmediate(
+				(a: number, b: string) => resolve([a, b]),
+				1,
+				"foo",
+			);
+		});
+		t.expect(actual).toStrictEqual([1, "foo"]);
+	});
+
+	test(`${variant}: clear() prevents the callback from running`, async (t) => {
+		const timers = await load();
+		let called = false;
+		const immediate = timers.setImmediate(() => {
+			called = true;
+		});
+		immediate.clear();
+
+		// Yield twice, so an uncleared callback would have had a chance to run
+		await new Promise<void>((resolve) => timers.setImmediate(resolve));
+		await new Promise<void>((resolve) => timers.setImmediate(resolve));
+		t.expect(called).toBe(false);
+	});
+}

--- a/packages/shared/src/Timers.ts
+++ b/packages/shared/src/Timers.ts
@@ -188,8 +188,6 @@ export function setInterval<TArgs extends any[]>(
 
 /**
  * Schedules the callback to run in a later task, once the microtask queue has drained.
- * This uses Node's `setImmediate` where available, so its ordering relative to timers
- * and I/O is whatever the runtime provides.
  */
 export function setImmediate<TArgs extends any[]>(
 	callback: (...args: TArgs) => void,

--- a/packages/shared/src/Timers.ts
+++ b/packages/shared/src/Timers.ts
@@ -63,6 +63,109 @@ export class Interval {
 	}
 }
 
+interface ImmediateBackend {
+	schedule(
+		callback: (...args: any[]) => void,
+		args: any[],
+	): NodeJS.Immediate | number;
+	clear(handle: NodeJS.Immediate | number): void;
+}
+
+function createImmediateBackend(): ImmediateBackend {
+	// Typed as possibly undefined because only Node has this
+	const nativeSetImmediate: typeof globalThis.setImmediate | undefined =
+		globalThis.setImmediate;
+	if (nativeSetImmediate) {
+		return {
+			schedule: (callback, args) => nativeSetImmediate(callback, ...args),
+			clear: (handle) =>
+				globalThis.clearImmediate(handle as NodeJS.Immediate),
+		};
+	}
+
+	const pending = new Map<
+		number,
+		{ callback: (...args: any[]) => void; args: any[] }
+	>();
+	let nextHandle = 1;
+	let running = false;
+
+	function run(handle: number): void {
+		// Defer while another callback is executing, so callbacks never run nested
+		if (running) {
+			globalThis.setTimeout(run, 0, handle);
+			return;
+		}
+		const task = pending.get(handle);
+		if (!task) return;
+		running = true;
+		try {
+			task.callback(...task.args);
+		} finally {
+			pending.delete(handle);
+			running = false;
+		}
+	}
+
+	// The Node type definitions describe MessagePort without the DOM methods, and this
+	// branch only runs where there is no native setImmediate
+	const MessageChannelCtor = globalThis.MessageChannel as unknown as
+		| (new () => {
+			port1: {
+				addEventListener(
+					type: "message",
+					listener: (event: { data: number }) => void,
+				): void;
+				start(): void;
+			};
+			port2: { postMessage(value: number): void };
+		})
+		| undefined;
+
+	let register: (handle: number) => void;
+	if (MessageChannelCtor) {
+		// Posting a message queues a task rather than a timer, so neither Node's 1 ms
+		// delay floor nor the HTML spec's 4 ms clamp on nested timeouts applies
+		const channel = new MessageChannelCtor();
+		channel.port1.addEventListener("message", (event) => run(event.data));
+		// addEventListener does not implicitly start the port, unlike assigning to onmessage
+		channel.port1.start();
+		register = (handle) => channel.port2.postMessage(handle);
+	} else {
+		register = (handle) => {
+			globalThis.setTimeout(run, 0, handle);
+		};
+	}
+
+	return {
+		schedule: (callback, args) => {
+			const handle = nextHandle++;
+			pending.set(handle, { callback, args });
+			register(handle);
+			return handle;
+		},
+		clear: (handle) => {
+			pending.delete(handle as number);
+		},
+	};
+}
+
+const immediateBackend = createImmediateBackend();
+
+export class Immediate {
+	readonly #inner: NodeJS.Immediate | number;
+
+	/** @internal */
+	constructor(callback: (...args: any[]) => void, args: any[]) {
+		this.#inner = immediateBackend.schedule(callback, args);
+	}
+
+	/** Cancels the callback if it has not run yet. */
+	public clear(): void {
+		immediateBackend.clear(this.#inner);
+	}
+}
+
 export function setTimer<TArgs extends any[]>(
 	callback: (...args: TArgs) => void,
 	delay?: number,
@@ -81,4 +184,15 @@ export function setInterval<TArgs extends any[]>(
 	...args: TArgs
 ): Interval {
 	return new Interval(globalThis.setInterval(callback, delay, ...args));
+}
+
+/**
+ * Schedules the callback to run after the current operation completes and pending I/O
+ * has been processed, equivalent to Node's `setImmediate`.
+ */
+export function setImmediate<TArgs extends any[]>(
+	callback: (...args: TArgs) => void,
+	...args: TArgs
+): Immediate {
+	return new Immediate(callback, args);
 }

--- a/packages/shared/src/Timers.ts
+++ b/packages/shared/src/Timers.ts
@@ -187,8 +187,9 @@ export function setInterval<TArgs extends any[]>(
 }
 
 /**
- * Schedules the callback to run after the current operation completes and pending I/O
- * has been processed, equivalent to Node's `setImmediate`.
+ * Schedules the callback to run in a later task, once the microtask queue has drained.
+ * This uses Node's `setImmediate` where available, so its ordering relative to timers
+ * and I/O is whatever the runtime provides.
  */
 export function setImmediate<TArgs extends any[]>(
 	callback: (...args: TArgs) => void,

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -298,6 +298,7 @@ import {
 	noop,
 	num2hex,
 	pick,
+	setImmediate,
 } from "@zwave-js/shared";
 import { waitFor } from "@zwave-js/waddle";
 import { distinct } from "alcalzone-shared/arrays";

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -68,6 +68,7 @@ import {
 	SerialAPIWakeUpReason,
 	SoftResetRequest,
 } from "@zwave-js/serial/serialapi";
+import { setImmediate } from "@zwave-js/shared";
 import {
 	MOCK_FRAME_ACK_TIMEOUT,
 	type MockController,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -183,6 +183,7 @@ import {
 	AsyncQueue,
 	Bytes,
 	type BytesView,
+	type Immediate,
 	type Interval,
 	type Timer,
 	TypedEventTarget,
@@ -198,6 +199,7 @@ import {
 	noop,
 	num2hex,
 	pick,
+	setImmediate,
 	setInterval,
 	setTimer,
 } from "@zwave-js/shared";
@@ -6798,10 +6800,10 @@ ${handlers.length} left`,
 	private async drainTransactionQueue(
 		queue: TransactionQueue,
 	): Promise<void> {
-		let setIdleTimer: NodeJS.Immediate | undefined;
+		let setIdleTimer: Immediate | undefined;
 		for await (const transaction of queue) {
 			if (setIdleTimer) {
-				clearImmediate(setIdleTimer);
+				setIdleTimer.clear();
 				setIdleTimer = undefined;
 			}
 			this.markQueueBusy(queue, true);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -170,6 +170,7 @@ import {
 	getErrorMessage,
 	noop,
 	pick,
+	setImmediate,
 } from "@zwave-js/shared";
 import { waitFor } from "@zwave-js/waddle";
 import { wait } from "alcalzone-shared/async";

--- a/packages/zwave-js/src/lib/node/mixins/70_FirmwareUpdate.ts
+++ b/packages/zwave-js/src/lib/node/mixins/70_FirmwareUpdate.ts
@@ -31,7 +31,12 @@ import {
 	timespan,
 } from "@zwave-js/core";
 import { containsCC } from "@zwave-js/serial/serialapi";
-import { type BytesView, getEnumMemberName, throttle } from "@zwave-js/shared";
+import {
+	type BytesView,
+	getEnumMemberName,
+	setImmediate,
+	throttle,
+} from "@zwave-js/shared";
 import { waitFor } from "@zwave-js/waddle";
 import { distinct } from "alcalzone-shared/arrays";
 import { wait } from "alcalzone-shared/async";

--- a/packages/zwave-js/src/lib/zniffer/Zniffer.ts
+++ b/packages/zwave-js/src/lib/zniffer/Zniffer.ts
@@ -83,6 +83,7 @@ import {
 	noop,
 	num2hex,
 	pick,
+	setImmediate,
 } from "@zwave-js/shared";
 import type { ZWaveOptions } from "../driver/ZWaveOptions.js";
 import { ZnifferLogger } from "../log/Zniffer.js";


### PR DESCRIPTION
## Why

`setImmediate` is a Node.js-only global. Around 17 production call sites used it directly, so the driver could not even start on non-Node runtimes — QuickJS/txiki.js, Deno, Bun, or in the browser.

`queueMicrotask` is not a usable substitute: draining microtasks never advances the event loop, and every one of these call sites depends on pending I/O being flushed first.

## What

`@zwave-js/shared` now exports `setImmediate`, returning an `Immediate` with a `clear()` method. This mirrors the existing `setTimer`/`setInterval` shape, so the idle timer in `Driver.drainTransactionQueue` keeps working without a separate `clearImmediate`.

The backend is resolved once at module scope:

1. `globalThis.setImmediate` when present (Node).
2. `MessageChannel` when present (browsers, workers). Posting a message queues a *task*, not a timer, so neither Node's 1 ms delay floor nor the HTML spec's 4 ms clamp on nested timeouts applies. Dispatch goes through a handle id into a `Map`, with the same re-entrancy guard as the YuzuJS polyfill so callbacks never run nested.
3. `setTimeout(fn, 0)` as a last resort.

All call sites in `Controller.ts`, `Driver.ts`, `Node.ts`, `70_FirmwareUpdate.ts`, `Zniffer.ts`, `MockControllerBehaviors.ts` and `SerialModeSwitch.ts` now import it from `@zwave-js/shared`. The `IS_TEST` control flow in `SerialModeSwitch.ts` is unchanged.

`packages/web/setimmediate.js` is left in place: `packages/web/index.html` still loads it, and bundled third-party dependencies may still rely on the global.

## Verification

- `yarn test:ts packages/zwave-js` — 786 tests pass
- `yarn test:ts packages/serial packages/shared` — 123 tests pass
- `yarn check:browser`, `yarn build`, `yarn lint:ts` — clean
- New `packages/shared/src/Timers.test.ts` runs asynchronous-dispatch, argument-forwarding and `clear()` assertions against all three backends, forcing the fallbacks by re-importing the module with the globals stubbed out.