### PR TITLE
fix(cc): ignore (un)lock notifications superseded by a newer Door Lock report

### DIFF
--- a/packages/cc/src/cc/DoorLockCC.ts
+++ b/packages/cc/src/cc/DoorLockCC.ts
@@ -81,6 +81,12 @@ export const DoorLockCCValues = V.defineCCValues(CommandClasses["Door Lock"], {
 			states: enumValuesToMetadataStates(DoorLockMode),
 		},
 	),
+	// Some locks repeat their Notification CC reports several seconds after the
+	// original. Remembering when the device last reported its mode through Door Lock CC
+	// lets us discard a repeated notification that has since been superseded.
+	...V.staticProperty("currentModeReportedAt", undefined, {
+		internal: true,
+	}),
 	...V.staticProperty(
 		"duration",
 		{
@@ -1150,6 +1156,12 @@ export class DoorLockCCOperationReport extends DoorLockCC {
 
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;
+
+		this.setValue(
+			ctx,
+			DoorLockCCValues.currentModeReportedAt,
+			Date.now(),
+		);
 
 		// Only store the door/bolt/latch status if the lock supports it
 		const supportsDoorStatus = !!this.getValue(

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -2128,6 +2128,33 @@ export const DoorLockCCValues = Object.freeze({
 			autoCreate: true,
 		} as const satisfies CCValueOptions,
 	},
+	currentModeReportedAt: {
+		id: {
+			commandClass: CommandClasses["Door Lock"],
+			property: "currentModeReportedAt",
+		} as const,
+		endpoint: (endpoint: number = 0) => ({
+			commandClass: CommandClasses["Door Lock"],
+			endpoint,
+			property: "currentModeReportedAt",
+		} as const),
+		is: (valueId: ValueID): boolean => {
+			return valueId.commandClass === CommandClasses["Door Lock"]
+				&& valueId.property === "currentModeReportedAt"
+				&& valueId.propertyKey == undefined;
+		},
+		get meta() {
+			return ValueMetadata.Any;
+		},
+		options: {
+			internal: true,
+			minVersion: 1,
+			secret: false,
+			stateful: true,
+			supportsEndpoints: true,
+			autoCreate: true,
+		} as const satisfies CCValueOptions,
+	},
 	duration: {
 		id: {
 			commandClass: CommandClasses["Door Lock"],

--- a/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
@@ -467,7 +467,7 @@ function isOutdatedLockOperation(
 }
 
 function handleKnownNotification(
-	ctx: GetValueDB,
+	ctx: GetValueDB & LogNode,
 	node: ZWaveNode,
 	command: NotificationCCReport,
 ): void {
@@ -504,6 +504,13 @@ function handleKnownNotification(
 		// a duplicate of an operation that has already been superseded. Applying it
 		// would leave the lock in the wrong state until something polls it again.
 		if (isOutdatedLockOperation(node, command.endpointIndex, isLocked)) {
+			ctx.logNode(node.id, {
+				message: `Ignoring ${
+					isLocked ? "lock" : "unlock"
+				} notification because Door Lock CC reported a different mode more recently`,
+				direction: "inbound",
+				level: "verbose",
+			});
 			return;
 		}
 

--- a/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
@@ -429,6 +429,43 @@ export function handleNotificationReport(
 	}
 }
 
+/**
+ * How long a Door Lock CC report shadows contradicting (un)lock notifications.
+ * Chosen to cover the observed retransmission interval of locks that repeat their
+ * notifications, while staying within the time a device is expected to answer at all.
+ */
+const OUTDATED_LOCK_NOTIFICATION_TIMEOUT = 10000;
+
+/**
+ * Determines whether an (un)lock notification is contradicted by a more recent
+ * Door Lock CC report, which means the notification refers to an operation that
+ * is no longer current.
+ */
+function isOutdatedLockOperation(
+	node: ZWaveNode,
+	endpointIndex: number,
+	isLocked: boolean,
+): boolean {
+	const reportedAt = node.valueDB.getValue<number>(
+		DoorLockCCValues.currentModeReportedAt.endpoint(endpointIndex),
+	);
+	// Devices that never report through Door Lock CC are unaffected by this
+	if (reportedAt == undefined) return false;
+	if (Date.now() - reportedAt > OUTDATED_LOCK_NOTIFICATION_TIMEOUT) {
+		return false;
+	}
+
+	const currentMode = node.valueDB.getValue<DoorLockMode>(
+		DoorLockCCValues.currentMode.endpoint(endpointIndex),
+	);
+	if (currentMode == undefined) return false;
+
+	// Door Lock CC can distinguish more modes than a notification can express, so a
+	// mismatch also means the device knows more about its state than we would write
+	return currentMode
+		!== (isLocked ? DoorLockMode.Secured : DoorLockMode.Unsecured);
+}
+
 function handleKnownNotification(
 	ctx: GetValueDB,
 	node: ZWaveNode,
@@ -460,6 +497,15 @@ function handleKnownNotification(
 		const isLocked = lockEvents.has(
 			command.notificationEvent as number,
 		);
+
+		// Some locks repeat their notifications several seconds after the original.
+		// If the device has reported a contradicting mode through Door Lock CC in the
+		// meantime, that report is the more recent information and the notification is
+		// a duplicate of an operation that has already been superseded. Applying it
+		// would leave the lock in the wrong state until something polls it again.
+		if (isOutdatedLockOperation(node, command.endpointIndex, isLocked)) {
+			return;
+		}
 
 		// Update the current lock status
 		if (node.supportsCC(CommandClasses["Door Lock"])) {

--- a/packages/zwave-js/src/lib/test/cc-specific/mapNotificationDoorLockOutdated.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/mapNotificationDoorLockOutdated.test.ts
@@ -1,0 +1,70 @@
+import { DoorLockMode } from "@zwave-js/cc";
+import {
+	DoorLockCCOperationReport,
+	DoorLockCCValues,
+} from "@zwave-js/cc/DoorLockCC";
+import { NotificationCCReport } from "@zwave-js/cc/NotificationCC";
+import { createMockZWaveRequestFrame } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"A repeated (un)lock notification must not override a newer Door Lock CC report",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/notificationAndDoorLockCC",
+		),
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const valueId = DoorLockCCValues.currentMode.id;
+
+			const unlockNotification = () =>
+				new NotificationCCReport({
+					nodeId: mockController.ownNodeId,
+					notificationType: 0x06, // Access Control
+					notificationEvent: 0x06, // Keypad Unlock Operation
+				});
+
+			// The door is unlocked, and the lock reports it
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(unlockNotification(), {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+			t.expect(node.getValue(valueId)).toBe(DoorLockMode.Unsecured);
+
+			// It is locked again, which the lock reports through Door Lock CC
+			const operationReport = new DoorLockCCOperationReport({
+				nodeId: mockController.ownNodeId,
+				currentMode: DoorLockMode.Secured,
+				outsideHandlesCanOpenDoor: [false, false, false, false],
+				insideHandlesCanOpenDoor: [false, false, false, false],
+				doorStatus: "open",
+				boltStatus: "locked",
+				latchStatus: "open",
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(operationReport, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+			t.expect(node.getValue(valueId)).toBe(DoorLockMode.Secured);
+
+			// Some locks repeat their notifications several seconds later. The repeated
+			// notification refers to an operation that has already been superseded, so
+			// applying it would leave the lock in the wrong state.
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(unlockNotification(), {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+			t.expect(node.getValue(valueId)).toBe(DoorLockMode.Secured);
+		},
+	},
+);


### PR DESCRIPTION
Fixes #9134.

### The problem

Some locks repeat their Notification CC reports several seconds after the original. If a real state change happens inside that window, the repeat arrives *after* the device has already reported the newer state through Door Lock CC — and `handleKnownNotification` applies it unconditionally, so the stale operation wins. The lock entity then shows the opposite of physical state until something polls it again.

From the reporting device (Schlage BE469ZP), sequence numbers are the S2 sequence numbers, so nothing is delivered out of order — only the content is stale:

```
16:12:55.540  #174  NotificationCCReport       Manual unlock operation
16:13:00.047  #176  DoorLockCCOperationReport  current mode: Secured   <- real re-lock
16:13:00.495  #178  NotificationCCReport       Manual unlock operation <- repeat of #174
                                               -> currentMode 255 => 0
```

`currentMode` stayed `Unsecured` for 35 minutes with the deadbolt thrown. Measured over 7 days on this device: ~21% of unsolicited reports are repeated, clustered tightly at 4.2–4.5 s.

### The change

Record when the device last reported its mode through Door Lock CC, and skip an (un)lock notification that contradicts a recent report.

The mapping from #1641 exists for locks that report manual/keypad operations *only* through Notification CC. Those devices never emit a `DoorLockCCOperationReport`, so the new timestamp is never set and the guard never engages — their behaviour is unchanged. It only takes effect on devices that report both ways, which is exactly where the mapping can do harm.

### Trade-off worth reviewing

`OUTDATED_LOCK_NOTIFICATION_TIMEOUT` is 10 s. Too short and repeats still get through; too long and a device that reports *some* transitions only via Notification CC could have a legitimate change suppressed. I picked 10 s to cover the observed retransmission interval with margin, but you know the device landscape far better than I do — happy to change it, or to switch to suppressing exact duplicates instead (same event, alarm level and user slot within a few seconds), which was the other option in the issue.

### Testing

- New integration test `mapNotificationDoorLockOutdated.test.ts`, following the existing `mapNotificationDoorLock.test.ts`. Verified it **fails without the source change and passes with it**.
- The existing `mapNotificationDoorLock.test.ts` still passes.
- `packages/zwave-js/src/lib/test/cc-specific` — 23 files / 46 tests pass.
- `yarn build`, `yarn fmt` and `eslint` clean.
- One unrelated flake in `driver/partialCCSessions.test.ts` under full parallel load; it passes in isolation both with and without this change.

I also have the affected hardware, so I can test a candidate build against the real lock if that would help.
