### PR TITLE
fix(driver): name the transmit status when a send fails without NoAck

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -191,6 +191,7 @@ import {
 	buffer2hex,
 	cloneDeep,
 	createWrappingCounter,
+	getEnumMemberName,
 	getErrorMessage,
 	getenv,
 	isAbortError,
@@ -6949,8 +6950,18 @@ ${handlers.length} left`,
 						}
 
 						if (!prevResult.isOK()) {
+							// Only a TX status of NoAck means the node did not answer.
+							// For anything else, name the status instead of guessing.
 							throw new ZWaveError(
-								"The node did not acknowledge the command",
+								prevResult.transmitStatus
+										=== TransmitStatus.NoAck
+									? "The node did not acknowledge the command"
+									: `Failed to send the command (Status ${
+										getEnumMemberName(
+											TransmitStatus,
+											prevResult.transmitStatus,
+										)
+									})`,
 								ZWaveErrorCodes.Controller_CallbackNOK,
 								prevResult,
 								transaction.stack,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -6954,14 +6954,12 @@ ${handlers.length} left`,
 							// For anything else, name the status instead of guessing.
 							throw new ZWaveError(
 								prevResult.transmitStatus
-										=== TransmitStatus.NoAck
+									=== TransmitStatus.NoAck
 									? "The node did not acknowledge the command"
-									: `Failed to send the command (Status ${
-										getEnumMemberName(
+									: `Failed to send the command (Status ${getEnumMemberName(
 											TransmitStatus,
 											prevResult.transmitStatus,
-										)
-									})`,
+										)})`,
 								ZWaveErrorCodes.Controller_CallbackNOK,
 								prevResult,
 								transaction.stack,

--- a/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
@@ -413,3 +413,84 @@ integrationTestMulti(
 		},
 	},
 );
+
+let shouldFailAfterTransmitting = false;
+
+integrationTest.sequential(
+	"a TX status of Fail after transmitting is reported as such, not as a missing acknowledgement",
+	{
+		controllerCapabilities: controllerCapabilitiesNoBridge,
+
+		additionalDriverOptions: {
+			testingHooks: {
+				skipNodeInterview: true,
+			},
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			const handleSendData: MockControllerBehavior = {
+				async onHostMessage(controller, msg) {
+					if (msg instanceof SendDataRequest) {
+						if (!shouldFailAfterTransmitting) {
+							// Defer to the default behavior
+							return false;
+						}
+
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Sending,
+						);
+
+						const res = new SendDataResponse({
+							wasSent: true,
+						});
+						await controller.sendMessageToHost(res);
+
+						await wait(100);
+
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+
+						// txTicks > 0 means the controller did transmit,
+						// so this is a failed transmission and not a jam
+						const cb = new SendDataRequestTransmitReport({
+							callbackId: msg.callbackId!,
+							transmitStatus: TransmitStatus.Fail,
+							txReport: {
+								txTicks: 10,
+								routeSpeed: 0 as any,
+								routingAttempts: 1,
+								ackRSSI: 0,
+							},
+						});
+						await controller.sendMessageToHost(cb);
+
+						return true;
+					} else if (msg instanceof SendDataAbort) {
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+					}
+				},
+			};
+			controller.defineBehavior(handleSendData);
+		},
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.markAsAlive();
+			shouldFailAfterTransmitting = true;
+
+			await assertZWaveError(
+				t.expect,
+				() => node.commandClasses.Basic.set(99),
+				{
+					messageMatches: "Fail",
+				},
+			);
+
+			shouldFailAfterTransmitting = false;
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
@@ -414,8 +414,6 @@ integrationTestMulti(
 	},
 );
 
-let shouldFailAfterTransmitting = false;
-
 integrationTest.sequential(
 	"a TX status of Fail after transmitting is reported as such, not as a missing acknowledgement",
 	{
@@ -428,12 +426,21 @@ integrationTest.sequential(
 		},
 
 		customSetup: async (driver, controller, mockNode) => {
+			// Every SendData in this test fails after being transmitted
 			const handleSendData: MockControllerBehavior = {
 				async onHostMessage(controller, msg) {
 					if (msg instanceof SendDataRequest) {
-						if (!shouldFailAfterTransmitting) {
-							// Defer to the default behavior
-							return false;
+						// Check if this command is legal right now
+						const state = controller.state.get(
+							MockControllerStateKeys.CommunicationState,
+						) as MockControllerCommunicationState | undefined;
+						if (
+							state != undefined
+							&& state !== MockControllerCommunicationState.Idle
+						) {
+							throw new Error(
+								"Received SendDataRequest while not idle",
+							);
 						}
 
 						controller.state.set(
@@ -480,17 +487,17 @@ integrationTest.sequential(
 		},
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			node.markAsAlive();
-			shouldFailAfterTransmitting = true;
 
+			// "Fail" alone would also match the jam rejection
+			// ("Failed to send the command after N attempts")
 			await assertZWaveError(
 				t.expect,
 				() => node.commandClasses.Basic.set(99),
 				{
-					messageMatches: "Fail",
+					errorCode: ZWaveErrorCodes.Controller_CallbackNOK,
+					messageMatches: "Status Fail",
 				},
 			);
-
-			shouldFailAfterTransmitting = false;
 		},
 	},
 );


### PR DESCRIPTION
Fixes #7198.

A transmit status that is not `NoAck` is reported as `The node did not acknowledge the command (ZW0204)`, which is what the log in #7194 shows for a multicast that came back with status `Fail`.

## Where the wrong message comes from

`serialAPICommandErrorToZWaveError` already names the status and picks the code from it, for both unicast and multicast transmit reports. It never runs for SendData, though. In `queueSerialAPICommand`, the `"failure"` case returns the result instead of throwing when the reason is `callback NOK` and the message is SendData, with the comment that a NOK callback still carries information worth evaluating.

So the report travels back up to `sendMessage`, and the throw that actually fires is the `!prevResult.isOK()` one at the end of the send loop, which has the `NoAck` wording and `Controller_CallbackNOK` hardcoded regardless of `prevResult.transmitStatus`.

The jammed branch just above catches `Fail` only when `txReport.txTicks === 0`, so a `Fail` where the controller really did transmit falls straight through to that throw.

## What this changes

The message now names the status the same way `StateMachineShared.ts` does, and keeps the old wording when the status really is `NoAck`, so nothing changes for the common case.

## What this deliberately leaves alone

The error code stays `Controller_CallbackNOK` for every status. Two places key behaviour off it:

- `mayRetry` refuses to retry `SendDataMulticastRequest` and `SendDataMulticastBridgeRequest` when the code is `Controller_CallbackNOK`, because some nodes may already have reacted. Moving `Fail` to `Controller_MessageDropped` would start retrying multicasts that are not retried today.
- `isMissingNodeACK` matches on the same code for unicast SendData, and it is what routes a transaction into `handleMissingNodeACK`, so it decides whether a node gets treated as sleeping.

Both are behaviour decisions rather than message wording, so I left them out of this diff. Happy to follow whichever way you prefer if you want the code derived from the status too.

## Test

Added to `controllerJammed.test.ts`, next to the other TX status Fail cases and reusing the same mock controller shape. The callback reports `Fail` with `txTicks: 10` so the jam branch is skipped and the send loop reaches the throw.

Without the change the test fails with `The node did not acknowledge the command (ZW0204)`.

Run in a Linux container, since the suite does not start on my Windows checkout:

```
yarn test:ts run packages/zwave-js/src/lib/test/driver/
```

The whole folder is green with the change: 83 files, 180 passed and 1 skipped. `yarn build`, `yarn oxlint`, `yarn eslint` and `dprint check` are clean on both touched files.
