### PR TITLE
fix(config): add Aeotec ZWA012 productId 0x0037

### DIFF
--- a/packages/config/config/devices/0x0371/zwa012.json
+++ b/packages/config/config/devices/0x0371/zwa012.json
@@ -31,7 +31,15 @@
 			"productId": "0x002a"
 		},
 		{
+			"productType": "0x0002",
+			"productId": "0x0037"
+		},
+		{
 			"productType": "0x0102",
+			"productId": "0x0037"
+		},
+		{
+			"productType": "0x0202",
 			"productId": "0x0037"
 		}
 	],

--- a/packages/config/config/devices/0x0371/zwa012.json
+++ b/packages/config/config/devices/0x0371/zwa012.json
@@ -29,6 +29,10 @@
 		{
 			"productType": "0x0202",
 			"productId": "0x002a"
+		},
+		{
+			"productType": "0x0102",
+			"productId": "0x0037"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
### Device

Aeotec Door / Window Sensor 7 Pro (ZWA012), a newer hardware revision.

| field | value |
|---|---|
| manufacturerId | `0x0371` |
| productType | `0x0102` |
| productId | `0x0037` |
| firmwareVersion | 1.0.4 |

### Problem

`zwa012.json` already covers productType `0x0102`, but only product IDs `0x000c` and `0x002a`.
This unit reports `0x0037`, so it matches no config file and shows as **"Unknown product 0x0037"**
in zwave-js-ui, even though the manufacturer resolves correctly to Aeotec Ltd.

Device database link: https://devices.zwave-js.io/?jumpTo=0x0371:0x0102:0x0037:1.0.4

### Change

Adds the single verified productType/productId pair to the existing `devices` array. Nothing else
changes — the existing firmware range (0.0–255.255), all 24 parameters and the Lifeline
association apply unchanged.

### Verification

Tested on a live device by copying the upstream file into `deviceConfigPriorityDir` with only this
entry added. The node then matched:

```
manufacturer: Aeotec Ltd.
label:        ZWA012
description:  Door / Window Sensor 7 Pro
```

Interview completes, all parameters are exposed, and the device functions normally
(tilt, temperature, humidity, accelerometer, tamper).

### Note for maintainers

The existing entries pair each productId with all three productTypes (`0x0002`, `0x0102`,
`0x0202`), which suggests regional variants. I have added only `0x0102` because that is the only
one I can physically verify. If you would prefer the full set added for consistency, happy to
update.
