### PR TITLE
fix(config): add fingerprint to Climax SDCO

### DIFF
--- a/packages/config/config/devices/0x018e/sdco.json
+++ b/packages/config/config/devices/0x018e/sdco.json
@@ -17,6 +17,10 @@
 		{
 			"productType": "0x0003",
 			"productId": "0x001a"
+		},
+		{
+			"productType": "0x0003",
+			"productId": "0x001b"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
## Proposed change

Add the `0x001b` product variant of the Climax Technology SDCO (Smoke and
Carbon Monoxide Detector) to the existing device file. The device is sold by
Futurehome as "Futurehome SDCO brannvarsler" and reports smoke, CO, heat,
temperature and humidity.

## Checklist

- [x] Config has been linted (`yarn lint:zwave` — 0 errors)
- [x] Formatting verified (`yarn lint:configjson`)
