### PR TITLE
feat(config): update Zooz ZEN32 config for firmware 3.30

### DIFF
--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -169,8 +169,20 @@
 		},
 		{
 			"#": "11",
+			"$if": "firmwareVersion >= 3.30 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
+			"label": "LED Indicator Brightness (Relay)"
+		},
+		{
+			"#": "11",
 			"$import": "templates/zooz_template.json#led_indicator_brightness",
 			"label": "LED Indicator Brightness (Relay)"
+		},
+		{
+			"#": "12",
+			"$if": "firmwareVersion >= 3.30 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
+			"label": "LED Indicator Brightness (Button 1)"
 		},
 		{
 			"#": "12",
@@ -179,13 +191,31 @@
 		},
 		{
 			"#": "13",
+			"$if": "firmwareVersion >= 3.30 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
+			"label": "LED Indicator Brightness (Button 2)"
+		},
+		{
+			"#": "13",
 			"$import": "templates/zooz_template.json#led_indicator_brightness",
 			"label": "LED Indicator Brightness (Button 2)"
 		},
 		{
 			"#": "14",
+			"$if": "firmwareVersion >= 3.30 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
+			"label": "LED Indicator Brightness (Button 3)"
+		},
+		{
+			"#": "14",
 			"$import": "templates/zooz_template.json#led_indicator_brightness",
 			"label": "LED Indicator Brightness (Button 3)"
+		},
+		{
+			"#": "15",
+			"$if": "firmwareVersion >= 3.30 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#led_indicator_brightness_1_10",
+			"label": "LED Indicator Brightness (Button 4)"
 		},
 		{
 			"#": "15",


### PR DESCRIPTION
From https://www.support.getzooz.com/kb/article/706-zen32-scene-controller-change-log/:

**Firmware: 3.30 (released 08/2026 as OTA)**
- Updated LED brightness settings for Parameters 11–15, changing the supported value range from 0–2 to 1–10. 

Verified the 10.x firmware version (pre 800LR version) does not (yet) have this change