### PR TITLE
Extend notification value metadata for V3+ devices on demand

### DIFF
--- a/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
@@ -631,25 +631,22 @@ function clearNotificationIdleReset(
 	}
 }
 
-// Fallback for V2 notifications that don't allow us to predefine the metadata during the interview.
-// Instead of defining useless values for each possible notification event, we build the metadata on demand
+// Extend notification value metadata when the received event isn't already
+// in the states map. V2 devices never get interview-set metadata, and V3+
+// devices may report events they didn't declare during interview.
 function extendNotificationValueMetadata(
-	ctx: GetSupportedCCVersion,
+	_ctx: GetSupportedCCVersion,
 	node: NodeId & NodeValues,
 	valueId: ValueID,
 	notification: Notification,
 	valueConfig: NotificationState,
 ) {
-	const ccVersion = ctx.getSupportedCCVersion(
-		CommandClasses.Notification,
-		node.id,
-		node.index,
-	);
-	if (ccVersion === 2 || !node.valueDB.hasMetadata(valueId)) {
+	const existing = node.valueDB.getMetadata(valueId) as
+		| ValueMetadataNumeric
+		| undefined;
+	if (!existing || !(valueConfig.value in (existing.states ?? {}))) {
 		const metadata = getNotificationValueMetadata(
-			node.valueDB.getMetadata(valueId) as
-				| ValueMetadataNumeric
-				| undefined,
+			existing,
 			notification,
 			valueConfig,
 		);


### PR DESCRIPTION
## Problem

V3+ devices can report notification events they didn't declare as supported during interview. The interview sends `NotificationCCEventSupportedGet` and builds `metadata.states` from the device's response, so only declared events get labels. When the device later sends an undeclared event, the value has no entry in `metadata.states`. Downstream consumers like Home Assistant treat this as an enum sensor with a value outside its options list and crash with a `ValueError`.

Affected devices include:
- Yale Assure 2 lock (Access Control door state 22, "Window/door is open", not declared during interview)
- Honeywell T6 Pro thermostat (mains_status value 3)
- Hoppe ConnectSense window handles (door handle state)

Related: #5027 (fixed metadata overwrite during interview for variables with multiple states in PR #5037). This addresses the remaining case where the event was never declared during interview at all.

Downstream HA core issues: [home-assistant/core#94841](https://github.com/home-assistant/core/issues/94841), [home-assistant/core#108178](https://github.com/home-assistant/core/issues/108178), [home-assistant/core#174972](https://github.com/home-assistant/core/issues/174972).

## Fix

`extendNotificationValueMetadata` already builds metadata on demand for V2 devices (which can't be interviewed for supported events). The condition `ccVersion === 2 || !node.valueDB.hasMetadata(valueId)` blocked this for V3+ devices that already had interview-set metadata.

This replaces the version-based check with a check for whether the specific event value is already in the existing `states` map. If the value is missing, `getNotificationValueMetadata` extends the metadata with the label from `Notifications.ts`. The function is already idempotent, and V2 behavior is unchanged (metadata is always missing or incomplete on first arrival).

1 file changed, 9 insertions, 12 deletions.