### PR TITLE
feat(controller): restore NVMs with Network Restore

### DIFF
--- a/packages/nvmedit/nvmedit.api.md
+++ b/packages/nvmedit/nvmedit.api.md
@@ -593,6 +593,11 @@ export type NodeNVMProperty = {
 // @public (undocumented)
 export type NodeNVMPropertyToDataType<P extends NodeNVMProperty> = P["type"] extends keyof NodeNVMPropertyTypes ? NodeNVMPropertyTypes[P["type"]] : never;
 
+// Warning: (ae-missing-release-tag) "normalizeNVM" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function normalizeNVM(nvm: BytesView): Promise<NVMJSON>;
+
 // Warning: (ae-missing-release-tag) "NVM" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public

--- a/packages/nvmedit/src/convert.ts
+++ b/packages/nvmedit/src/convert.ts
@@ -234,7 +234,7 @@ async function parseNVM(nvm: BytesView): Promise<ParsedNVMResult> {
 		};
 	} catch (e) {
 		if (isZWaveError(e) && e.code === ZWaveErrorCodes.NVM_InvalidFormat) {
-			// The 700-series parser rejects 500-series NVMs as invalid
+			// This is not a 700 series NVM, maybe it is a 500 series one?
 			return {
 				nvm: {
 					type: 500,
@@ -247,7 +247,7 @@ async function parseNVM(nvm: BytesView): Promise<ParsedNVMResult> {
 			&& isObject(e.context)
 			&& typeof e.context.protocolFileFormat === "number"
 		) {
-			// The protocol file format identifies an unsupported 700-series NVM
+			// This is a 700 series NVM, but the protocol version is not (yet) supported
 			return {
 				nvm: { type: "unknown" },
 				protocolFileFormat: e.context.protocolFileFormat,

--- a/packages/nvmedit/src/convert.ts
+++ b/packages/nvmedit/src/convert.ts
@@ -234,6 +234,7 @@ async function parseNVM(nvm: BytesView): Promise<ParsedNVMResult> {
 		};
 	} catch (e) {
 		if (isZWaveError(e) && e.code === ZWaveErrorCodes.NVM_InvalidFormat) {
+			// The 700-series parser rejects 500-series NVMs as invalid
 			return {
 				nvm: {
 					type: 500,
@@ -246,6 +247,7 @@ async function parseNVM(nvm: BytesView): Promise<ParsedNVMResult> {
 			&& isObject(e.context)
 			&& typeof e.context.protocolFileFormat === "number"
 		) {
+			// The protocol file format identifies an unsupported 700-series NVM
 			return {
 				nvm: { type: "unknown" },
 				protocolFileFormat: e.context.protocolFileFormat,

--- a/packages/nvmedit/src/convert.ts
+++ b/packages/nvmedit/src/convert.ts
@@ -217,6 +217,44 @@ type ParsedNVM =
 		type: "unknown";
 	};
 
+interface ParsedNVMResult {
+	nvm: ParsedNVM;
+	protocolFileFormat?: number;
+}
+
+async function parseNVM(nvm: BytesView): Promise<ParsedNVMResult> {
+	try {
+		const json = await nvmToJSON(nvm);
+		return {
+			nvm: {
+				type: 700,
+				json,
+			},
+			protocolFileFormat: json.format,
+		};
+	} catch (e) {
+		if (isZWaveError(e) && e.code === ZWaveErrorCodes.NVM_InvalidFormat) {
+			return {
+				nvm: {
+					type: 500,
+					json: await nvm500ToJSON(nvm),
+				},
+			};
+		} else if (
+			isZWaveError(e)
+			&& e.code === ZWaveErrorCodes.NVM_NotSupported
+			&& isObject(e.context)
+			&& typeof e.context.protocolFileFormat === "number"
+		) {
+			return {
+				nvm: { type: "unknown" },
+				protocolFileFormat: e.context.protocolFileFormat,
+			};
+		}
+		return { nvm: { type: "unknown" } };
+	}
+}
+
 /**
  * Ensures that the controller node is marked as listening.
  * Failure to do so causes the radio to stop after one RX event on SDK 8.0.0+.
@@ -228,6 +266,23 @@ function setControllerIsListening(json: NVMJSON): void {
 	if (controllerNode && "isListening" in controllerNode) {
 		controllerNode.isListening = true;
 	}
+}
+
+/** Converts a supported NVM backup to the common 700-series JSON representation. */
+export async function normalizeNVM(nvm: BytesView): Promise<NVMJSON> {
+	const parsed = (await parseNVM(nvm)).nvm;
+	if (parsed.type === "unknown") {
+		throw new ZWaveError(
+			"The NVM has an unsupported format",
+			ZWaveErrorCodes.NVM_NotSupported,
+		);
+	}
+
+	const json = parsed.type === 700
+		? parsed.json
+		: json500To700(parsed.json, true);
+	setControllerIsListening(json);
+	return json;
 }
 
 /**
@@ -1998,65 +2053,12 @@ export async function migrateNVM(
 	targetNVM: BytesView,
 	options: MigrateNVMOptions = {},
 ): Promise<BytesView> {
-	let source: ParsedNVM;
-	let target: ParsedNVM;
-	let sourceProtocolFileFormat: number | undefined;
-	let targetProtocolFileFormat: number | undefined;
-
-	try {
-		source = {
-			type: 700,
-			json: await nvmToJSON(sourceNVM),
-		};
-		sourceProtocolFileFormat = source.json.format;
-	} catch (e) {
-		if (isZWaveError(e) && e.code === ZWaveErrorCodes.NVM_InvalidFormat) {
-			// This is not a 700 series NVM, maybe it is a 500 series one?
-			source = {
-				type: 500,
-				json: await nvm500ToJSON(sourceNVM),
-			};
-		} else if (
-			isZWaveError(e)
-			&& e.code === ZWaveErrorCodes.NVM_NotSupported
-			&& isObject(e.context)
-			&& typeof e.context.protocolFileFormat === "number"
-		) {
-			// This is a 700 series NVM, but the protocol version is not (yet) supported
-			source = { type: "unknown" };
-			sourceProtocolFileFormat = e.context.protocolFileFormat;
-		} else {
-			source = { type: "unknown" };
-		}
-	}
-
-	try {
-		target = {
-			type: 700,
-			json: await nvmToJSON(targetNVM),
-		};
-		targetProtocolFileFormat = target.json.format;
-	} catch (e) {
-		if (isZWaveError(e) && e.code === ZWaveErrorCodes.NVM_InvalidFormat) {
-			// This is not a 700 series NVM, maybe it is a 500 series one?
-			target = {
-				type: 500,
-				json: await nvm500ToJSON(targetNVM),
-			};
-		} else if (
-			isZWaveError(e)
-			&& e.code === ZWaveErrorCodes.NVM_NotSupported
-			&& source.type === 700
-			&& isObject(e.context)
-			&& typeof e.context.protocolFileFormat === "number"
-		) {
-			// This is a 700 series NVM, but the protocol version is not (yet) supported
-			target = { type: "unknown" };
-			targetProtocolFileFormat = e.context.protocolFileFormat;
-		} else {
-			target = { type: "unknown" };
-		}
-	}
+	const parsedSource = await parseNVM(sourceNVM);
+	let source = parsedSource.nvm;
+	const sourceProtocolFileFormat = parsedSource.protocolFileFormat;
+	const parsedTarget = await parseNVM(targetNVM);
+	let target = parsedTarget.nvm;
+	const targetProtocolFileFormat = parsedTarget.protocolFileFormat;
 
 	const {
 		preserveApplicationData = true,

--- a/packages/nvmedit/src/index.ts
+++ b/packages/nvmedit/src/index.ts
@@ -6,6 +6,7 @@ export {
 	jsonToNVM,
 	jsonToNVM500,
 	migrateNVM,
+	normalizeNVM,
 	nvm500ToJSON,
 	nvmToJSON,
 } from "./convert.js";

--- a/packages/nvmedit/src/index_browser.ts
+++ b/packages/nvmedit/src/index_browser.ts
@@ -8,6 +8,7 @@ export {
 	jsonToNVM,
 	jsonToNVM500,
 	migrateNVM,
+	normalizeNVM,
 	nvm500ToJSON,
 	nvmToJSON,
 } from "./convert.js";

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -8243,7 +8243,7 @@ export class ZWaveController
 			setImmediate(() => restoreProgress(completed, plan.totalCommands));
 		};
 
-		// Set Default must clear existing device data before Network Restore
+		// The specification recommends Set Default to clear existing device data before Network Restore
 		await this.hardResetInternal(false);
 
 		await this.networkRestorePrepare();

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -9102,7 +9102,7 @@ export class ZWaveController
 	 *
 	 * @param nvmData The NVM backup to be restored
 	 * @param convertProgress Can be used to monitor the progress of the NVM conversion, which may take several seconds up to a few minutes depending on the NVM size
-	 * @param restoreProgress Can be used to monitor the progress of the restore operation. Network Restore reports command counts. Raw restore reports byte counts.
+	 * @param restoreProgress Can be used to monitor the progress of the restore operation. The operation may take several seconds to a few minutes. Network Restore reports command counts. Raw restore reports byte counts.
 	 * @param migrateOptions Influence which data should be preserved during a migration
 	 *
 	 * Network Restore cannot transfer application data or SUC update entries.

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -57,6 +57,7 @@ import {
 	NODE_ID_BROADCAST_LR,
 	NOT_KNOWN,
 	NodeIDType,
+	type NodeProtocolInfo,
 	NodeType,
 	type ProtocolDataRate,
 	ProtocolType,
@@ -66,6 +67,7 @@ import {
 	type RSSI,
 	type Route,
 	RouteKind,
+	RouteProtocolDataRate,
 	SecurityClass,
 	SecurityManager,
 	SecurityManager2,
@@ -75,7 +77,7 @@ import {
 	type UnknownZWaveChipType,
 	ValueDB,
 	type ZWaveApiVersion,
-	type ZWaveDataRate,
+	ZWaveDataRate,
 	ZWaveError,
 	ZWaveErrorCodes,
 	ZWaveLibraryTypes,
@@ -86,6 +88,8 @@ import {
 	deriveTempKeys,
 	dskFromString,
 	dskToString,
+	encodeNodeBitMask,
+	encodeNodeProtocolInfo,
 	generateECDHKeyPair,
 	getChipTypeAndVersion,
 	getHighestSecurityClass,
@@ -116,7 +120,10 @@ import {
 	NVM500,
 	NVM500Adapter,
 	type NVMAdapter,
+	type NVMJSON,
+	type NVMJSONNodeWithInfo,
 	migrateNVM,
+	normalizeNVM,
 } from "@zwave-js/nvmedit";
 import {
 	FunctionType,
@@ -213,7 +220,8 @@ import {
 	NVMOperationsReadRequest,
 	type NVMOperationsResponse,
 	NVMOperationsWriteRequest,
-	type NetworkRestoreCallback,
+	NetworkRestoreCallback,
+	NetworkRestoreCommand,
 	NetworkRestoreDeviceRequest,
 	type NetworkRestoreDeviceRequestOptions,
 	NetworkRestoreFinalizeRequest,
@@ -222,8 +230,13 @@ import {
 	NetworkRestoreNeighborsRequest,
 	type NetworkRestoreNeighborsRequestOptions,
 	NetworkRestorePrepareRequest,
+	type NetworkRestoreRequest,
+	type NetworkRestoreResponse,
+	type NetworkRestoreRoute,
+	NetworkRestoreRouteType,
 	NetworkRestoreRoutesRequest,
 	type NetworkRestoreRoutesRequestOptions,
+	NetworkRestoreStatus,
 	NodeNeighborUpdateStatus,
 	RemoveFailedNodeRequest,
 	type RemoveFailedNodeRequestStatusReport,
@@ -392,6 +405,142 @@ import {
 	getInitial500SeriesNVMBackupChunkSize,
 	isRebuildRoutesTask,
 } from "./utils.js";
+
+type NVMRoute = NonNullable<NVMJSONNodeWithInfo["lwr"]>;
+type NetworkRestoreProtocolNode =
+	& Omit<NodeProtocolInfo, "hasSpecificDeviceClass">
+	& {
+		genericDeviceClass: number;
+		specificDeviceClass?: number | null;
+	};
+
+interface NetworkRestoreClassicNodePlan {
+	nodeId: number;
+	protocolData: Bytes;
+	neighbors?: Bytes;
+	routes?: NetworkRestoreRoute[];
+}
+
+interface NetworkRestoreNodePlan {
+	nodeId: number;
+	protocolData: Bytes;
+}
+
+interface NetworkRestorePlan {
+	homeId: number;
+	controllerNodeId: number;
+	classicNodes: NetworkRestoreClassicNodePlan[];
+	longRangeNodes: NetworkRestoreNodePlan[];
+	totalCommands: number;
+}
+
+function encodeNetworkRestoreProtocolData(
+	node: NetworkRestoreProtocolNode,
+	isLongRange: boolean,
+): Bytes {
+	const hasSpecificDeviceClass = node.specificDeviceClass != null;
+	return Bytes.concat([
+		encodeNodeProtocolInfo(
+			{
+				...node,
+				hasSpecificDeviceClass,
+			},
+			isLongRange,
+		),
+		[node.genericDeviceClass, node.specificDeviceClass ?? 0],
+	]);
+}
+
+function mapNetworkRestoreRouteSpeed(
+	protocolRate: RouteProtocolDataRate,
+): ZWaveDataRate {
+	switch (protocolRate) {
+		case RouteProtocolDataRate.Unspecified:
+		case RouteProtocolDataRate.ZWave_9k6:
+			return ZWaveDataRate["9k6"];
+		case RouteProtocolDataRate.ZWave_40k:
+			return ZWaveDataRate["40k"];
+		case RouteProtocolDataRate.ZWave_100k:
+			return ZWaveDataRate["100k"];
+		default:
+			throw new ZWaveError(
+				`Cannot restore a Classic route with protocol data rate ${protocolRate}`,
+				ZWaveErrorCodes.NVM_NotSupported,
+			);
+	}
+}
+
+function mapNetworkRestoreRoute(
+	route: NVMRoute,
+	type: NetworkRestoreRouteType,
+): NetworkRestoreRoute {
+	return {
+		type,
+		beam: route.beaming,
+		speed: mapNetworkRestoreRouteSpeed(route.protocolRate),
+		hops: route.repeaterNodeIDs ?? [],
+	};
+}
+
+function createNetworkRestorePlan(
+	nvm: NVMJSON,
+	options: MigrateNVMOptions = {},
+): NetworkRestorePlan {
+	const preserveNeighbors = options.preserveNeighbors ?? true;
+	const preserveRoutes = options.preserveRoutes ?? true;
+
+	const classicNodes: NetworkRestoreClassicNodePlan[] = [];
+	for (const [nodeIdString, node] of Object.entries(nvm.nodes)) {
+		if (!("isListening" in node)) continue;
+
+		const routes: NetworkRestoreRoute[] = [];
+		if (preserveRoutes && node.lwr) {
+			routes.push(mapNetworkRestoreRoute(
+				node.lwr,
+				node.appRouteLock
+					? NetworkRestoreRouteType.APR
+					: NetworkRestoreRouteType.LWR,
+			));
+		}
+		if (preserveRoutes && node.nlwr) {
+			routes.push(mapNetworkRestoreRoute(
+				node.nlwr,
+				NetworkRestoreRouteType.NLWR,
+			));
+		}
+
+		classicNodes.push({
+			nodeId: Number(nodeIdString),
+			protocolData: encodeNetworkRestoreProtocolData(node, false),
+			neighbors: preserveNeighbors
+				? encodeNodeBitMask(node.neighbors)
+				: undefined,
+			routes: routes.length > 0 ? routes : undefined,
+		});
+	}
+	classicNodes.sort((a, b) => a.nodeId - b.nodeId);
+
+	const longRangeNodes: NetworkRestoreNodePlan[] = [];
+	for (const [nodeIdString, node] of Object.entries(nvm.lrNodes ?? {})) {
+		longRangeNodes.push({
+			nodeId: Number(nodeIdString),
+			protocolData: encodeNetworkRestoreProtocolData(node, true),
+		});
+	}
+	longRangeNodes.sort((a, b) => a.nodeId - b.nodeId);
+
+	return {
+		homeId: Number.parseInt(nvm.controller.homeId, 16),
+		controllerNodeId: nvm.controller.nodeId,
+		classicNodes,
+		longRangeNodes,
+		totalCommands: 4
+			+ classicNodes.length
+			+ longRangeNodes.length
+			+ classicNodes.filter((node) => node.neighbors).length
+			+ classicNodes.filter((node) => node.routes).length,
+	};
+}
 
 // Strongly type the event emitter events
 interface ControllerEventCallbacks
@@ -2032,9 +2181,17 @@ export class ZWaveController
 	 * @internal
 	 */
 	public async hardReset(): Promise<void> {
+		return this.hardResetInternal(true);
+	}
+
+	private async hardResetInternal(
+		notifyAssociatedNodes: boolean,
+	): Promise<void> {
 		// begin the reset process
 		try {
-			const associations = this.associations;
+			const associations = notifyAssociatedNodes
+				? this.associations
+				: undefined;
 			if (associations?.length) {
 				this.driver.controllerLog.print(
 					"Notifying associated nodes about reset...",
@@ -8165,9 +8322,31 @@ export class ZWaveController
 		return this._nvm;
 	}
 
+	private async sendNetworkRestoreCommand(
+		request: NetworkRestoreRequest,
+		pauseSendThread: boolean = false,
+	): Promise<void> {
+		const result = await this.driver.sendMessage<
+			NetworkRestoreCallback | NetworkRestoreResponse
+		>(request, { pauseSendThread });
+		if (result.isOK()) return;
+
+		const command = getEnumMemberName(
+			NetworkRestoreCommand,
+			request.command,
+		);
+		const reason = result instanceof NetworkRestoreCallback
+			? getEnumMemberName(NetworkRestoreStatus, result.status)
+			: "request rejected";
+		throw new ZWaveError(
+			`${command} Network Restore command failed: ${reason}`,
+			ZWaveErrorCodes.Controller_CommandError,
+		);
+	}
+
 	/** Prepares the controller for restoring network data. */
 	public async networkRestorePrepare(): Promise<void> {
-		await this.driver.sendMessage<NetworkRestoreCallback>(
+		await this.sendNetworkRestoreCommand(
 			new NetworkRestorePrepareRequest(),
 		);
 	}
@@ -8176,7 +8355,7 @@ export class ZWaveController
 	public async networkRestoreSetController(
 		options: NetworkRestoreHomeIDRequestOptions,
 	): Promise<void> {
-		await this.driver.sendMessage<NetworkRestoreCallback>(
+		await this.sendNetworkRestoreCommand(
 			new NetworkRestoreHomeIDRequest(options),
 		);
 	}
@@ -8185,7 +8364,7 @@ export class ZWaveController
 	public async networkRestoreNode(
 		options: NetworkRestoreDeviceRequestOptions,
 	): Promise<void> {
-		await this.driver.sendMessage<NetworkRestoreCallback>(
+		await this.sendNetworkRestoreCommand(
 			new NetworkRestoreDeviceRequest(options),
 		);
 	}
@@ -8194,7 +8373,7 @@ export class ZWaveController
 	public async networkRestoreNeighbors(
 		options: NetworkRestoreNeighborsRequestOptions,
 	): Promise<void> {
-		await this.driver.sendMessage<NetworkRestoreCallback>(
+		await this.sendNetworkRestoreCommand(
 			new NetworkRestoreNeighborsRequest(options),
 		);
 	}
@@ -8203,16 +8382,77 @@ export class ZWaveController
 	public async networkRestoreRoutes(
 		options: NetworkRestoreRoutesRequestOptions,
 	): Promise<void> {
-		await this.driver.sendMessage<NetworkRestoreCallback>(
+		await this.sendNetworkRestoreCommand(
 			new NetworkRestoreRoutesRequest(options),
 		);
 	}
 
 	/** Finalizes the network data restore. */
 	public async networkRestoreFinalize(): Promise<void> {
-		await this.driver.sendMessage<NetworkRestoreCallback>(
+		await this.sendNetworkRestoreCommand(
 			new NetworkRestoreFinalizeRequest(),
 		);
+	}
+
+	private async restoreNVMWithNetworkRestore(
+		plan: NetworkRestorePlan,
+		restoreProgress: (
+			commandsCompleted: number,
+			totalCommands: number,
+		) => void,
+		onFinalized: () => void,
+	): Promise<void> {
+		let commandsCompleted = 0;
+		const reportProgress = (): void => {
+			const completed = ++commandsCompleted;
+			setImmediate(() => restoreProgress(completed, plan.totalCommands));
+		};
+
+		await this.hardResetInternal(false);
+		reportProgress();
+
+		await this.networkRestorePrepare();
+		reportProgress();
+
+		await this.networkRestoreSetController({
+			homeId: plan.homeId,
+			controllerNodeId: plan.controllerNodeId,
+		});
+		reportProgress();
+
+		for (const node of plan.classicNodes) {
+			await this.networkRestoreNode(node);
+			reportProgress();
+		}
+		for (const node of plan.longRangeNodes) {
+			await this.networkRestoreNode(node);
+			reportProgress();
+		}
+		for (const node of plan.classicNodes) {
+			if (!node.neighbors) continue;
+			await this.networkRestoreNeighbors({
+				nodeId: node.nodeId,
+				neighbors: node.neighbors,
+			});
+			reportProgress();
+		}
+		for (const node of plan.classicNodes) {
+			if (!node.routes) continue;
+			await this.networkRestoreRoutes({
+				nodeId: node.nodeId,
+				routes: node.routes,
+			});
+			reportProgress();
+		}
+
+		await this.driver.restartAfterControllerReboot(async () => {
+			await this.sendNetworkRestoreCommand(
+				new NetworkRestoreFinalizeRequest(),
+				true,
+			);
+			reportProgress();
+			onFinalized();
+		});
 	}
 
 	/**
@@ -8862,13 +9102,18 @@ export class ZWaveController
 	 *
 	 * @param nvmData The NVM backup to be restored
 	 * @param convertProgress Can be used to monitor the progress of the NVM conversion, which may take several seconds up to a few minutes depending on the NVM size
-	 * @param restoreProgress Can be used to monitor the progress of the restore operation, which may take several seconds up to a few minutes depending on the NVM size
+	 * @param restoreProgress Can be used to monitor the progress of the restore operation. Network Restore reports command counts. Raw restore reports byte counts.
 	 * @param migrateOptions Influence which data should be preserved during a migration
+	 *
+	 * Network Restore cannot transfer application data or SUC update entries.
 	 */
 	public restoreNVM(
 		nvmData: BytesView,
 		convertProgress?: (bytesRead: number, total: number) => void,
-		restoreProgress?: (bytesWritten: number, total: number) => void,
+		restoreProgress?: (
+			commandsCompleted: number,
+			totalCommands: number,
+		) => void,
 		migrateOptions?: MigrateNVMOptions,
 	): Promise<void> {
 		return this.driver.scheduler.queueTask(
@@ -8884,7 +9129,10 @@ export class ZWaveController
 	private getRestoreNVMTask(
 		nvmData: BytesView,
 		convertProgress?: (bytesRead: number, total: number) => void,
-		restoreProgress?: (bytesWritten: number, total: number) => void,
+		restoreProgress?: (
+			commandsCompleted: number,
+			totalCommands: number,
+		) => void,
 		migrateOptions?: MigrateNVMOptions,
 	): TaskBuilder<void> {
 		const self = this;
@@ -8898,6 +9146,39 @@ export class ZWaveController
 			// The radio is off during the restore, so other tasks cannot communicate anyways
 			interrupt: TaskInterruptBehavior.Forbidden,
 			task: async function* restoreNVMTask() {
+				let networkRestorePlan: NetworkRestorePlan | undefined;
+				if (
+					self.isFunctionSupported(FunctionType.NetworkRestore)
+						=== true
+				) {
+					let normalizedNVM: NVMJSON | undefined;
+					try {
+						normalizedNVM = yield* waitFor(normalizeNVM(nvmData));
+					} catch (e) {
+						self.driver.controllerLog.print(
+							`Could not normalize the source NVM for Network Restore: ${
+								getErrorMessage(e)
+							}. Falling back to raw NVM migration.`,
+							"warn",
+						);
+					}
+
+					if (normalizedNVM) {
+						try {
+							networkRestorePlan = createNetworkRestorePlan(
+								normalizedNVM,
+								migrateOptions,
+							);
+						} catch (e) {
+							const message = "Failed to restore NVM backup: "
+								+ getErrorMessage(e);
+							self.driver.controllerLog.print(message, "error");
+							(e as Error).message = message;
+							throw e;
+						}
+					}
+				}
+
 				// Turn Z-Wave radio off to avoid having the protocol write to the NVM while dumping it
 				if (!(yield* waitFor(self.toggleRF(false)))) {
 					throw new ZWaveError(
@@ -8908,6 +9189,36 @@ export class ZWaveController
 
 				// Disable watchdog to prevent resets during NVM access
 				yield* waitFor(self.stopWatchdog());
+
+				if (networkRestorePlan) {
+					try {
+						self.driver.controllerLog.print(
+							"Restoring NVM backup using Network Restore...",
+						);
+						yield* waitFor(self.restoreNVMWithNetworkRestore(
+							networkRestorePlan,
+							restoreProgress ?? noop,
+							() => {
+								rfRestored = true;
+							},
+						));
+						self.driver.controllerLog.print(
+							"NVM backup restored",
+						);
+					} catch (e) {
+						if (!rfRestored) {
+							yield* waitFor(self.toggleRF(true));
+							rfRestored = true;
+						}
+
+						const message = "Failed to restore NVM backup: "
+							+ getErrorMessage(e);
+						self.driver.controllerLog.print(message, "error");
+						(e as Error).message = message;
+						throw e;
+					}
+					return;
+				}
 
 				// Restoring a potentially incompatible NVM happens in three steps:
 				// 1. the current NVM is read

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -57,7 +57,6 @@ import {
 	NODE_ID_BROADCAST_LR,
 	NOT_KNOWN,
 	NodeIDType,
-	type NodeProtocolInfo,
 	NodeType,
 	type ProtocolDataRate,
 	ProtocolType,
@@ -67,7 +66,6 @@ import {
 	type RSSI,
 	type Route,
 	RouteKind,
-	RouteProtocolDataRate,
 	SecurityClass,
 	SecurityManager,
 	SecurityManager2,
@@ -77,7 +75,7 @@ import {
 	type UnknownZWaveChipType,
 	ValueDB,
 	type ZWaveApiVersion,
-	ZWaveDataRate,
+	type ZWaveDataRate,
 	ZWaveError,
 	ZWaveErrorCodes,
 	ZWaveLibraryTypes,
@@ -88,8 +86,6 @@ import {
 	deriveTempKeys,
 	dskFromString,
 	dskToString,
-	encodeNodeBitMask,
-	encodeNodeProtocolInfo,
 	generateECDHKeyPair,
 	getChipTypeAndVersion,
 	getHighestSecurityClass,
@@ -121,7 +117,6 @@ import {
 	NVM500Adapter,
 	type NVMAdapter,
 	type NVMJSON,
-	type NVMJSONNodeWithInfo,
 	migrateNVM,
 	normalizeNVM,
 } from "@zwave-js/nvmedit";
@@ -220,8 +215,6 @@ import {
 	NVMOperationsReadRequest,
 	type NVMOperationsResponse,
 	NVMOperationsWriteRequest,
-	NetworkRestoreCallback,
-	NetworkRestoreCommand,
 	NetworkRestoreDeviceRequest,
 	type NetworkRestoreDeviceRequestOptions,
 	NetworkRestoreFinalizeRequest,
@@ -230,13 +223,8 @@ import {
 	NetworkRestoreNeighborsRequest,
 	type NetworkRestoreNeighborsRequestOptions,
 	NetworkRestorePrepareRequest,
-	type NetworkRestoreRequest,
-	type NetworkRestoreResponse,
-	type NetworkRestoreRoute,
-	NetworkRestoreRouteType,
 	NetworkRestoreRoutesRequest,
 	type NetworkRestoreRoutesRequestOptions,
-	NetworkRestoreStatus,
 	NodeNeighborUpdateStatus,
 	RemoveFailedNodeRequest,
 	type RemoveFailedNodeRequestStatusReport,
@@ -380,6 +368,11 @@ import {
 	type SmartStartProvisioningEntry,
 } from "./Inclusion.js";
 import { SerialNVMIO500, SerialNVMIO700 } from "./NVMIO.js";
+import {
+	type NetworkRestorePlan,
+	canUseNetworkRestore,
+	createNetworkRestorePlan,
+} from "./NetworkRestore.js";
 import { determineNIF } from "./NodeInformationFrame.js";
 import {
 	type ControllerProprietary,
@@ -405,142 +398,6 @@ import {
 	getInitial500SeriesNVMBackupChunkSize,
 	isRebuildRoutesTask,
 } from "./utils.js";
-
-type NVMRoute = NonNullable<NVMJSONNodeWithInfo["lwr"]>;
-type NetworkRestoreProtocolNode =
-	& Omit<NodeProtocolInfo, "hasSpecificDeviceClass">
-	& {
-		genericDeviceClass: number;
-		specificDeviceClass?: number | null;
-	};
-
-interface NetworkRestoreClassicNodePlan {
-	nodeId: number;
-	protocolData: Bytes;
-	neighbors?: Bytes;
-	routes?: NetworkRestoreRoute[];
-}
-
-interface NetworkRestoreNodePlan {
-	nodeId: number;
-	protocolData: Bytes;
-}
-
-interface NetworkRestorePlan {
-	homeId: number;
-	controllerNodeId: number;
-	classicNodes: NetworkRestoreClassicNodePlan[];
-	longRangeNodes: NetworkRestoreNodePlan[];
-	totalCommands: number;
-}
-
-function encodeNetworkRestoreProtocolData(
-	node: NetworkRestoreProtocolNode,
-	isLongRange: boolean,
-): Bytes {
-	const hasSpecificDeviceClass = node.specificDeviceClass != null;
-	return Bytes.concat([
-		encodeNodeProtocolInfo(
-			{
-				...node,
-				hasSpecificDeviceClass,
-			},
-			isLongRange,
-		),
-		[node.genericDeviceClass, node.specificDeviceClass ?? 0],
-	]);
-}
-
-function mapNetworkRestoreRouteSpeed(
-	protocolRate: RouteProtocolDataRate,
-): ZWaveDataRate {
-	switch (protocolRate) {
-		case RouteProtocolDataRate.Unspecified:
-		case RouteProtocolDataRate.ZWave_9k6:
-			return ZWaveDataRate["9k6"];
-		case RouteProtocolDataRate.ZWave_40k:
-			return ZWaveDataRate["40k"];
-		case RouteProtocolDataRate.ZWave_100k:
-			return ZWaveDataRate["100k"];
-		default:
-			throw new ZWaveError(
-				`Cannot restore a Classic route with protocol data rate ${protocolRate}`,
-				ZWaveErrorCodes.NVM_NotSupported,
-			);
-	}
-}
-
-function mapNetworkRestoreRoute(
-	route: NVMRoute,
-	type: NetworkRestoreRouteType,
-): NetworkRestoreRoute {
-	return {
-		type,
-		beam: route.beaming,
-		speed: mapNetworkRestoreRouteSpeed(route.protocolRate),
-		hops: route.repeaterNodeIDs ?? [],
-	};
-}
-
-function createNetworkRestorePlan(
-	nvm: NVMJSON,
-	options: MigrateNVMOptions = {},
-): NetworkRestorePlan {
-	const preserveNeighbors = options.preserveNeighbors ?? true;
-	const preserveRoutes = options.preserveRoutes ?? true;
-
-	const classicNodes: NetworkRestoreClassicNodePlan[] = [];
-	for (const [nodeIdString, node] of Object.entries(nvm.nodes)) {
-		if (!("isListening" in node)) continue;
-
-		const routes: NetworkRestoreRoute[] = [];
-		if (preserveRoutes && node.lwr) {
-			routes.push(mapNetworkRestoreRoute(
-				node.lwr,
-				node.appRouteLock
-					? NetworkRestoreRouteType.APR
-					: NetworkRestoreRouteType.LWR,
-			));
-		}
-		if (preserveRoutes && node.nlwr) {
-			routes.push(mapNetworkRestoreRoute(
-				node.nlwr,
-				NetworkRestoreRouteType.NLWR,
-			));
-		}
-
-		classicNodes.push({
-			nodeId: Number(nodeIdString),
-			protocolData: encodeNetworkRestoreProtocolData(node, false),
-			neighbors: preserveNeighbors
-				? encodeNodeBitMask(node.neighbors)
-				: undefined,
-			routes: routes.length > 0 ? routes : undefined,
-		});
-	}
-	classicNodes.sort((a, b) => a.nodeId - b.nodeId);
-
-	const longRangeNodes: NetworkRestoreNodePlan[] = [];
-	for (const [nodeIdString, node] of Object.entries(nvm.lrNodes ?? {})) {
-		longRangeNodes.push({
-			nodeId: Number(nodeIdString),
-			protocolData: encodeNetworkRestoreProtocolData(node, true),
-		});
-	}
-	longRangeNodes.sort((a, b) => a.nodeId - b.nodeId);
-
-	return {
-		homeId: Number.parseInt(nvm.controller.homeId, 16),
-		controllerNodeId: nvm.controller.nodeId,
-		classicNodes,
-		longRangeNodes,
-		totalCommands: 4
-			+ classicNodes.length
-			+ longRangeNodes.length
-			+ classicNodes.filter((node) => node.neighbors).length
-			+ classicNodes.filter((node) => node.routes).length,
-	};
-}
 
 // Strongly type the event emitter events
 interface ControllerEventCallbacks
@@ -8322,31 +8179,9 @@ export class ZWaveController
 		return this._nvm;
 	}
 
-	private async sendNetworkRestoreCommand(
-		request: NetworkRestoreRequest,
-		pauseSendThread: boolean = false,
-	): Promise<void> {
-		const result = await this.driver.sendMessage<
-			NetworkRestoreCallback | NetworkRestoreResponse
-		>(request, { pauseSendThread });
-		if (result.isOK()) return;
-
-		const command = getEnumMemberName(
-			NetworkRestoreCommand,
-			request.command,
-		);
-		const reason = result instanceof NetworkRestoreCallback
-			? getEnumMemberName(NetworkRestoreStatus, result.status)
-			: "request rejected";
-		throw new ZWaveError(
-			`${command} Network Restore command failed: ${reason}`,
-			ZWaveErrorCodes.Controller_CommandError,
-		);
-	}
-
 	/** Prepares the controller for restoring network data. */
 	public async networkRestorePrepare(): Promise<void> {
-		await this.sendNetworkRestoreCommand(
+		await this.driver.sendMessage(
 			new NetworkRestorePrepareRequest(),
 		);
 	}
@@ -8355,7 +8190,7 @@ export class ZWaveController
 	public async networkRestoreSetController(
 		options: NetworkRestoreHomeIDRequestOptions,
 	): Promise<void> {
-		await this.sendNetworkRestoreCommand(
+		await this.driver.sendMessage(
 			new NetworkRestoreHomeIDRequest(options),
 		);
 	}
@@ -8364,7 +8199,7 @@ export class ZWaveController
 	public async networkRestoreNode(
 		options: NetworkRestoreDeviceRequestOptions,
 	): Promise<void> {
-		await this.sendNetworkRestoreCommand(
+		await this.driver.sendMessage(
 			new NetworkRestoreDeviceRequest(options),
 		);
 	}
@@ -8373,7 +8208,7 @@ export class ZWaveController
 	public async networkRestoreNeighbors(
 		options: NetworkRestoreNeighborsRequestOptions,
 	): Promise<void> {
-		await this.sendNetworkRestoreCommand(
+		await this.driver.sendMessage(
 			new NetworkRestoreNeighborsRequest(options),
 		);
 	}
@@ -8382,14 +8217,14 @@ export class ZWaveController
 	public async networkRestoreRoutes(
 		options: NetworkRestoreRoutesRequestOptions,
 	): Promise<void> {
-		await this.sendNetworkRestoreCommand(
+		await this.driver.sendMessage(
 			new NetworkRestoreRoutesRequest(options),
 		);
 	}
 
 	/** Finalizes the network data restore. */
 	public async networkRestoreFinalize(): Promise<void> {
-		await this.sendNetworkRestoreCommand(
+		await this.driver.sendMessage(
 			new NetworkRestoreFinalizeRequest(),
 		);
 	}
@@ -8408,8 +8243,8 @@ export class ZWaveController
 			setImmediate(() => restoreProgress(completed, plan.totalCommands));
 		};
 
+		// Set Default must clear existing device data before Network Restore
 		await this.hardResetInternal(false);
-		reportProgress();
 
 		await this.networkRestorePrepare();
 		reportProgress();
@@ -8446,9 +8281,9 @@ export class ZWaveController
 		}
 
 		await this.driver.restartAfterControllerReboot(async () => {
-			await this.sendNetworkRestoreCommand(
+			await this.driver.sendMessage(
 				new NetworkRestoreFinalizeRequest(),
-				true,
+				{ pauseSendThread: true },
 			);
 			reportProgress();
 			onFinalized();
@@ -9105,7 +8940,7 @@ export class ZWaveController
 	 * @param restoreProgress Can be used to monitor the progress of the restore operation. The operation may take several seconds to a few minutes. Network Restore reports command counts. Raw restore reports byte counts.
 	 * @param migrateOptions Influence which data should be preserved during a migration
 	 *
-	 * Network Restore cannot transfer application data or SUC update entries.
+	 * Network Restore cannot transfer application data or SUC update entries. Raw NVM migration is used when either must be preserved.
 	 */
 	public restoreNVM(
 		nvmData: BytesView,
@@ -9163,8 +8998,16 @@ export class ZWaveController
 						);
 					}
 
-					if (normalizedNVM) {
+					if (
+						normalizedNVM
+						&& canUseNetworkRestore(
+							normalizedNVM,
+							migrateOptions,
+							self.supportsLongRange,
+						)
+					) {
 						try {
+							// The entire plan must be validated before Set Default clears the target NVM
 							networkRestorePlan = createNetworkRestorePlan(
 								normalizedNVM,
 								migrateOptions,

--- a/packages/zwave-js/src/lib/controller/NetworkRestore.ts
+++ b/packages/zwave-js/src/lib/controller/NetworkRestore.ts
@@ -1,0 +1,181 @@
+import {
+	type NodeProtocolInfo,
+	RouteProtocolDataRate,
+	ZWaveDataRate,
+	ZWaveError,
+	ZWaveErrorCodes,
+	encodeNodeBitMask,
+	encodeNodeProtocolInfo,
+} from "@zwave-js/core";
+import type {
+	MigrateNVMOptions,
+	NVMJSON,
+	NVMJSONNodeWithInfo,
+} from "@zwave-js/nvmedit";
+import {
+	type NetworkRestoreRoute,
+	NetworkRestoreRouteType,
+} from "@zwave-js/serial/serialapi";
+import { Bytes } from "@zwave-js/shared";
+
+type NVMRoute = NonNullable<NVMJSONNodeWithInfo["lwr"]>;
+type NetworkRestoreProtocolNode =
+	& Omit<NodeProtocolInfo, "hasSpecificDeviceClass">
+	& {
+		genericDeviceClass: number;
+		specificDeviceClass?: number | null;
+	};
+
+interface NetworkRestoreClassicNodePlan {
+	nodeId: number;
+	protocolData: Bytes;
+	neighbors?: Bytes;
+	routes?: NetworkRestoreRoute[];
+}
+
+interface NetworkRestoreNodePlan {
+	nodeId: number;
+	protocolData: Bytes;
+}
+
+export interface NetworkRestorePlan {
+	homeId: number;
+	controllerNodeId: number;
+	classicNodes: NetworkRestoreClassicNodePlan[];
+	longRangeNodes: NetworkRestoreNodePlan[];
+	totalCommands: number;
+}
+
+function encodeNetworkRestoreProtocolData(
+	node: NetworkRestoreProtocolNode,
+	isLongRange: boolean,
+): Bytes {
+	const hasSpecificDeviceClass = node.specificDeviceClass != null;
+	return Bytes.concat([
+		encodeNodeProtocolInfo(
+			{
+				...node,
+				hasSpecificDeviceClass,
+			},
+			isLongRange,
+		),
+		[node.genericDeviceClass, node.specificDeviceClass ?? 0],
+	]);
+}
+
+function mapNetworkRestoreRouteSpeed(
+	protocolRate: RouteProtocolDataRate,
+): ZWaveDataRate {
+	switch (protocolRate) {
+		case RouteProtocolDataRate.Unspecified:
+		case RouteProtocolDataRate.ZWave_9k6:
+			return ZWaveDataRate["9k6"];
+		case RouteProtocolDataRate.ZWave_40k:
+			return ZWaveDataRate["40k"];
+		case RouteProtocolDataRate.ZWave_100k:
+			return ZWaveDataRate["100k"];
+		default:
+			throw new ZWaveError(
+				`Cannot restore a Classic route with protocol data rate ${protocolRate}`,
+				ZWaveErrorCodes.NVM_NotSupported,
+			);
+	}
+}
+
+function nvmRouteToNetworkRestoreRoute(
+	route: NVMRoute,
+	type: NetworkRestoreRouteType,
+): NetworkRestoreRoute {
+	return {
+		type,
+		beam: route.beaming,
+		speed: mapNetworkRestoreRouteSpeed(route.protocolRate),
+		hops: route.repeaterNodeIDs ?? [],
+	};
+}
+
+export function canUseNetworkRestore(
+	nvm: NVMJSON,
+	options: MigrateNVMOptions | undefined,
+	targetSupportsLongRange: boolean | undefined,
+): boolean {
+	if (
+		(options?.preserveApplicationData ?? true)
+		&& nvm.controller.applicationData
+	) {
+		return false;
+	}
+	if (
+		(options?.preserveSUCUpdateEntries ?? true)
+		&& nvm.controller.sucUpdateEntries.length > 0
+	) {
+		return false;
+	}
+	if (
+		Object.keys(nvm.lrNodes ?? {}).length > 0
+		&& targetSupportsLongRange === false
+	) {
+		return false;
+	}
+	return true;
+}
+
+export function createNetworkRestorePlan(
+	nvm: NVMJSON,
+	options: MigrateNVMOptions = {},
+): NetworkRestorePlan {
+	const preserveNeighbors = options.preserveNeighbors ?? true;
+	const preserveRoutes = options.preserveRoutes ?? true;
+
+	const classicNodes: NetworkRestoreClassicNodePlan[] = [];
+	for (const [nodeIdString, node] of Object.entries(nvm.nodes)) {
+		if (!("isListening" in node)) continue;
+
+		const routes: NetworkRestoreRoute[] = [];
+		if (preserveRoutes && node.lwr) {
+			routes.push(nvmRouteToNetworkRestoreRoute(
+				node.lwr,
+				node.appRouteLock
+					? NetworkRestoreRouteType.APR
+					: NetworkRestoreRouteType.LWR,
+			));
+		}
+		if (preserveRoutes && node.nlwr) {
+			routes.push(nvmRouteToNetworkRestoreRoute(
+				node.nlwr,
+				NetworkRestoreRouteType.NLWR,
+			));
+		}
+
+		classicNodes.push({
+			nodeId: Number(nodeIdString),
+			protocolData: encodeNetworkRestoreProtocolData(node, false),
+			neighbors: preserveNeighbors
+				? encodeNodeBitMask(node.neighbors)
+				: undefined,
+			routes: routes.length > 0 ? routes : undefined,
+		});
+	}
+	classicNodes.sort((a, b) => a.nodeId - b.nodeId);
+
+	const longRangeNodes: NetworkRestoreNodePlan[] = [];
+	for (const [nodeIdString, node] of Object.entries(nvm.lrNodes ?? {})) {
+		longRangeNodes.push({
+			nodeId: Number(nodeIdString),
+			protocolData: encodeNetworkRestoreProtocolData(node, true),
+		});
+	}
+	longRangeNodes.sort((a, b) => a.nodeId - b.nodeId);
+
+	return {
+		homeId: Number.parseInt(nvm.controller.homeId, 16),
+		controllerNodeId: nvm.controller.nodeId,
+		classicNodes,
+		longRangeNodes,
+		totalCommands: 3
+			+ classicNodes.length
+			+ longRangeNodes.length
+			+ classicNodes.filter((node) => node.neighbors).length
+			+ classicNodes.filter((node) => node.routes).length,
+	};
+}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3618,6 +3618,45 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 		void this.initializeControllerAndNodes();
 	}
 
+	/** @internal */
+	public async restartAfterControllerReboot(
+		triggerRestart: () => Promise<void>,
+	): Promise<void> {
+		const abortController = new AbortController();
+		const serialAPIStarted = this.waitForMessage<SerialAPIStartedRequest>(
+			(msg) => msg.functionType === FunctionType.SerialAPIStarted,
+			undefined,
+			undefined,
+			abortController.signal,
+		);
+
+		this.isSoftResetting = true;
+		try {
+			await triggerRestart();
+			const waitResult = await Promise.race([
+				serialAPIStarted,
+				wait(1500).then(() => false as const),
+			]);
+			if (!waitResult) abortController.abort();
+
+			if (
+				!(await this.ensureSerialAPI(Promise.resolve(waitResult)))
+			) {
+				await this.destroyWithMessage(
+					"The Serial API did not respond after controller restart",
+				);
+			}
+		} catch (e) {
+			abortController.abort();
+			throw e;
+		} finally {
+			this.isSoftResetting = false;
+		}
+
+		await this.destroyController();
+		void this.initializeControllerAndNodes();
+	}
+
 	/**
 	 * Checks whether recovering an unresponsive controller is enabled
 	 * and whether the driver is in a state where it makes sense.
@@ -3630,15 +3669,20 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 		return this._controllerInterviewed;
 	}
 
-	private async ensureSerialAPI(): Promise<boolean> {
+	private async ensureSerialAPI(
+		serialAPIStarted?: Promise<SerialAPIStartedRequest | false>,
+	): Promise<boolean> {
 		// Wait 1.5 seconds after reset to ensure that the module is ready for communication again
 		// Z-Wave 700 sticks are relatively fast, so we also wait for the Serial API started command
 		// to bail early
 		this.controllerLog.print("Waiting for the controller to reconnect...");
-		let waitResult = await this.waitForMessage<SerialAPIStartedRequest>(
-			(msg) => msg.functionType === FunctionType.SerialAPIStarted,
-			1500,
-		).catch(() => false as const);
+		let waitResult = await (
+			serialAPIStarted
+				?? this.waitForMessage<SerialAPIStartedRequest>(
+					(msg) => msg.functionType === FunctionType.SerialAPIStarted,
+					1500,
+				).catch(() => false as const)
+		);
 
 		if (waitResult) {
 			// Serial API did start

--- a/packages/zwave-js/zwave-js.api.md
+++ b/packages/zwave-js/zwave-js.api.md
@@ -2552,7 +2552,7 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    restoreNVM(nvmData: BytesView, convertProgress?: (bytesRead: number, total: number) => void, restoreProgress?: (bytesWritten: number, total: number) => void, migrateOptions?: MigrateNVMOptions): Promise<void>;
+    restoreNVM(nvmData: BytesView, convertProgress?: (bytesRead: number, total: number) => void, restoreProgress?: (commandsCompleted: number, totalCommands: number) => void, migrateOptions?: MigrateNVMOptions): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "restoreNVM"


### PR DESCRIPTION
Part 3 of 3 of the Network Restore stack.

Depends on #9123, which depends on #9122.

Fixes #9121

## Summary

- Normalize supported 500-series and 700-series backups into the common NVM JSON shape before touching the target
- Use Network Restore when the target advertises it, with raw NVM migration preserved as the pre-destructive fallback
- Restore controller identity, Classic and LR protocol data, optional Classic neighbors, and APR/LWR/NLWR routes in spec order
- Count completed Network Restore commands in `restoreProgress` and handle the Finalize reboot without a second reset
- Keep application data and SUC update entries on the raw migration path because Network Restore cannot transfer them

## Validation

- `yarn vitest run packages/nvmedit/src/convert.test.ts --reporter=dot`
- `yarn build @zwave-js/nvmedit`
- `yarn build zwave-js`
- `yarn build`