### PR TITLE
feat(controller): expose Network Restore operations

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -213,6 +213,17 @@ import {
 	NVMOperationsReadRequest,
 	type NVMOperationsResponse,
 	NVMOperationsWriteRequest,
+	type NetworkRestoreCallback,
+	NetworkRestoreDeviceRequest,
+	type NetworkRestoreDeviceRequestOptions,
+	NetworkRestoreFinalizeRequest,
+	NetworkRestoreHomeIDRequest,
+	type NetworkRestoreHomeIDRequestOptions,
+	NetworkRestoreNeighborsRequest,
+	type NetworkRestoreNeighborsRequestOptions,
+	NetworkRestorePrepareRequest,
+	NetworkRestoreRoutesRequest,
+	type NetworkRestoreRoutesRequestOptions,
 	NodeNeighborUpdateStatus,
 	RemoveFailedNodeRequest,
 	type RemoveFailedNodeRequestStatusReport,
@@ -8152,6 +8163,56 @@ export class ZWaveController
 		}
 
 		return this._nvm;
+	}
+
+	/** Prepares the controller for restoring network data. */
+	public async networkRestorePrepare(): Promise<void> {
+		await this.driver.sendMessage<NetworkRestoreCallback>(
+			new NetworkRestorePrepareRequest(),
+		);
+	}
+
+	/** Restores the Home ID and controller node ID. */
+	public async networkRestoreSetController(
+		options: NetworkRestoreHomeIDRequestOptions,
+	): Promise<void> {
+		await this.driver.sendMessage<NetworkRestoreCallback>(
+			new NetworkRestoreHomeIDRequest(options),
+		);
+	}
+
+	/** Restores the protocol data for a node. */
+	public async networkRestoreNode(
+		options: NetworkRestoreDeviceRequestOptions,
+	): Promise<void> {
+		await this.driver.sendMessage<NetworkRestoreCallback>(
+			new NetworkRestoreDeviceRequest(options),
+		);
+	}
+
+	/** Restores the neighbor table for a node. */
+	public async networkRestoreNeighbors(
+		options: NetworkRestoreNeighborsRequestOptions,
+	): Promise<void> {
+		await this.driver.sendMessage<NetworkRestoreCallback>(
+			new NetworkRestoreNeighborsRequest(options),
+		);
+	}
+
+	/** Restores the application and last working routes for a node. */
+	public async networkRestoreRoutes(
+		options: NetworkRestoreRoutesRequestOptions,
+	): Promise<void> {
+		await this.driver.sendMessage<NetworkRestoreCallback>(
+			new NetworkRestoreRoutesRequest(options),
+		);
+	}
+
+	/** Finalizes the network data restore. */
+	public async networkRestoreFinalize(): Promise<void> {
+		await this.driver.sendMessage<NetworkRestoreCallback>(
+			new NetworkRestoreFinalizeRequest(),
+		);
 	}
 
 	/**

--- a/packages/zwave-js/zwave-js.api.md
+++ b/packages/zwave-js/zwave-js.api.md
@@ -120,6 +120,10 @@ import { MPDU } from '@zwave-js/core';
 import { MPDUHeaderType } from '@zwave-js/core';
 import { MulticastDestination } from '@zwave-js/core';
 import { MultilevelSwitchCommand } from '@zwave-js/cc';
+import { NetworkRestoreDeviceRequestOptions } from '@zwave-js/serial/serialapi';
+import { NetworkRestoreHomeIDRequestOptions } from '@zwave-js/serial/serialapi';
+import { NetworkRestoreNeighborsRequestOptions } from '@zwave-js/serial/serialapi';
+import { NetworkRestoreRoutesRequestOptions } from '@zwave-js/serial/serialapi';
 import { NODE_ID_BROADCAST } from '@zwave-js/core';
 import { NODE_ID_BROADCAST_LR } from '@zwave-js/core';
 import { NODE_ID_MAX } from '@zwave-js/core';
@@ -2502,6 +2506,12 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
     get maxLongRangePowerlevel(): MaybeNotKnown<number>;
     get maxPayloadSize(): MaybeNotKnown<number>;
     get maxPayloadSizeLR(): MaybeNotKnown<number>;
+    networkRestoreFinalize(): Promise<void>;
+    networkRestoreNeighbors(options: NetworkRestoreNeighborsRequestOptions): Promise<void>;
+    networkRestoreNode(options: NetworkRestoreDeviceRequestOptions): Promise<void>;
+    networkRestorePrepare(): Promise<void>;
+    networkRestoreRoutes(options: NetworkRestoreRoutesRequestOptions): Promise<void>;
+    networkRestoreSetController(options: NetworkRestoreHomeIDRequestOptions): Promise<void>;
     get nodeIdType(): NodeIDType;
     get nodes(): ReadonlyThrowingMap<number, ZWaveNode>;
     // (undocumented)


### PR DESCRIPTION
Part 2/3 of #9121.

Depends on #9122 and targets `alcalzone-network-restore-messages-cba`.

Adds low-level `ZWaveController` methods for each Network Restore Serial API operation. Each method waits for the request response and completion callback through `driver.sendMessage`.

Validation:
- `yarn fmt`
- `yarn build`
- `yarn build zwave-js`
- `yarn workspace zwave-js extract-api --local`