### PR TITLE
test: wait for the expected User Code events instead of sleeping

### DIFF
--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -33,6 +33,11 @@ import {
 } from "../../node/feature-apis/AccessControl.js";
 import { integrationTest } from "../integrationTestSuite.js";
 
+// Emitted events may lag behind the frame that triggers them, so assertions on them
+// are retried. The bound is generous because CI runners are slow under load, and well
+// below the 30s each integration test gets, so a real mismatch still fails as one.
+const eventWaitOptions = { timeout: 5000, interval: 10 };
+
 // =============================================================================
 // Capabilities
 // =============================================================================
@@ -2258,8 +2263,9 @@ integrationTest(
 				credentialSlot: 2,
 				data: "2222",
 			});
-			await vi.waitFor(() =>
-				t.expect(events).toStrictEqual(["credential modified"])
+			await vi.waitFor(
+				() => t.expect(events).toStrictEqual(["credential modified"]),
+				eventWaitOptions,
 			);
 		},
 	},
@@ -2309,8 +2315,9 @@ integrationTest(
 				userId: 2,
 				active: false,
 			});
-			await vi.waitFor(() =>
-				t.expect(events).toStrictEqual(["user modified"])
+			await vi.waitFor(
+				() => t.expect(events).toStrictEqual(["user modified"]),
+				eventWaitOptions,
 			);
 		},
 	},
@@ -2477,26 +2484,28 @@ integrationTest(
 				createMockZWaveRequestFrame(cc, { ackRequested: false }),
 			);
 
-			await vi.waitFor(() =>
-				t.expect(events).toStrictEqual([
-					["credential modified", {
-						userId: 2,
-						credentialType: UserCredentialType.PINCode,
-						credentialSlot: 2,
-						data: "9999",
-					}],
-					["user added", {
-						userId: 3,
-						active: true,
-						userType: UserCredentialUserType.General,
-					}],
-					["credential added", {
-						userId: 3,
-						credentialType: UserCredentialType.PINCode,
-						credentialSlot: 3,
-						data: "3333",
-					}],
-				])
+			await vi.waitFor(
+				() =>
+					t.expect(events).toStrictEqual([
+						["credential modified", {
+							userId: 2,
+							credentialType: UserCredentialType.PINCode,
+							credentialSlot: 2,
+							data: "9999",
+						}],
+						["user added", {
+							userId: 3,
+							active: true,
+							userType: UserCredentialUserType.General,
+						}],
+						["credential added", {
+							userId: 3,
+							credentialType: UserCredentialType.PINCode,
+							credentialSlot: 3,
+							data: "3333",
+						}],
+					]),
+				eventWaitOptions,
 			);
 		},
 	},

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -26,6 +26,7 @@ import {
 } from "@zwave-js/testing";
 import type { MockNodeBehavior } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
+import { vi } from "vitest";
 import {
 	SetCredentialResult,
 	SetUserResult,
@@ -2257,8 +2258,9 @@ integrationTest(
 				credentialSlot: 2,
 				data: "2222",
 			});
-			await wait(50);
-			t.expect(events).toStrictEqual(["credential modified"]);
+			await vi.waitFor(() =>
+				t.expect(events).toStrictEqual(["credential modified"])
+			);
 		},
 	},
 );
@@ -2307,8 +2309,9 @@ integrationTest(
 				userId: 2,
 				active: false,
 			});
-			await wait(50);
-			t.expect(events).toStrictEqual(["user modified"]);
+			await vi.waitFor(() =>
+				t.expect(events).toStrictEqual(["user modified"])
+			);
 		},
 	},
 );
@@ -2474,26 +2477,27 @@ integrationTest(
 				createMockZWaveRequestFrame(cc, { ackRequested: false }),
 			);
 
-			await wait(100);
-			t.expect(events).toStrictEqual([
-				["credential modified", {
-					userId: 2,
-					credentialType: UserCredentialType.PINCode,
-					credentialSlot: 2,
-					data: "9999",
-				}],
-				["user added", {
-					userId: 3,
-					active: true,
-					userType: UserCredentialUserType.General,
-				}],
-				["credential added", {
-					userId: 3,
-					credentialType: UserCredentialType.PINCode,
-					credentialSlot: 3,
-					data: "3333",
-				}],
-			]);
+			await vi.waitFor(() =>
+				t.expect(events).toStrictEqual([
+					["credential modified", {
+						userId: 2,
+						credentialType: UserCredentialType.PINCode,
+						credentialSlot: 2,
+						data: "9999",
+					}],
+					["user added", {
+						userId: 3,
+						active: true,
+						userType: UserCredentialUserType.General,
+					}],
+					["credential added", {
+						userId: 3,
+						credentialType: UserCredentialType.PINCode,
+						credentialSlot: 3,
+						data: "3333",
+					}],
+				])
+			);
 		},
 	},
 );


### PR DESCRIPTION
## Why

Three assertions in `accessControl.UserCode.test.ts` slept for a fixed 50–100 ms and then required the expected events to have already arrived:

```ts
await wait(100);
t.expect(events).toStrictEqual([ /* 3 events */ ]);
```

On a loaded CI runner the unsolicited report has not been processed yet, so `events` is still `[]` and the shard fails. This flake failed shard 2/4 on three unrelated PRs today (#8998, #9000's neighbour, #9007), each time in a PR that could not have caused it.

## What

Those three now retry the same assertion with `vi.waitFor` instead of sleeping once, so they finish as soon as the events arrive and only fail if they never do. The assertions themselves are unchanged.

The two assertions that require **no** events to arrive keep their fixed `await wait(100)`:

```ts
// Solicited reads are discovery, not changes
await wait(100);
t.expect(events).toStrictEqual([]);
```

Retrying those would satisfy them on the first attempt and stop testing anything, so the delay there is load-bearing.

## Verification

- `yarn test:ts packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts` — 57 tests pass, run three times
- `yarn test:ts --shard 2/4` — 72 files / 493 tests pass, the shard and grouping where CI was failing
- `yarn build`, `yarn lint:ts`, `yarn fmt:check`