### PR TITLE
refactor(bot): use `while (true)` instead of `for (;;)`

### DIFF
--- a/.github/bot-scripts/collectDocsFeedback.cjs
+++ b/.github/bot-scripts/collectDocsFeedback.cjs
@@ -273,7 +273,7 @@ async function collectFromIssues(owner, repo, since, token) {
 	const searchQuery =
 		`repo:${owner}/${repo} is:issue commenter:${BOT_USER} updated:>=${since}`;
 	let cursor = null;
-	for (;;) {
+	while (true) {
 		const data = await ghGraphql(
 			`
 			query search($searchQuery: String!, $cursor: String) {
@@ -360,7 +360,7 @@ async function collectFromDiscussions(owner, repo, since, token) {
 	const searchQuery =
 		`repo:${owner}/${repo} commenter:${BOT_USER} updated:>=${since}`;
 	let cursor = null;
-	for (;;) {
+	while (true) {
 		const data = await ghGraphql(
 			`
 			query search($searchQuery: String!, $cursor: String) {

--- a/.github/bot-scripts/postsIndex.cjs
+++ b/.github/bot-scripts/postsIndex.cjs
@@ -34,7 +34,7 @@ function cleanQuestion(title, body) {
 	// an index scan, a regex would backtrack polynomially on crafted input
 	let text = body;
 	let searchFrom = 0;
-	for (;;) {
+	while (true) {
 		const start = text.indexOf("<!--", searchFrom);
 		if (start === -1) break;
 		const end = text.indexOf("-->", start + 4);


### PR DESCRIPTION
`for (;;)` appeared only in the bot scripts and nowhere else in the codebase. Replaced all three occurrences with `while (true)`:

- `.github/bot-scripts/postsIndex.cjs` — HTML comment stripping scan
- `.github/bot-scripts/collectDocsFeedback.cjs` — issue and discussion search pagination (2x)

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)