### PR TITLE
feat: detect sleeping nodes that stopped waking up

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -929,6 +929,23 @@ readonly lastSeen: MaybeNotKnown<Date>
 
 This property tracks when the node was last seen, meaning a command was either received from the node or successfully sent to it.
 
+### `isOverdue`
+
+```ts
+readonly isOverdue: boolean
+```
+
+This property indicates that a sleeping node has failed to report in for significantly longer than its configured wake up interval, which usually means its battery is dead or it is out of range. The threshold is twice the wake up interval plus 10%, as recommended for Reporting Sleeping Slaves in Silicon Labs' gateway documentation.
+
+The detection is entirely passive - nodes are never polled to determine this - and it does not affect a node's [`status`](#status). A node stops being overdue as soon as anything is received from it again.
+
+This is always `false` for nodes whose liveness cannot be predicted this way:
+
+- always listening nodes and FLiRS nodes, which can be reached on demand and whose failure is detected by other means
+- nodes with a wake up interval of `0`, which only wake up on local events and therefore have no expected reporting pattern
+
+> [!NOTE] A node restored from cache is evaluated during driver startup, before the `"driver ready"` event. If it was already overdue at that point, the `"overdue"` event fires before an application can attach listeners, so read this property for the initial state rather than relying on the event alone.
+
 ### `isControllerNode`
 
 ```ts
@@ -1290,6 +1307,14 @@ A sleeping node has woken up or gone back to sleep. The node is passed as the si
 ### `"dead"` / `"alive"`
 
 A non-sleeping node has stopped responding or just started responding again. The node is passed as the single argument to the callback:
+
+```ts
+(node: ZWaveNode) => void
+```
+
+### `"overdue"` / `"no longer overdue"`
+
+A sleeping node has missed its expected wake ups for significantly longer than its wake up interval, or has been heard from again after doing so. See [`isOverdue`](#isOverdue) for which nodes this applies to. The node is passed as the single argument to the callback:
 
 ```ts
 (node: ZWaveNode) => void

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -347,6 +347,7 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 		) {
 			timeout?.clear();
 		}
+		this.cancelOverdueCheck();
 
 		// Remove all event handlers
 		this.removeAllListeners();
@@ -432,6 +433,8 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			...cur,
 			lastSeen: value,
 		}));
+		// Hearing from a node resets how long it may stay silent before being overdue
+		this.scheduleOverdueCheck();
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -288,6 +288,8 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 	sleep: ZWaveNodeStatusChangeCallback;
 	dead: ZWaveNodeStatusChangeCallback;
 	alive: ZWaveNodeStatusChangeCallback;
+	overdue: (node: ZWaveNode) => void;
+	"no longer overdue": (node: ZWaveNode) => void;
 	"interview completed": (node: ZWaveNode) => void;
 	ready: (node: ZWaveNode) => void;
 	"interview stage completed": (node: ZWaveNode, stageName: string) => void;
@@ -330,6 +332,8 @@ export const zWaveNodeEvents = [
 	"sleep",
 	"dead",
 	"alive",
+	"overdue",
+	"no longer overdue",
 	"interview completed",
 	"ready",
 	"interview stage completed",

--- a/packages/zwave-js/src/lib/node/mixins/45_Liveness.test.ts
+++ b/packages/zwave-js/src/lib/node/mixins/45_Liveness.test.ts
@@ -1,0 +1,165 @@
+import { CommandClasses } from "@zwave-js/core";
+import { afterEach, beforeEach, test, vi } from "vitest";
+import {
+	NodeLivenessMixin,
+	TIMEOUT_MAX,
+	getOverdueThreshold,
+} from "./45_Liveness.js";
+
+test("the overdue threshold is twice the wake up interval plus 10%", (t) => {
+	// 1 h -> 2.2 h
+	t.expect(getOverdueThreshold(3600)).toBe(7_920_000);
+});
+
+test("the overdue threshold matches the worked example from the specification", (t) => {
+	// The Z/IP Gateway sleeping node lab uses a 20 s wake up interval and expects the node
+	// to be considered failed after 2 * 20 s + 10% = 44 s
+	t.expect(getOverdueThreshold(20)).toBe(44_000);
+});
+
+test("a wake up interval of 0 yields no threshold", (t) => {
+	// 0 means the node only wakes on local events, so there is no predictable pattern of
+	// Wake Up Notifications and a failure cannot be detected
+	t.expect(getOverdueThreshold(0)).toBeUndefined();
+});
+
+test("an unusable wake up interval yields no threshold", (t) => {
+	t.expect(getOverdueThreshold(undefined)).toBeUndefined();
+	t.expect(getOverdueThreshold(-1)).toBeUndefined();
+	t.expect(getOverdueThreshold(NaN)).toBeUndefined();
+	t.expect(getOverdueThreshold(Infinity)).toBeUndefined();
+});
+
+/**
+ * Exercises the scheduling logic in isolation. The node constructor chain needs a driver,
+ * so this builds an object on the mixin's prototype and supplies only what the method
+ * touches. `canSleep` is a prototype accessor further down the chain, hence defineProperty.
+ */
+function makeNode(
+	lastSeenAgoMs: number | undefined,
+	wakeUpInterval: number | undefined,
+	canSleep = true,
+): any {
+	const node = Object.create(NodeLivenessMixin.prototype);
+	const events: string[] = [];
+
+	Object.defineProperties(node, {
+		_isOverdue: { value: false, writable: true },
+		overdueTimer: { value: undefined, writable: true },
+		canSleep: { value: canSleep },
+		lastSeen: {
+			value: lastSeenAgoMs == undefined
+				? undefined
+				: new Date(Date.now() - lastSeenAgoMs),
+			writable: true,
+		},
+		events: { value: events },
+		supportsCC: {
+			value: (cc: CommandClasses) => cc === CommandClasses["Wake Up"],
+		},
+		getValue: { value: () => wakeUpInterval },
+		_emit: {
+			value: (event: string) => {
+				events.push(event);
+				return true;
+			},
+		},
+	});
+
+	return node;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+test("a node silent past its threshold is immediately overdue", (t) => {
+	// 12 h interval -> 26.4 h threshold
+	const node = makeNode(48 * 3600 * 1000, 43200);
+	node.scheduleOverdueCheck();
+
+	t.expect(node.isOverdue).toBe(true);
+	t.expect(node.events).toStrictEqual(["overdue"]);
+});
+
+test("a node within its threshold only becomes overdue once it elapses", (t) => {
+	const node = makeNode(0, 43200);
+	node.scheduleOverdueCheck();
+	t.expect(node.isOverdue).toBe(false);
+
+	vi.advanceTimersByTime(26 * 3600 * 1000);
+	t.expect(node.isOverdue).toBe(false);
+
+	vi.advanceTimersByTime(3600 * 1000);
+	t.expect(node.isOverdue).toBe(true);
+	t.expect(node.events).toStrictEqual(["overdue"]);
+});
+
+test("hearing from an overdue node clears it", (t) => {
+	const node = makeNode(48 * 3600 * 1000, 43200);
+	node.scheduleOverdueCheck();
+	t.expect(node.isOverdue).toBe(true);
+
+	node.lastSeen = new Date();
+	node.scheduleOverdueCheck();
+
+	t.expect(node.isOverdue).toBe(false);
+	t.expect(node.events).toStrictEqual(["overdue", "no longer overdue"]);
+});
+
+test("a wake up interval can exceed what setTimeout accepts in one go", (t) => {
+	// 2^24-1 s is the largest a 3 byte Wake Up Interval can express, giving a threshold of
+	// ~427 days. Arming setTimeout with that directly makes it fire immediately, which
+	// would report a healthy node as overdue, so the wait has to be split up.
+	t.expect(getOverdueThreshold(2 ** 24 - 1)!).toBeGreaterThan(TIMEOUT_MAX);
+
+	// Anything beyond roughly 11 days is affected
+	t.expect(getOverdueThreshold(14 * 24 * 3600)!).toBeGreaterThan(TIMEOUT_MAX);
+	t.expect(getOverdueThreshold(7 * 24 * 3600)!).toBeLessThan(TIMEOUT_MAX);
+});
+
+test("a long wait is re-armed instead of firing early", (t) => {
+	const node = makeNode(0, 2 ** 24 - 1);
+	node.scheduleOverdueCheck();
+
+	// Several times the longest delay a single timer can express
+	for (let i = 0; i < 5; i++) {
+		vi.advanceTimersByTime(TIMEOUT_MAX);
+		t.expect(node.isOverdue).toBe(false);
+	}
+});
+
+test("an always listening node is never overdue", (t) => {
+	const node = makeNode(365 * 24 * 3600 * 1000, 43200, false);
+	node.scheduleOverdueCheck();
+
+	t.expect(node.isOverdue).toBe(false);
+	t.expect(node.events).toStrictEqual([]);
+});
+
+test("a node that only wakes on local events is never overdue", (t) => {
+	const node = makeNode(365 * 24 * 3600 * 1000, 0);
+	node.scheduleOverdueCheck();
+
+	t.expect(node.isOverdue).toBe(false);
+	t.expect(node.events).toStrictEqual([]);
+});
+
+test("a node with an unknown wake up interval is never overdue", (t) => {
+	const node = makeNode(365 * 24 * 3600 * 1000, undefined);
+	node.scheduleOverdueCheck();
+
+	t.expect(node.isOverdue).toBe(false);
+	t.expect(node.events).toStrictEqual([]);
+});
+
+test("a node that has never been seen is not overdue", (t) => {
+	const node = makeNode(undefined, 43200);
+	node.scheduleOverdueCheck();
+
+	t.expect(node.isOverdue).toBe(false);
+});

--- a/packages/zwave-js/src/lib/node/mixins/45_Liveness.ts
+++ b/packages/zwave-js/src/lib/node/mixins/45_Liveness.ts
@@ -1,0 +1,144 @@
+import { WakeUpCCValues } from "@zwave-js/cc";
+import { CommandClasses, type MaybeNotKnown } from "@zwave-js/core";
+import { type Timer, setTimer } from "@zwave-js/shared";
+import { NodeCapabilityValuesMixin } from "./41_CapabilityValues.js";
+
+/**
+ * How many times its wake up interval a sleeping node may stay silent before it is
+ * considered overdue.
+ *
+ * Silicon Labs' gateway documentation ("Detection of Sleeping Device Failure",
+ * https://docs.silabs.com/z-wave/1.0.1/z-wave-training-docs/gateway-session4-sleeping-nodes)
+ * specifies `2 * Wake Up Interval + 10%` for Reporting Sleeping Slaves. Their worked
+ * example resolves the ambiguity in that wording: a 20 s interval is given as 44 s, so
+ * the 10% applies to the doubled interval rather than the original.
+ *
+ * Doubling tolerates a single missed notification; the additional 10% absorbs clock
+ * drift in the node's sleep timer.
+ */
+export const OVERDUE_WAKE_UP_INTERVAL_FACTOR = 2.2;
+
+/** `setTimeout` silently fires immediately for delays beyond this, so they are re-armed in chunks. */
+export const TIMEOUT_MAX = 2 ** 31 - 1;
+
+/**
+ * Computes how long a sleeping node may stay silent before it is considered overdue,
+ * in milliseconds. Returns `undefined` when no prediction is possible.
+ *
+ * @param wakeUpInterval The node's wake up interval in seconds
+ */
+export function getOverdueThreshold(
+	wakeUpInterval: MaybeNotKnown<number>,
+): number | undefined {
+	// A Wake Up Interval of 0 means the node only wakes on local events, so there is no
+	// predictable pattern of Wake Up Notifications and a failure cannot be detected.
+	// The comparison also rejects NaN, which would otherwise survive as a NaN threshold.
+	if (
+		wakeUpInterval == undefined
+		|| !(wakeUpInterval > 0)
+		|| !Number.isFinite(wakeUpInterval)
+	) {
+		return undefined;
+	}
+
+	return Math.round(
+		wakeUpInterval * OVERDUE_WAKE_UP_INTERVAL_FACTOR * 1000,
+	);
+}
+
+export interface NodeLiveness {
+	/**
+	 * Whether a sleeping node has failed to report in for significantly longer than its
+	 * wake up interval, suggesting it is no longer functioning - typically a dead battery
+	 * or a node that is out of range.
+	 *
+	 * This is always `false` for nodes whose liveness cannot be predicted this way, namely
+	 * always listening nodes, FLiRS nodes, and nodes with a wake up interval of 0.
+	 */
+	readonly isOverdue: boolean;
+}
+
+/**
+ * Defines functionality to detect sleeping nodes that have stopped waking up.
+ *
+ * The detection is purely passive - it only observes when expected Wake Up Notifications
+ * fail to arrive, and never transmits. This keeps it free of the cost and risk of polling
+ * nodes that may be unreachable.
+ */
+export abstract class NodeLivenessMixin extends NodeCapabilityValuesMixin
+	implements NodeLiveness
+{
+	private overdueTimer: Timer | undefined;
+	private _isOverdue: boolean = false;
+
+	public get isOverdue(): boolean {
+		return this._isOverdue;
+	}
+
+	/** The last time a message was received from this node */
+	public abstract get lastSeen(): MaybeNotKnown<Date>;
+
+	private setOverdue(overdue: boolean): void {
+		if (overdue === this._isOverdue) return;
+		this._isOverdue = overdue;
+		this._emit(overdue ? "overdue" : "no longer overdue", this);
+	}
+
+	/**
+	 * @internal
+	 * Re-evaluates whether this node is overdue and schedules the next check.
+	 * Called whenever the node is seen and when a sleeping node is restored from cache.
+	 */
+	public scheduleOverdueCheck(): void {
+		this.cancelOverdueCheck();
+
+		// This runs for every received command, so bail out before looking up any values
+		// for the nodes that can never be overdue. canSleep is false for always listening
+		// and FLiRS nodes; FLiRS failure is detected through failed beaming instead, since
+		// those nodes can be reached on demand.
+		if (!this.canSleep || !this.supportsCC(CommandClasses["Wake Up"])) {
+			this.setOverdue(false);
+			return;
+		}
+
+		const threshold = getOverdueThreshold(
+			this.getValue<number>(WakeUpCCValues.wakeUpInterval.id),
+		);
+		const lastSeen = this.lastSeen;
+		if (threshold == undefined || !lastSeen) {
+			this.setOverdue(false);
+			return;
+		}
+
+		const remaining = threshold - (Date.now() - lastSeen.getTime());
+		if (remaining <= 0) {
+			// Nodes restored from cache can already be overdue by months, so this must be
+			// evaluated immediately instead of waiting for a timer to elapse.
+			this.setOverdue(true);
+			return;
+		}
+
+		this.setOverdue(false);
+		// A Wake Up Interval is a 3 byte seconds field, so the delay can exceed what
+		// setTimeout accepts, where it would silently fire immediately. Re-arming in
+		// chunks and re-evaluating also keeps the result correct if the wall clock and
+		// the timer diverge, e.g. after the host suspends.
+		this.overdueTimer = setTimer(
+			() => this.scheduleOverdueCheck(),
+			Math.min(remaining, TIMEOUT_MAX),
+		).unref();
+	}
+
+	/** @internal */
+	public cancelOverdueCheck(): void {
+		this.overdueTimer?.clear();
+		this.overdueTimer = undefined;
+	}
+
+	public override markAsAsleep(): void {
+		super.markAsAsleep();
+		// Sleeping nodes are marked asleep when restored from cache, which is the only
+		// opportunity to notice a node that has not been heard from since a previous session.
+		this.scheduleOverdueCheck();
+	}
+}

--- a/packages/zwave-js/src/lib/node/mixins/50_Endpoints.ts
+++ b/packages/zwave-js/src/lib/node/mixins/50_Endpoints.ts
@@ -11,7 +11,7 @@ import { isArray, isObject } from "alcalzone-shared/typeguards";
 import { DeviceClass } from "../DeviceClass.js";
 import { Endpoint } from "../Endpoint.js";
 import * as nodeUtils from "../utils.js";
-import { NodeCapabilityValuesMixin } from "./41_CapabilityValues.js";
+import { NodeLivenessMixin } from "./45_Liveness.js";
 
 /** Defines functionality of Z-Wave nodes related to accessing endpoints and their capabilities */
 export interface Endpoints {
@@ -40,7 +40,7 @@ export interface Endpoints {
 	getAllEndpoints(): Endpoint[];
 }
 
-export abstract class EndpointsMixin extends NodeCapabilityValuesMixin
+export abstract class EndpointsMixin extends NodeLivenessMixin
 	implements Endpoints, GetEndpoint<Endpoint>, GetAllEndpoints<Endpoint>
 {
 	public get endpointCountIsDynamic(): MaybeNotKnown<boolean> {

--- a/packages/zwave-js/src/lib/test/driver/fixtures/overdueSleepingNode/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/overdueSleepingNode/7e570001.jsonl
@@ -1,0 +1,33 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+
+{"k":"node.2.isListening","v":false}
+{"k":"node.2.isFrequentListening","v":false}
+{"k":"node.2.isRouting","v":true}
+{"k":"node.2.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.2.protocolVersion","v":3}
+{"k":"node.2.nodeType","v":"End Node"}
+{"k":"node.2.supportsSecurity","v":false}
+{"k":"node.2.supportsBeaming","v":true}
+{"k":"node.2.deviceClass","v":{"basic":4,"generic":6,"specific":1}}
+// Basic
+{"k":"node.2.endpoint.0.commandClass.0x20","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+// Wakeup
+{"k":"node.2.endpoint.0.commandClass.0x84","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+{"k":"node.2.interviewStage","v":"Complete"}
+{"k":"node.2.hasSUCReturnRoute","v":true}
+// Last contact from the real device this test reproduces
+{"k":"node.2.lastSeen","v":1747322016769}

--- a/packages/zwave-js/src/lib/test/driver/fixtures/overdueSleepingNode/7e570001.values.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/overdueSleepingNode/7e570001.values.jsonl
@@ -1,0 +1,1 @@
+{"k":"{\"nodeId\":2,\"commandClass\":132,\"endpoint\":0,\"property\":\"wakeUpInterval\"}","v":43200,"ts":1747322016769}

--- a/packages/zwave-js/src/lib/test/driver/overdueSleepingNode.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/overdueSleepingNode.test.ts
@@ -1,0 +1,31 @@
+import { NodeStatus } from "@zwave-js/core";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+// The cache fixture reproduces a real device: a Zooz ZSE44 with the default 12 h wake up
+// interval whose last contact was 2025-05-15, restored from a previous session.
+
+integrationTest(
+	"a sleeping node that stopped reporting in is overdue after being restored from cache",
+	{
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/overdueSleepingNode",
+		),
+
+		testBody: async (t, driver, node2, mockController, mockNode) => {
+			t.expect(node2.status).toBe(NodeStatus.Asleep);
+			t.expect(node2.isOverdue).toBe(true);
+
+			const recovered = new Promise<void>((resolve) => {
+				node2.once("no longer overdue", () => resolve());
+			});
+
+			// Hearing from the node again must clear it
+			node2.lastSeen = new Date();
+			await recovered;
+
+			t.expect(node2.isOverdue).toBe(false);
+		},
+	},
+);


### PR DESCRIPTION
# feat: detect sleeping nodes that stopped waking up

Refs #4207. This implements one of the four detection cases listed there — overdue sleeping devices — and deliberately leaves the issue open for the rest.

#4207 has been open since 2022 because the design was undecided, not because nobody wrote the code. So please treat this as a concrete proposal rather than a finished answer. If you would rather settle the approach in the issue first, I am happy to close this and move the discussion there.

**In short:** nothing is transmitted, and no existing behavior changes — this adds a property and two events, and touches nothing else.

## The problem

A sleeping node can never be marked dead. `NodeStatusMachine` only permits `asleep -> awake`, and both `markAsDead()` call sites in `Driver.ts` are gated on `!node.canSleep`. That is deliberate and correct — not responding is exactly what a healthy sleeping node does, so a controller cannot tell "asleep" from "gone" by attempting to communicate.

The consequence is that a battery device whose cells have died is indistinguishable from a healthy one that has not woken up yet. It stays `asleep` and `ready: true` forever.

## A source I did not see referenced in the discussion

Silicon Labs' gateway documentation defines a bound for how long a Reporting Sleeping Slave may stay silent, and applying it requires transmitting nothing at all. From a section called **"Detection of Sleeping Device Failure"**:

> "[If] a duration of longer than **(2 \* [Wake Up Interval] + 10%)** passes without receipt of a Wake Up Notification from the RSS, it can be marked as 'failed.'"

It also excludes exactly the devices that make a general rule impossible — the ones that only wake on local events:

> "…for a device whose Wake Up Interval is **'0'**, no predictable pattern of expected Wake Up Notifications can be determined. As a result, failure of these devices cannot be detected."

Silicon Labs' own Z/IP Gateway implements this. The [companion lab](https://docs.silabs.com/z-wave/1.0.0/z-wave-training-labs/gateway-session4-sleeping-nodes-lab) walks through a node with a 20 s interval being reported as failing after `2 * 20 s + 10% = 44 s`, and recovering on its next notification:

```
mailbox node 6 is now failing, because it has not reported in
Node 6 is now ok.
```

Sources:

- https://docs.silabs.com/z-wave/1.0.1/z-wave-training-docs/gateway-session4-sleeping-nodes
- https://docs.silabs.com/z-wave/1.0.0/z-wave-training-labs/gateway-session4-sleeping-nodes-lab

One caveat on how normative this is: it is gateway implementation guidance — "*can* be marked as 'failed'" — not a certification `SHALL`, and I did not find an equivalent requirement in an SDS document. The threshold is a well-sourced default rather than a mandate, which is part of why this PR only reports and never acts.

## Against your requirements from the 2022 discussion

| Requirement | Status |
| --- | --- |
| Detect when a sleeping device hasn't woken up for too long | This PR. |
| Detect when a mains powered device no longer reacts to pings | Already handled — mains nodes are marked dead on failed communication today. Unchanged here. |
| Detect when a FLiRS device no longer reacts, at reduced frequency | Not addressed — see below. |
| Detect when the above are reachable again | Anything received from the node clears it. |
| Avoid false positives on fragile meshes | Doubling the interval tolerates one fully missed notification; the extra 10% absorbs sleep-timer drift. |
| Avoid delays from pinging unreachable devices | Nothing is transmitted. The check only observes that an expected notification did not arrive. |

On #5638, which was closed as a duplicate of this: the first objection there — that we have no way of knowing how long a battery device may go — is answered by the interval-0 exclusion above, which removes precisely the devices that have no schedule. The second objection, that flaky devices would get marked dead repeatedly, cannot happen here at all, because `NodeStatus` is never touched; a flapping node just toggles `isOverdue`.

## Why this only reports, and does not mark anything dead

My first attempt also promoted overdue nodes to `NodeStatus.Dead` behind an opt-in flag. I dropped it, and the reason seems worth recording since it is the obvious next question.

`NodeStatus` is effectively a "what do I do with messages for this node" machine, and overdue-ness is orthogonal to it — an overdue node is still asleep, and its messages should still be parked in the wake-up queue. Cramming the two together broke real things:

- `mayStartTransaction` gates on `status !== Asleep`, so a `Dead` sleeping node has its commands transmitted immediately rather than parked — burning `maxSendAttempts` against a node presumed to have a dead battery, and making the "never transmits" property false.
- `handleMissingNodeACK` re-queues a transaction without `reset()` and relies on `markAsAsleep()` to trigger `moveMessagesToWakeupQueue`, whose reducer carries `reset: true`. From `dead`, `markAsAsleep()` is a no-op, so the re-queued transaction resolves to `undefined` — `sendCommand()` reports success for a command the node never acknowledged.
- `markAsAwake()` is likewise a no-op from `dead`, so a dead sleeping node that does answer stays dead.

Around a dozen further sites assume `canSleep` implies `status ∈ {Unknown, Asleep, Awake}` — transaction sort order, the health checks' `waitForWakeup`, interview finality, route rebuilding. Making this work would mean special-casing "dead but sleeping" in each, i.e. inventing a second implicit status.

And the benefit I thought I was buying turned out not to exist. I assumed a `Dead` node's entities go unavailable in Home Assistant; they do not. `ZWaveBaseEntity.available` keys on `node.ready`, and `NodeReadyMachine` has no transition out of `ready`, so the node stays available with `status: Dead`. The only visible difference is the node-status sensor's value — the same visibility class as `isOverdue`, obtainable downstream at zero risk to queue semantics.

If you do want overdue-ness reflected in `NodeStatus`, I would rather agree the shape in #4207 first than guess again.

## Reaching applications

`isOverdue` needs a companion `zwave-js-server` change to appear in the node state dump and forward the two events, with a schema bump. Happy to open that PR if this lands. What Home Assistant then does with it — a dedicated binary sensor, or factoring it into availability — is a call for its maintainers.

## Out of scope

FLiRS nodes. They can be reached on demand, so Silicon Labs' guidance detects their failure through failed beaming instead — *"considered 'failed' after all retransmission attempts of a Beam have failed to wake the device"* — which belongs in the transmission path rather than in passive observation, and is the one case where your battery-drain concern genuinely applies. Worth a separate PR if this approach is acceptable.

## Implementation notes

Evaluation is scheduled from the `lastSeen` setter, which every received or successfully sent command already passes through, and from `markAsAsleep()`, which the driver calls for every sleeping node restored from cache. The latter is what catches a node that died during a previous session — by that point the network cache is restored, so both `lastSeen` and `wakeUpInterval` are available. One timer per eligible sleeping node, cleared in `destroy()`; no polling and no periodic work.

A Wake Up Interval is a 3-byte seconds field, so a large interval produces a delay beyond `setTimeout`'s 2^31−1 ms ceiling, where it would silently fire immediately and report a healthy node as overdue. Anything above roughly 11 days is affected, so long waits are re-armed in chunks.

Naming is entirely up for grabs; happy to rename `isOverdue` or the events.

## Verification

Unit tests cover the threshold computation, the `wakeUpInterval == 0` exclusion, unusable values, the `setTimeout` ceiling, and the worked example from the Silicon Labs lab (20 s → 44 s). An integration test starts the driver against a cache fixture reproducing the device below and asserts it comes up overdue and clears when heard from again. Docs updated: `isOverdue` and the two events in `docs/api/node.md`.

The device this came from: a Zooz ZSE44 with the default 12 h wake up interval (a 26.4 h threshold) that last reported in May 2025 and was still `asleep` with `ready: true` more than a year later. It was only noticed because of a `lastSeen`-based watchdog in Home Assistant — the same workaround several people describe in #4207.

---

Written with AI assistance; the Silicon Labs sourcing, the design decisions, and the real-device verification are mine.
