### PR TITLE
feat: add productId 0x5600 for YRM276 with ZW3 module (700 series)

### DIFF
--- a/packages/config/config/devices/0x0129/yrm276.json
+++ b/packages/config/config/devices/0x0129/yrm276.json
@@ -8,6 +8,10 @@
 			"productType": "0x8014",
 			"productId": "0x1600",
 			"zwaveAllianceId": 2911
+		},
+		{
+			"productType": "0x8014",
+			"productId": "0x5600"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

The YRM276 can have an update ZWave module inserted (700 series). It maintains the same settings as with the ZW2 (500 series) module.
