### PR TITLE
ci: recompile gh-aw workflows on Dependabot PRs instead of failing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,11 @@ updates:
         update-types: ['version-update:semver-major']
 
   - package-ecosystem: github-actions
+    # Dependabot cannot exclude the generated gh-aw workflows (*.lock.yml,
+    # agentics-maintenance.yml) from these updates
+    # (https://github.com/dependabot/dependabot-core/issues/2883). Their
+    # action pins are managed via .github/aw/actions-lock.json, so
+    # gh-aw-dependabot-recompile.yml recompiles Dependabot PRs touching them.
     directories:
       - '/'
       # Workaround for Dependabot not updating reusable composite actions

--- a/.github/workflows/gh-aw-dependabot-recompile.yml
+++ b/.github/workflows/gh-aw-dependabot-recompile.yml
@@ -1,0 +1,70 @@
+name: Recompile gh-aw workflows on Dependabot PRs
+
+# Dependabot cannot exclude individual workflow files in the github-actions
+# ecosystem (https://github.com/dependabot/dependabot-core/issues/2883), so
+# its PRs also bump action pins inside the generated gh-aw workflows, which
+# the compile check rejects. This workflow recompiles those PRs: generated
+# files revert to the pins from .github/aw/actions-lock.json, while bumps in
+# hand-written workflows survive. PRs left without effective changes are
+# closed.
+
+on:
+  # WARNING: This runs with write permissions in the PR base and checks out
+  # PR code, so it must stay restricted to Dependabot branches from this
+  # repository. Details under
+  # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+  pull_request_target:
+    paths:
+      - '.github/workflows/*.lock.yml'
+      - '.github/workflows/agentics-maintenance.yml'
+
+permissions: {}
+
+jobs:
+  recompile:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: [ubuntu-latest]
+    timeout-minutes: 15
+
+    steps:
+    - name: Checkout PR branch
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        # BOT_TOKEN is a PAT, so the fix-up push retriggers CI on the PR
+        token: ${{ secrets.BOT_TOKEN }}
+        # Full (blobless) history so the effective PR diff can be computed
+        # against the merge base
+        fetch-depth: 0
+        filter: blob:none
+
+    - name: Install gh-aw
+      env:
+        GH_TOKEN: ${{ github.token }}
+      # Keep the pin in sync with gh-aw-compile-check.yml
+      run: gh extension install github/gh-aw --pin v0.81.6
+
+    - name: Recompile workflows
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh aw compile
+
+    - name: Push recompiled workflows or close empty PR
+      env:
+        GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        merge_base=$(git merge-base HEAD "origin/$BASE_REF")
+        if git diff --quiet "$merge_base"; then
+          gh pr close "$PR_URL" --comment "Closing: this PR only bumped action pins inside generated gh-aw workflows. Those pins are managed via \`.github/aw/actions-lock.json\` and \`gh aw compile\`, so recompiling reverts all changes in this PR. They will be updated with the next gh-aw upgrade instead."
+          exit 0
+        fi
+        if git diff --quiet; then
+          echo "Generated workflows are already in sync"
+          exit 0
+        fi
+        git config user.email "bot@zwave-js.io"
+        git config user.name "Z-Wave JS Bot"
+        git commit -am "chore: recompile gh-aw workflows"
+        git push

--- a/.github/workflows/gh-aw-dependabot-recompile.yml
+++ b/.github/workflows/gh-aw-dependabot-recompile.yml
@@ -9,9 +9,10 @@ name: Recompile gh-aw workflows on Dependabot PRs
 # closed.
 
 on:
-  # WARNING: This runs with write permissions in the PR base and checks out
-  # PR code, so it must stay restricted to Dependabot branches from this
-  # repository. Details under
+  # WARNING: This runs in the PR base with access to secrets while checking
+  # out PR code, so it must stay restricted to Dependabot branches from this
+  # repository. No step both holds a credential and runs PR-authored content.
+  # Details under
   # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
   pull_request_target:
     paths:
@@ -25,23 +26,35 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [ubuntu-latest]
     timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
-    - name: Checkout PR branch
+    - name: Checkout PR head
       uses: actions/checkout@v7
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        # BOT_TOKEN is a PAT, so the fix-up push retriggers CI on the PR
-        token: ${{ secrets.BOT_TOKEN }}
+        # Pin to the SHA the event fired for, so a push to the branch cannot
+        # swap the code out between the event and the checkout
+        ref: ${{ github.event.pull_request.head.sha }}
+        # gh aw compile runs over PR-authored content, so leave no credential
+        # behind in .git/config
+        persist-credentials: false
         # Full (blobless) history so the effective PR diff can be computed
         # against the merge base
         fetch-depth: 0
         filter: blob:none
 
+    - name: Fetch base branch
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+
     - name: Install gh-aw
       env:
         GH_TOKEN: ${{ github.token }}
-      # Keep the pin in sync with gh-aw-compile-check.yml
+      # Keep the pin in sync with gh-aw-compile-check.yml. gh resolves --pin
+      # against release tags only, so this cannot be a commit SHA.
       run: gh extension install github/gh-aw --pin v0.81.6
 
     - name: Recompile workflows
@@ -49,22 +62,48 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: gh aw compile
 
-    - name: Push recompiled workflows or close empty PR
+    - name: Determine outcome
+      id: decide
       env:
-        GH_TOKEN: ${{ secrets.BOT_TOKEN }}
-        PR_URL: ${{ github.event.pull_request.html_url }}
         BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
+        # Refuse to commit anything outside the generated files, since that
+        # would mean the compile step did something unanticipated
+        unexpected=$(git diff --name-only | grep -Ev '^\.github/workflows/([^/]+\.lock\.yml|agentics-maintenance\.yml)$' || true)
+        if [ -n "$unexpected" ]; then
+          echo "::error::gh aw compile modified unexpected files:"
+          echo "$unexpected"
+          exit 1
+        fi
         merge_base=$(git merge-base HEAD "origin/$BASE_REF")
         if git diff --quiet "$merge_base"; then
-          gh pr close "$PR_URL" --comment "Closing: this PR only bumped action pins inside generated gh-aw workflows. Those pins are managed via \`.github/aw/actions-lock.json\` and \`gh aw compile\`, so recompiling reverts all changes in this PR. They will be updated with the next gh-aw upgrade instead."
-          exit 0
+          echo "action=close" >> "$GITHUB_OUTPUT"
+        elif git diff --quiet; then
+          echo "action=none" >> "$GITHUB_OUTPUT"
+        else
+          echo "action=push" >> "$GITHUB_OUTPUT"
         fi
-        if git diff --quiet; then
-          echo "Generated workflows are already in sync"
-          exit 0
-        fi
+
+    - name: Close PR without effective changes
+      if: ${{ steps.decide.outputs.action == 'close' }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      run: |
+        gh pr close "$PR_URL" --comment "Closing: this PR only bumped action pins inside generated gh-aw workflows. Those pins are managed via \`.github/aw/actions-lock.json\` and \`gh aw compile\`, so recompiling reverts all changes in this PR. They will be updated with the next gh-aw upgrade instead."
+
+    - name: Push recompiled workflows
+      if: ${{ steps.decide.outputs.action == 'push' }}
+      env:
+        # A PAT, so the push retriggers CI on the PR
+        BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      run: |
         git config user.email "bot@zwave-js.io"
         git config user.name "Z-Wave JS Bot"
+        # Read the PAT from the environment at push time, so it reaches
+        # neither .git/config nor a process argument
+        git config credential.helper '!f() { echo username=x-access-token; echo "password=$BOT_TOKEN"; }; f'
         git commit -am "chore: recompile gh-aw workflows"
-        git push
+        # Fails if the branch moved since the checkout, which is intended
+        git push origin "HEAD:refs/heads/$HEAD_REF"


### PR DESCRIPTION
### The problem

Dependabot's `github-actions` updates also bump action SHAs inside the generated gh-aw files (`.github/workflows/*.lock.yml` and `agentics-maintenance.yml`). The `gh-aw-compile-check` workflow then correctly rejects the drift, so those PRs (e.g. #9027, #9029) fail CI and can never merge.

Dependabot cannot exclude individual workflow files in the `github-actions` ecosystem — the feature request is still open at dependabot/dependabot-core#2883 — so this can't be fixed in `dependabot.yml` alone.

### The fix

A new `gh-aw-dependabot-recompile.yml` workflow runs on `pull_request_target` for Dependabot PRs that touch the generated files (same trust model as `dependabot-automerge.yml`):

1. Checks out the PR head SHA **without credentials** and runs `gh aw compile` (pinned to the same version as the compile check). This reverts the generated files to the pins from `.github/aw/actions-lock.json` while keeping bumps in hand-written workflows.
2. Guards that the compile touched only generated files, and fails loudly otherwise.
3. If the PR has no effective changes left (diff vs. merge base is empty), it closes the PR with an explanatory comment, using only `GITHUB_TOKEN`.
4. Otherwise it commits and pushes the recompiled files with `BOT_TOKEN`, so CI retriggers and the compile check passes.

Since the job runs on `pull_request_target` with access to secrets, no step both holds a credential and runs PR-authored content:

- Checkout uses `persist-credentials: false`, so no token reaches `.git/config` while `gh aw compile` runs over the PR's files.
- The checkout pins `head.sha` rather than `head.ref`, so a push to the branch can't swap the code out between the event and the checkout.
- `BOT_TOKEN` is in scope for the push step alone, supplied through a credential helper that reads it from the environment so it lands in neither `.git/config` nor a process argument. The close path never sees it.
- `git commit` is gated on the guard in step 2, so an unexpected compile result aborts instead of being committed.

`dependabot.yml` gets a comment documenting why the generated files can't simply be excluded.

### Trigger and data flow

```mermaid
flowchart TD
    DB(["Dependabot<br/>monthly github-actions run"]) -->|"opens / updates PR<br/>with bumped action SHAs"| PR["PR branch<br/>dependabot/github_actions/…"]

    PR -->|"pull_request_target<br/>paths: *.lock.yml,<br/>agentics-maintenance.yml"| GATE{"author is dependabot[bot]<br/>and head repo is this repo?"}
    GATE -->|no| SKIP(["job skipped"])
    GATE -->|yes| CO["Checkout head.sha<br/>persist-credentials: false"]

    LOCK[("aw/actions-lock.json<br/>authoritative pins")] -.-> COMPILE
    MD[("workflows/*.md<br/>sources")] -.-> COMPILE
    CO --> COMPILE["gh aw compile<br/>pinned v0.81.6"]
    COMPILE -->|"regenerates"| GEN["*.lock.yml<br/>agentics-maintenance.yml"]

    GEN --> GUARD{"only generated<br/>files changed?"}
    GUARD -->|no| FAIL(["fail the job"])
    GUARD -->|yes| D1{"diff vs merge base<br/>empty?"}
    D1 -->|"yes — PR only touched<br/>generated files"| CLOSE(["gh pr close<br/>+ explanatory comment"])
    D1 -->|no| D2{"compile changed<br/>anything?"}
    D2 -->|no| NOOP(["already in sync,<br/>nothing to do"])
    D2 -->|yes| PUSH["commit + push<br/>as Z-Wave JS Bot"]

    PUSH -->|"new commit retriggers CI"| CHECK["gh-aw-compile-check"]
    CHECK -->|"no drift"| PASS(["PR mergeable"])

    subgraph creds ["credential scope"]
        direction LR
        T1["compile steps:<br/>GITHUB_TOKEN, contents: read"]
        T2["close step:<br/>GITHUB_TOKEN, pull-requests: write"]
        T3["push step:<br/>BOT_TOKEN (PAT)"]
    end

    COMPILE -.- T1
    CLOSE -.- T2
    PUSH -.- T3
```

Bumps to hand-written workflows survive the recompile, so a mixed PR keeps its real changes and only loses the generated-file edits.

### Verification

Dry-ran the decision logic locally against #9029's head SHA: after `gh aw compile`, only the four generated files differ, the guard passes, and the diff against the merge base is empty — so the workflow resolves to `action=close`. Same applies to #9027. Both PRs only bump pins inside generated files; the real update path for those pins is `gh aw upgrade`.

> [!NOTE]
> The push path modifies workflow files, so `BOT_TOKEN` needs the `workflow` scope. The close path — which is what #9027 and #9029 hit — never uses the PAT at all.
>
> `gh extension install --pin` resolves release tags only, so the gh-aw pin can't be a commit SHA. It runs in a step whose only credential is a `contents: read` `GITHUB_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
