### PR TITLE
feat(config): update Inovelli VZW32-SN P111 to match public docs

### DIFF
--- a/packages/config/config/devices/0x031e/vzw32-sn.json
+++ b/packages/config/config/devices/0x031e/vzw32-sn.json
@@ -801,28 +801,24 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Restore the mmwave module factory configuration",
+					"label": "Factory reset mmWave module",
 					"value": 0
 				},
 				{
-					"label": "The interference area is automatically generated",
+					"label": "Generate and store interference area",
 					"value": 1
 				},
 				{
-					"label": "Obtains the interference region and detection region",
+					"label": "Reserved for future use",
 					"value": 2
 				},
 				{
-					"label": "Clears the interference area",
+					"label": "Clear stored interference area",
 					"value": 3
 				},
 				{
-					"label": "Resets the detection area",
+					"label": "Reset detection area to defaults",
 					"value": 4
-				},
-				{
-					"label": "Clears the stay area",
-					"value": 5
 				}
 			]
 		},


### PR DESCRIPTION
Ref: https://help.inovelli.com/en/articles/11463885-red-series-mmwave-presence-dimmer-switch-parameters#h_be5f7ddf15
Options for 2 and 5 were both originally removed, but Inovelli felt that `[2] Reserved for future use (Default)` would be friendlier  than `[2] (Default)` with `[2] Custom` in the drop-down.