### PR TITLE
fix(config): reject an embedded config directory that is not one

### DIFF
--- a/packages/config/src/ConfigManager.test.ts
+++ b/packages/config/src/ConfigManager.test.ts
@@ -136,6 +136,22 @@ test.sequential(
 );
 
 test.sequential(
+	"loadAll() rejects a deviceConfigEmbeddedDir that is not a config directory",
+	async ({ context, expect }) => {
+		delete process.env.ZWAVEJS_EXTERNAL_CONFIG;
+
+		const { tempDir, logContainer } = context;
+		const cm = new ConfigManager({
+			logContainer,
+			deviceConfigEmbeddedDir: tempDir,
+		});
+
+		await expect(cm.loadAll()).rejects.toThrow("manufacturers.json");
+	},
+	60000,
+);
+
+test.sequential(
 	"loading config files from the ZWAVEJS_EXTERNAL_CONFIG",
 	async ({ context, expect }) => {
 		const { tempDir, logContainer } = context;

--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -66,6 +66,24 @@ export class ConfigManager {
 		return getDevicesPaths(this.embeddedConfigDir).devicesDir;
 	}
 
+	private embeddedConfigDirVerified: boolean = false;
+
+	private async assertEmbeddedConfigDir(): Promise<void> {
+		if (this.embeddedConfigDirVerified) return;
+
+		// A wrong location is otherwise only visible as an empty device index, because
+		// the manufacturers and device index loaders both tolerate missing files
+		const marker = path.join(this.embeddedConfigDir, "manufacturers.json");
+		if (!(await pathExists(await this.getFS(), marker))) {
+			throw new ZWaveError(
+				`The embedded configuration directory ${this.embeddedConfigDir} does not contain manufacturers.json. Set the deviceConfigEmbeddedDir option to the location of the configuration files shipped with @zwave-js/config.`,
+				ZWaveErrorCodes.Driver_InvalidOptions,
+			);
+		}
+
+		this.embeddedConfigDirVerified = true;
+	}
+
 	private _fs: FileSystem | undefined;
 	private async getFS(): Promise<FileSystem> {
 		this._fs ??= (await import("#default_bindings/fs")).fs;
@@ -121,6 +139,8 @@ export class ConfigManager {
 	}
 
 	public async loadAll(): Promise<void> {
+		await this.assertEmbeddedConfigDir();
+
 		const logger = await this.getLogger();
 		// If the environment option for an external config dir is set
 		// try to sync it and then use it


### PR DESCRIPTION
## Why

Follow-up to #8999. `loadManufacturers()` catches `Config_Invalid` and falls back to an empty map, and the device index loader regenerates a missing index rather than failing, so pointing `storage.deviceConfigEmbeddedDir` at the wrong place produced an empty device index and no diagnostic — every node then looked like it had no config file.

This is easy to hit in exactly the case the option was added for. On txiki.js, for instance, `import.meta.dirname` *is* defined, so `getEmbeddedConfigDir()` resolves a path relative to the bundle instead of throwing, and an embedder who forgets the option silently gets the broken-but-quiet behavior rather than the clear error the option was meant to produce.

## What

`ConfigManager.loadAll()` now asserts up front that the resolved embedded configuration directory contains `manufacturers.json`, and otherwise throws `ZWaveErrorCodes.Driver_InvalidOptions` naming the path it tried.

- The marker is `manufacturers.json` rather than `devices/index.json`: the index is generated on first load and is not committed, so requiring it would fail on a fresh checkout. `manufacturers.json` is committed and part of the package's `files`.
- Checked once and memoized, and only from `loadAll()`, so resolution stays lazy — a driver started with `testingHooks.loadConfiguration: false` still never needs the directory.

## Verification

- `yarn test:ts packages/config/src` — 88 tests pass, including a new one asserting `loadAll()` rejects when the option points at an empty directory
- `yarn build`, `yarn lint:ts`, `yarn fmt:check`, `yarn check:browser`