### PR TITLE
feat: implement command relations for several CCs

### DIFF
--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -39,6 +39,7 @@ import {
 import {
 	type CCRaw,
 	CommandClass,
+	CommandRelation,
 	type InterviewContext,
 	type PersistValuesContext,
 	type RefreshValuesContext,
@@ -55,6 +56,7 @@ import {
 	implementedVersion,
 	useSupervision,
 } from "../lib/CommandClassDecorators.js";
+import { areDurationsEqual } from "../lib/CommandRelationUtils.js";
 import { V } from "../lib/Values.js";
 import { BasicCommand } from "../lib/_Types.js";
 import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
@@ -396,6 +398,15 @@ export class BasicCCSet extends BasicCC {
 
 	public targetValue: number;
 
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (!(other instanceof BasicCCSet)) {
+			return CommandRelation.Unrelated;
+		}
+		return this.targetValue === other.targetValue
+			? CommandRelation.Redundant
+			: CommandRelation.Supersedes;
+	}
+
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		this.payload = Bytes.from([this.targetValue]);
 		return super.serialize(ctx);
@@ -462,6 +473,17 @@ export class BasicCCReport extends BasicCC {
 	public readonly targetValue: MaybeUnknown<number> | undefined;
 
 	public readonly duration: Duration | undefined;
+
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (!(other instanceof BasicCCReport)) {
+			return CommandRelation.Unrelated;
+		}
+		return this.currentValue === other.currentValue
+				&& this.targetValue === other.targetValue
+				&& areDurationsEqual(this.duration, other.duration)
+			? CommandRelation.Redundant
+			: CommandRelation.Supersedes;
+	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
 		// Basic CC Report persists its values itself, since there are some
@@ -545,4 +567,10 @@ export class BasicCCReport extends BasicCC {
 
 @CCCommand(BasicCommand.Get)
 @expectedCCResponse(BasicCCReport)
-export class BasicCCGet extends BasicCC {}
+export class BasicCCGet extends BasicCC {
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		return other instanceof BasicCCGet
+			? CommandRelation.Redundant
+			: CommandRelation.Unrelated;
+	}
+}

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -56,7 +56,6 @@ import {
 	implementedVersion,
 	useSupervision,
 } from "../lib/CommandClassDecorators.js";
-import { areDurationsEqual } from "../lib/CommandRelationUtils.js";
 import { V } from "../lib/Values.js";
 import { BasicCommand } from "../lib/_Types.js";
 import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
@@ -478,7 +477,8 @@ export class BasicCCReport extends BasicCC {
 		if (other instanceof BasicCCReport) {
 			return this.currentValue === other.currentValue
 					&& this.targetValue === other.targetValue
-					&& areDurationsEqual(this.duration, other.duration)
+					&& (this.duration ?? Duration.default())
+						.equals(other.duration ?? Duration.default())
 				? CommandRelation.Redundant
 				: CommandRelation.Supersedes;
 		}

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -398,7 +398,7 @@ export class BasicCCSet extends BasicCC {
 
 	public targetValue: number;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (!(other instanceof BasicCCSet)) {
 			return CommandRelation.Unrelated;
 		}
@@ -474,7 +474,7 @@ export class BasicCCReport extends BasicCC {
 
 	public readonly duration: Duration | undefined;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (!(other instanceof BasicCCReport)) {
 			return CommandRelation.Unrelated;
 		}
@@ -568,7 +568,7 @@ export class BasicCCReport extends BasicCC {
 @CCCommand(BasicCommand.Get)
 @expectedCCResponse(BasicCCReport)
 export class BasicCCGet extends BasicCC {
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		return other instanceof BasicCCGet
 			? CommandRelation.Redundant
 			: CommandRelation.Unrelated;

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -399,12 +399,12 @@ export class BasicCCSet extends BasicCC {
 	public targetValue: number;
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		if (!(other instanceof BasicCCSet)) {
-			return CommandRelation.Unrelated;
+		if (other instanceof BasicCCSet) {
+			return this.targetValue === other.targetValue
+				? CommandRelation.Redundant
+				: CommandRelation.Supersedes;
 		}
-		return this.targetValue === other.targetValue
-			? CommandRelation.Redundant
-			: CommandRelation.Supersedes;
+		return CommandRelation.Unrelated;
 	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
@@ -475,14 +475,14 @@ export class BasicCCReport extends BasicCC {
 	public readonly duration: Duration | undefined;
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		if (!(other instanceof BasicCCReport)) {
-			return CommandRelation.Unrelated;
+		if (other instanceof BasicCCReport) {
+			return this.currentValue === other.currentValue
+					&& this.targetValue === other.targetValue
+					&& areDurationsEqual(this.duration, other.duration)
+				? CommandRelation.Redundant
+				: CommandRelation.Supersedes;
 		}
-		return this.currentValue === other.currentValue
-				&& this.targetValue === other.targetValue
-				&& areDurationsEqual(this.duration, other.duration)
-			? CommandRelation.Redundant
-			: CommandRelation.Supersedes;
+		return CommandRelation.Unrelated;
 	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
@@ -569,8 +569,9 @@ export class BasicCCReport extends BasicCC {
 @expectedCCResponse(BasicCCReport)
 export class BasicCCGet extends BasicCC {
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		return other instanceof BasicCCGet
-			? CommandRelation.Redundant
-			: CommandRelation.Unrelated;
+		if (other instanceof BasicCCGet) {
+			return CommandRelation.Redundant;
+		}
+		return CommandRelation.Unrelated;
 	}
 }

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -48,7 +48,6 @@ import {
 	implementedVersion,
 	useSupervision,
 } from "../lib/CommandClassDecorators.js";
-import { areDurationsEqual } from "../lib/CommandRelationUtils.js";
 import { V } from "../lib/Values.js";
 import { BinarySwitchCommand } from "../lib/_Types.js";
 import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
@@ -346,10 +345,8 @@ export class BinarySwitchCCSet extends BinarySwitchCC {
 	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (other instanceof BinarySwitchCCSet) {
 			return this.targetValue === other.targetValue
-					&& areDurationsEqual(
-						this.duration ?? Duration.default(),
-						other.duration ?? Duration.default(),
-					)
+					&& (this.duration ?? Duration.default())
+						.equals(other.duration ?? Duration.default())
 				? CommandRelation.Redundant
 				: CommandRelation.Supersedes;
 		}
@@ -446,7 +443,8 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 		if (other instanceof BinarySwitchCCReport) {
 			return this.currentValue === other.currentValue
 					&& this.targetValue === other.targetValue
-					&& areDurationsEqual(this.duration, other.duration)
+					&& (this.duration ?? Duration.default())
+						.equals(other.duration ?? Duration.default())
 				? CommandRelation.Redundant
 				: CommandRelation.Supersedes;
 		}

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -32,6 +32,7 @@ import {
 import {
 	type CCRaw,
 	CommandClass,
+	CommandRelation,
 	type InterviewContext,
 	type RefreshValuesContext,
 	type RefreshValuesOptions,
@@ -47,6 +48,7 @@ import {
 	implementedVersion,
 	useSupervision,
 } from "../lib/CommandClassDecorators.js";
+import { areDurationsEqual } from "../lib/CommandRelationUtils.js";
 import { V } from "../lib/Values.js";
 import { BinarySwitchCommand } from "../lib/_Types.js";
 import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
@@ -341,6 +343,19 @@ export class BinarySwitchCCSet extends BinarySwitchCC {
 	public targetValue: boolean;
 	public duration: Duration | undefined;
 
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (!(other instanceof BinarySwitchCCSet)) {
+			return CommandRelation.Unrelated;
+		}
+		return this.targetValue === other.targetValue
+				&& areDurationsEqual(
+					this.duration ?? Duration.default(),
+					other.duration ?? Duration.default(),
+				)
+			? CommandRelation.Redundant
+			: CommandRelation.Supersedes;
+	}
+
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		this.payload = Bytes.from([
 			this.targetValue ? 0xff : 0x00,
@@ -427,6 +442,17 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 
 	public readonly duration: Duration | undefined;
 
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (!(other instanceof BinarySwitchCCReport)) {
+			return CommandRelation.Unrelated;
+		}
+		return this.currentValue === other.currentValue
+				&& this.targetValue === other.targetValue
+				&& areDurationsEqual(this.duration, other.duration)
+			? CommandRelation.Redundant
+			: CommandRelation.Supersedes;
+	}
+
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		this.payload = Bytes.from([
 			encodeMaybeBoolean(this.currentValue ?? UNKNOWN_STATE),
@@ -462,4 +488,10 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 
 @CCCommand(BinarySwitchCommand.Get)
 @expectedCCResponse(BinarySwitchCCReport)
-export class BinarySwitchCCGet extends BinarySwitchCC {}
+export class BinarySwitchCCGet extends BinarySwitchCC {
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		return other instanceof BinarySwitchCCGet
+			? CommandRelation.Redundant
+			: CommandRelation.Unrelated;
+	}
+}

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -343,7 +343,7 @@ export class BinarySwitchCCSet extends BinarySwitchCC {
 	public targetValue: boolean;
 	public duration: Duration | undefined;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (!(other instanceof BinarySwitchCCSet)) {
 			return CommandRelation.Unrelated;
 		}
@@ -442,7 +442,7 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 
 	public readonly duration: Duration | undefined;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (!(other instanceof BinarySwitchCCReport)) {
 			return CommandRelation.Unrelated;
 		}
@@ -489,7 +489,7 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 @CCCommand(BinarySwitchCommand.Get)
 @expectedCCResponse(BinarySwitchCCReport)
 export class BinarySwitchCCGet extends BinarySwitchCC {
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		return other instanceof BinarySwitchCCGet
 			? CommandRelation.Redundant
 			: CommandRelation.Unrelated;

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -344,16 +344,16 @@ export class BinarySwitchCCSet extends BinarySwitchCC {
 	public duration: Duration | undefined;
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		if (!(other instanceof BinarySwitchCCSet)) {
-			return CommandRelation.Unrelated;
+		if (other instanceof BinarySwitchCCSet) {
+			return this.targetValue === other.targetValue
+					&& areDurationsEqual(
+						this.duration ?? Duration.default(),
+						other.duration ?? Duration.default(),
+					)
+				? CommandRelation.Redundant
+				: CommandRelation.Supersedes;
 		}
-		return this.targetValue === other.targetValue
-				&& areDurationsEqual(
-					this.duration ?? Duration.default(),
-					other.duration ?? Duration.default(),
-				)
-			? CommandRelation.Redundant
-			: CommandRelation.Supersedes;
+		return CommandRelation.Unrelated;
 	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
@@ -443,14 +443,14 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 	public readonly duration: Duration | undefined;
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		if (!(other instanceof BinarySwitchCCReport)) {
-			return CommandRelation.Unrelated;
+		if (other instanceof BinarySwitchCCReport) {
+			return this.currentValue === other.currentValue
+					&& this.targetValue === other.targetValue
+					&& areDurationsEqual(this.duration, other.duration)
+				? CommandRelation.Redundant
+				: CommandRelation.Supersedes;
 		}
-		return this.currentValue === other.currentValue
-				&& this.targetValue === other.targetValue
-				&& areDurationsEqual(this.duration, other.duration)
-			? CommandRelation.Redundant
-			: CommandRelation.Supersedes;
+		return CommandRelation.Unrelated;
 	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
@@ -490,8 +490,9 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 @expectedCCResponse(BinarySwitchCCReport)
 export class BinarySwitchCCGet extends BinarySwitchCC {
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		return other instanceof BinarySwitchCCGet
-			? CommandRelation.Redundant
-			: CommandRelation.Unrelated;
+		if (other instanceof BinarySwitchCCGet) {
+			return CommandRelation.Redundant;
+		}
+		return CommandRelation.Unrelated;
 	}
 }

--- a/packages/cc/src/cc/CRC16CC.ts
+++ b/packages/cc/src/cc/CRC16CC.ts
@@ -12,7 +12,11 @@ import {
 	validatePayload,
 } from "@zwave-js/core";
 import { CCAPI } from "../lib/API.js";
-import { type CCRaw, CommandClass } from "../lib/CommandClass.js";
+import {
+	type CCRaw,
+	CommandClass,
+	CommandRelation,
+} from "../lib/CommandClass.js";
 import {
 	API,
 	CCCommand,
@@ -145,6 +149,15 @@ export class CRC16CCCommandEncapsulation extends CRC16CC {
 	}
 
 	public encapsulated: CommandClass;
+
+	protected override determineRelation(
+		other: CommandClass,
+	): CommandRelation {
+		if (other instanceof CRC16CCCommandEncapsulation) {
+			return this.encapsulated.getRelationTo(other.encapsulated);
+		}
+		return CommandRelation.Unrelated;
+	}
 
 	public async serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		const commandBuffer = await this.encapsulated.serialize(ctx);

--- a/packages/cc/src/cc/CommandRelations.test.ts
+++ b/packages/cc/src/cc/CommandRelations.test.ts
@@ -1,0 +1,598 @@
+import { Duration, UNKNOWN_STATE } from "@zwave-js/core";
+import { describe, expect, test } from "vitest";
+import { CommandRelation, getCommandRelation } from "../lib/CommandClass.js";
+import { ThermostatSetpointType } from "../lib/_Types.js";
+import { BasicCCGet, BasicCCReport, BasicCCSet } from "./BasicCC.js";
+import {
+	BinarySwitchCCGet,
+	BinarySwitchCCReport,
+	BinarySwitchCCSet,
+} from "./BinarySwitchCC.js";
+import {
+	MultilevelSwitchCCGet,
+	MultilevelSwitchCCReport,
+	MultilevelSwitchCCSet,
+	MultilevelSwitchCCStartLevelChange,
+} from "./MultilevelSwitchCC.js";
+import {
+	ThermostatSetpointCCGet,
+	ThermostatSetpointCCReport,
+	ThermostatSetpointCCSet,
+} from "./ThermostatSetpointCC.js";
+
+const nodeId = 2;
+
+describe("Basic CC command relations", () => {
+	test("repeated Gets are redundant", () => {
+		expect(
+			getCommandRelation(
+				new BasicCCGet({ nodeId }),
+				new BasicCCGet({ nodeId }),
+			),
+		).toBe(CommandRelation.Redundant);
+	});
+
+	test("Sets are redundant for the same target and supersede for a different target", () => {
+		expect(
+			getCommandRelation(
+				new BasicCCSet({ nodeId, targetValue: 40 }),
+				new BasicCCSet({ nodeId, targetValue: 40 }),
+			),
+		).toBe(CommandRelation.Redundant);
+		expect(
+			getCommandRelation(
+				new BasicCCSet({ nodeId, targetValue: 99 }),
+				new BasicCCSet({ nodeId, targetValue: 40 }),
+			),
+		).toBe(CommandRelation.Supersedes);
+	});
+
+	test("Reports compare current value, target value, and duration", () => {
+		const older = new BasicCCReport({
+			nodeId,
+			currentValue: 40,
+			targetValue: 99,
+			duration: new Duration(2, "seconds"),
+		});
+		const identical = new BasicCCReport({
+			nodeId,
+			currentValue: 40,
+			targetValue: 99,
+			duration: new Duration(2, "seconds"),
+		});
+		expect(getCommandRelation(identical, older)).toBe(
+			CommandRelation.Redundant,
+		);
+
+		for (
+			const newer of [
+				new BasicCCReport({
+					nodeId,
+					currentValue: 41,
+					targetValue: 99,
+					duration: new Duration(2, "seconds"),
+				}),
+				new BasicCCReport({
+					nodeId,
+					currentValue: 40,
+					targetValue: 98,
+					duration: new Duration(2, "seconds"),
+				}),
+				new BasicCCReport({
+					nodeId,
+					currentValue: 40,
+					targetValue: 99,
+					duration: new Duration(3, "seconds"),
+				}),
+			]
+		) {
+			expect(getCommandRelation(newer, older)).toBe(
+				CommandRelation.Supersedes,
+			);
+		}
+	});
+
+	test("Reports distinguish unknown and omitted values", () => {
+		const unknown = new BasicCCReport({
+			nodeId,
+			currentValue: UNKNOWN_STATE,
+			targetValue: UNKNOWN_STATE,
+			duration: Duration.unknown(),
+		});
+		expect(
+			getCommandRelation(
+				new BasicCCReport({
+					nodeId,
+					currentValue: UNKNOWN_STATE,
+					targetValue: UNKNOWN_STATE,
+					duration: Duration.unknown(),
+				}),
+				unknown,
+			),
+		).toBe(CommandRelation.Redundant);
+		expect(
+			getCommandRelation(
+				new BasicCCReport({ nodeId }),
+				unknown,
+			),
+		).toBe(CommandRelation.Supersedes);
+	});
+});
+
+describe("Binary Switch CC command relations", () => {
+	test("repeated Gets are redundant", () => {
+		expect(
+			getCommandRelation(
+				new BinarySwitchCCGet({ nodeId }),
+				new BinarySwitchCCGet({ nodeId }),
+			),
+		).toBe(CommandRelation.Redundant);
+	});
+
+	test("Sets compare target value and duration", () => {
+		const older = new BinarySwitchCCSet({
+			nodeId,
+			targetValue: false,
+			duration: new Duration(2, "seconds"),
+		});
+		expect(
+			getCommandRelation(
+				new BinarySwitchCCSet({
+					nodeId,
+					targetValue: false,
+					duration: new Duration(2, "seconds"),
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Redundant);
+		expect(
+			getCommandRelation(
+				new BinarySwitchCCSet({
+					nodeId,
+					targetValue: true,
+					duration: new Duration(2, "seconds"),
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Supersedes);
+		expect(
+			getCommandRelation(
+				new BinarySwitchCCSet({
+					nodeId,
+					targetValue: false,
+					duration: new Duration(3, "seconds"),
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Supersedes);
+	});
+
+	test("an omitted Set duration equals the default duration", () => {
+		expect(
+			getCommandRelation(
+				new BinarySwitchCCSet({
+					nodeId,
+					targetValue: true,
+					duration: Duration.default(),
+				}),
+				new BinarySwitchCCSet({
+					nodeId,
+					targetValue: true,
+				}),
+			),
+		).toBe(CommandRelation.Redundant);
+	});
+
+	test("Reports compare current value, target value, and duration", () => {
+		const older = new BinarySwitchCCReport({
+			nodeId,
+			currentValue: false,
+			targetValue: true,
+			duration: new Duration(2, "seconds"),
+		});
+		expect(
+			getCommandRelation(
+				new BinarySwitchCCReport({
+					nodeId,
+					currentValue: false,
+					targetValue: true,
+					duration: new Duration(2, "seconds"),
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Redundant);
+
+		for (
+			const newer of [
+				new BinarySwitchCCReport({
+					nodeId,
+					currentValue: true,
+					targetValue: true,
+					duration: new Duration(2, "seconds"),
+				}),
+				new BinarySwitchCCReport({
+					nodeId,
+					currentValue: false,
+					targetValue: false,
+					duration: new Duration(2, "seconds"),
+				}),
+				new BinarySwitchCCReport({
+					nodeId,
+					currentValue: false,
+					targetValue: true,
+					duration: new Duration(3, "seconds"),
+				}),
+			]
+		) {
+			expect(getCommandRelation(newer, older)).toBe(
+				CommandRelation.Supersedes,
+			);
+		}
+	});
+
+	test("Reports preserve unknown and optional values", () => {
+		const older = new BinarySwitchCCReport({
+			nodeId,
+			currentValue: UNKNOWN_STATE,
+		});
+		expect(
+			getCommandRelation(
+				new BinarySwitchCCReport({
+					nodeId,
+					currentValue: UNKNOWN_STATE,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Redundant);
+		expect(
+			getCommandRelation(
+				new BinarySwitchCCReport({
+					nodeId,
+					currentValue: UNKNOWN_STATE,
+					targetValue: UNKNOWN_STATE,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Supersedes);
+	});
+});
+
+describe("Multilevel Switch CC command relations", () => {
+	test("repeated Gets are redundant", () => {
+		expect(
+			getCommandRelation(
+				new MultilevelSwitchCCGet({ nodeId }),
+				new MultilevelSwitchCCGet({ nodeId }),
+			),
+		).toBe(CommandRelation.Redundant);
+	});
+
+	test("Sets compare target value and duration", () => {
+		const zero = new MultilevelSwitchCCSet({
+			nodeId,
+			targetValue: 0,
+		});
+		const fifty = new MultilevelSwitchCCSet({
+			nodeId,
+			targetValue: 50,
+		});
+		const ninetyNine = new MultilevelSwitchCCSet({
+			nodeId,
+			targetValue: 99,
+		});
+		expect(getCommandRelation(fifty, zero)).toBe(
+			CommandRelation.Supersedes,
+		);
+		expect(getCommandRelation(ninetyNine, fifty)).toBe(
+			CommandRelation.Supersedes,
+		);
+		expect(
+			getCommandRelation(
+				new MultilevelSwitchCCSet({
+					nodeId,
+					targetValue: 40,
+				}),
+				new MultilevelSwitchCCSet({
+					nodeId,
+					targetValue: 40,
+					duration: Duration.default(),
+				}),
+			),
+		).toBe(CommandRelation.Redundant);
+		expect(
+			getCommandRelation(
+				new MultilevelSwitchCCSet({
+					nodeId,
+					targetValue: 40,
+					duration: new Duration(2, "seconds"),
+				}),
+				new MultilevelSwitchCCSet({
+					nodeId,
+					targetValue: 40,
+					duration: new Duration(1, "seconds"),
+				}),
+			),
+		).toBe(CommandRelation.Supersedes);
+	});
+
+	test("Start Level Change commands compare their full payload", () => {
+		const older = new MultilevelSwitchCCStartLevelChange({
+			nodeId,
+			direction: "up",
+			ignoreStartLevel: false,
+			startLevel: 50,
+			duration: new Duration(2, "seconds"),
+		});
+		expect(
+			getCommandRelation(
+				new MultilevelSwitchCCStartLevelChange({
+					nodeId,
+					direction: "up",
+					ignoreStartLevel: false,
+					startLevel: 50,
+					duration: new Duration(2, "seconds"),
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Redundant);
+
+		for (
+			const newer of [
+				new MultilevelSwitchCCStartLevelChange({
+					nodeId,
+					direction: "down",
+					ignoreStartLevel: false,
+					startLevel: 50,
+					duration: new Duration(2, "seconds"),
+				}),
+				new MultilevelSwitchCCStartLevelChange({
+					nodeId,
+					direction: "up",
+					ignoreStartLevel: true,
+					startLevel: 50,
+					duration: new Duration(2, "seconds"),
+				}),
+				new MultilevelSwitchCCStartLevelChange({
+					nodeId,
+					direction: "up",
+					ignoreStartLevel: false,
+					startLevel: 40,
+					duration: new Duration(2, "seconds"),
+				}),
+				new MultilevelSwitchCCStartLevelChange({
+					nodeId,
+					direction: "up",
+					ignoreStartLevel: false,
+					startLevel: 50,
+					duration: new Duration(3, "seconds"),
+				}),
+			]
+		) {
+			expect(getCommandRelation(newer, older)).toBe(
+				CommandRelation.Supersedes,
+			);
+		}
+	});
+
+	test("Set and Start Level Change supersede each other", () => {
+		const set = new MultilevelSwitchCCSet({
+			nodeId,
+			targetValue: 50,
+		});
+		const start = new MultilevelSwitchCCStartLevelChange({
+			nodeId,
+			direction: "up",
+			ignoreStartLevel: true,
+		});
+		expect(getCommandRelation(start, set)).toBe(
+			CommandRelation.Supersedes,
+		);
+		expect(getCommandRelation(set, start)).toBe(
+			CommandRelation.Supersedes,
+		);
+	});
+
+	test("Reports compare current value, target value, and duration", () => {
+		const older = new MultilevelSwitchCCReport({
+			nodeId,
+			currentValue: 40,
+			targetValue: 99,
+			duration: new Duration(2, "minutes"),
+		});
+		expect(
+			getCommandRelation(
+				new MultilevelSwitchCCReport({
+					nodeId,
+					currentValue: 40,
+					targetValue: 99,
+					duration: new Duration(2, "minutes"),
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Redundant);
+
+		for (
+			const newer of [
+				new MultilevelSwitchCCReport({
+					nodeId,
+					currentValue: 41,
+					targetValue: 99,
+					duration: new Duration(2, "minutes"),
+				}),
+				new MultilevelSwitchCCReport({
+					nodeId,
+					currentValue: 40,
+					targetValue: 98,
+					duration: new Duration(2, "minutes"),
+				}),
+				new MultilevelSwitchCCReport({
+					nodeId,
+					currentValue: 40,
+					targetValue: 99,
+					duration: new Duration(2, "seconds"),
+				}),
+			]
+		) {
+			expect(getCommandRelation(newer, older)).toBe(
+				CommandRelation.Supersedes,
+			);
+		}
+	});
+
+	test("Reports preserve unknown and optional values", () => {
+		const older = new MultilevelSwitchCCReport({
+			nodeId,
+			currentValue: UNKNOWN_STATE,
+			targetValue: UNKNOWN_STATE,
+			duration: Duration.unknown(),
+		});
+		expect(
+			getCommandRelation(
+				new MultilevelSwitchCCReport({
+					nodeId,
+					currentValue: UNKNOWN_STATE,
+					targetValue: UNKNOWN_STATE,
+					duration: Duration.unknown(),
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Redundant);
+		expect(
+			getCommandRelation(
+				new MultilevelSwitchCCReport({ nodeId }),
+				older,
+			),
+		).toBe(CommandRelation.Supersedes);
+	});
+});
+
+describe("Thermostat Setpoint CC command relations", () => {
+	test("Gets are related only for the same setpoint type", () => {
+		const heating = new ThermostatSetpointCCGet({
+			nodeId,
+			setpointType: ThermostatSetpointType.Heating,
+		});
+		const cooling = new ThermostatSetpointCCGet({
+			nodeId,
+			setpointType: ThermostatSetpointType.Cooling,
+		});
+		expect(getCommandRelation(cooling, heating)).toBe(
+			CommandRelation.Unrelated,
+		);
+		expect(
+			getCommandRelation(
+				new ThermostatSetpointCCGet({
+					nodeId,
+					setpointType: ThermostatSetpointType.Cooling,
+				}),
+				cooling,
+			),
+		).toBe(CommandRelation.Redundant);
+	});
+
+	test("Sets compare value and scale within one setpoint type", () => {
+		const older = new ThermostatSetpointCCSet({
+			nodeId,
+			setpointType: ThermostatSetpointType.Heating,
+			value: 20,
+			scale: 0,
+		});
+		expect(
+			getCommandRelation(
+				new ThermostatSetpointCCSet({
+					nodeId,
+					setpointType: ThermostatSetpointType.Heating,
+					value: 20,
+					scale: 0,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Redundant);
+		expect(
+			getCommandRelation(
+				new ThermostatSetpointCCSet({
+					nodeId,
+					setpointType: ThermostatSetpointType.Heating,
+					value: 21,
+					scale: 0,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Supersedes);
+		expect(
+			getCommandRelation(
+				new ThermostatSetpointCCSet({
+					nodeId,
+					setpointType: ThermostatSetpointType.Heating,
+					value: 20,
+					scale: 1,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Supersedes);
+		expect(
+			getCommandRelation(
+				new ThermostatSetpointCCSet({
+					nodeId,
+					setpointType: ThermostatSetpointType.Cooling,
+					value: 20,
+					scale: 0,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Unrelated);
+	});
+
+	test("Reports compare value and scale within one setpoint type", () => {
+		const older = new ThermostatSetpointCCReport({
+			nodeId,
+			type: ThermostatSetpointType.Heating,
+			value: 20,
+			scale: 0,
+		});
+		expect(
+			getCommandRelation(
+				new ThermostatSetpointCCReport({
+					nodeId,
+					type: ThermostatSetpointType.Heating,
+					value: 20,
+					scale: 0,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Redundant);
+		expect(
+			getCommandRelation(
+				new ThermostatSetpointCCReport({
+					nodeId,
+					type: ThermostatSetpointType.Heating,
+					value: 21,
+					scale: 0,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Supersedes);
+		expect(
+			getCommandRelation(
+				new ThermostatSetpointCCReport({
+					nodeId,
+					type: ThermostatSetpointType.Heating,
+					value: 20,
+					scale: 1,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Supersedes);
+		expect(
+			getCommandRelation(
+				new ThermostatSetpointCCReport({
+					nodeId,
+					type: ThermostatSetpointType.Cooling,
+					value: 20,
+					scale: 0,
+				}),
+				older,
+			),
+		).toBe(CommandRelation.Unrelated);
+	});
+});

--- a/packages/cc/src/cc/MultiChannelCC.ts
+++ b/packages/cc/src/cc/MultiChannelCC.ts
@@ -33,9 +33,11 @@ import { CCAPI } from "../lib/API.js";
 import {
 	type CCRaw,
 	CommandClass,
+	CommandRelation,
 	type InterviewContext,
 	type PersistValuesContext,
 	getEffectiveCCVersion,
+	haveSameDestination,
 } from "../lib/CommandClass.js";
 import {
 	API,
@@ -1492,6 +1494,18 @@ export class MultiChannelCCCommandEncapsulation extends MultiChannelCC {
 	/** The destination end point (0-127) or an array of destination end points (1-7) */
 	public destination: MultiChannelCCDestination;
 
+	protected override determineRelation(
+		other: CommandClass,
+	): CommandRelation {
+		if (
+			other instanceof MultiChannelCCCommandEncapsulation
+			&& haveSameDestination(this.destination, other.destination)
+		) {
+			return this.encapsulated.getRelationTo(other.encapsulated);
+		}
+		return CommandRelation.Unrelated;
+	}
+
 	public async serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		if (
 			ctx.getDeviceConfig?.(this.nodeId as number)?.compat
@@ -1719,6 +1733,15 @@ export class MultiChannelCCV1CommandEncapsulation extends MultiChannelCC {
 	}
 
 	public encapsulated!: CommandClass;
+
+	protected override determineRelation(
+		other: CommandClass,
+	): CommandRelation {
+		if (other instanceof MultiChannelCCV1CommandEncapsulation) {
+			return this.encapsulated.getRelationTo(other.encapsulated);
+		}
+		return CommandRelation.Unrelated;
+	}
 
 	public async serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		this.payload = Bytes.concat([

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -660,23 +660,19 @@ export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
 	public duration: Duration | undefined;
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		if (
-			!(other instanceof MultilevelSwitchCCSet)
-			&& !(other instanceof MultilevelSwitchCCStartLevelChange)
-		) {
-			return CommandRelation.Unrelated;
+		if (other instanceof MultilevelSwitchCCSet) {
+			return this.targetValue === other.targetValue
+					&& areDurationsEqual(
+						this.duration ?? Duration.default(),
+						other.duration ?? Duration.default(),
+					)
+				? CommandRelation.Redundant
+				: CommandRelation.Supersedes;
 		}
-		if (
-			other instanceof MultilevelSwitchCCSet
-			&& this.targetValue === other.targetValue
-			&& areDurationsEqual(
-				this.duration ?? Duration.default(),
-				other.duration ?? Duration.default(),
-			)
-		) {
-			return CommandRelation.Redundant;
+		if (other instanceof MultilevelSwitchCCStartLevelChange) {
+			return CommandRelation.Supersedes;
 		}
-		return CommandRelation.Supersedes;
+		return CommandRelation.Unrelated;
 	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
@@ -767,14 +763,14 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 	public currentValue: MaybeUnknown<number> | undefined;
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		if (!(other instanceof MultilevelSwitchCCReport)) {
-			return CommandRelation.Unrelated;
+		if (other instanceof MultilevelSwitchCCReport) {
+			return this.currentValue === other.currentValue
+					&& this.targetValue === other.targetValue
+					&& areDurationsEqual(this.duration, other.duration)
+				? CommandRelation.Redundant
+				: CommandRelation.Supersedes;
 		}
-		return this.currentValue === other.currentValue
-				&& this.targetValue === other.targetValue
-				&& areDurationsEqual(this.duration, other.duration)
-			? CommandRelation.Redundant
-			: CommandRelation.Supersedes;
+		return CommandRelation.Unrelated;
 	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
@@ -872,9 +868,10 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 @expectedCCResponse(MultilevelSwitchCCReport)
 export class MultilevelSwitchCCGet extends MultilevelSwitchCC {
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		return other instanceof MultilevelSwitchCCGet
-			? CommandRelation.Redundant
-			: CommandRelation.Unrelated;
+		if (other instanceof MultilevelSwitchCCGet) {
+			return CommandRelation.Redundant;
+		}
+		return CommandRelation.Unrelated;
 	}
 }
 
@@ -941,25 +938,21 @@ export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
 	public direction: keyof typeof LevelChangeDirection;
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		if (
-			!(other instanceof MultilevelSwitchCCSet)
-			&& !(other instanceof MultilevelSwitchCCStartLevelChange)
-		) {
-			return CommandRelation.Unrelated;
+		if (other instanceof MultilevelSwitchCCStartLevelChange) {
+			return this.direction === other.direction
+					&& this.ignoreStartLevel === other.ignoreStartLevel
+					&& this.startLevel === other.startLevel
+					&& areDurationsEqual(
+						this.duration ?? Duration.default(),
+						other.duration ?? Duration.default(),
+					)
+				? CommandRelation.Redundant
+				: CommandRelation.Supersedes;
 		}
-		if (
-			other instanceof MultilevelSwitchCCStartLevelChange
-			&& this.direction === other.direction
-			&& this.ignoreStartLevel === other.ignoreStartLevel
-			&& this.startLevel === other.startLevel
-			&& areDurationsEqual(
-				this.duration ?? Duration.default(),
-				other.duration ?? Duration.default(),
-			)
-		) {
-			return CommandRelation.Redundant;
+		if (other instanceof MultilevelSwitchCCSet) {
+			return CommandRelation.Supersedes;
 		}
-		return CommandRelation.Supersedes;
+		return CommandRelation.Unrelated;
 	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -53,7 +53,6 @@ import {
 	implementedVersion,
 	useSupervision,
 } from "../lib/CommandClassDecorators.js";
-import { areDurationsEqual } from "../lib/CommandRelationUtils.js";
 import { V } from "../lib/Values.js";
 import {
 	LevelChangeDirection,
@@ -662,10 +661,8 @@ export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
 	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (other instanceof MultilevelSwitchCCSet) {
 			return this.targetValue === other.targetValue
-					&& areDurationsEqual(
-						this.duration ?? Duration.default(),
-						other.duration ?? Duration.default(),
-					)
+					&& (this.duration ?? Duration.default())
+						.equals(other.duration ?? Duration.default())
 				? CommandRelation.Redundant
 				: CommandRelation.Supersedes;
 		}
@@ -766,7 +763,8 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 		if (other instanceof MultilevelSwitchCCReport) {
 			return this.currentValue === other.currentValue
 					&& this.targetValue === other.targetValue
-					&& areDurationsEqual(this.duration, other.duration)
+					&& (this.duration ?? Duration.default())
+						.equals(other.duration ?? Duration.default())
 				? CommandRelation.Redundant
 				: CommandRelation.Supersedes;
 		}
@@ -942,10 +940,8 @@ export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
 			return this.direction === other.direction
 					&& this.ignoreStartLevel === other.ignoreStartLevel
 					&& this.startLevel === other.startLevel
-					&& areDurationsEqual(
-						this.duration ?? Duration.default(),
-						other.duration ?? Duration.default(),
-					)
+					&& (this.duration ?? Duration.default())
+						.equals(other.duration ?? Duration.default())
 				? CommandRelation.Redundant
 				: CommandRelation.Supersedes;
 		}

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -36,6 +36,7 @@ import {
 import {
 	type CCRaw,
 	CommandClass,
+	CommandRelation,
 	type InterviewContext,
 	type PersistValuesContext,
 	type RefreshValuesContext,
@@ -52,6 +53,7 @@ import {
 	implementedVersion,
 	useSupervision,
 } from "../lib/CommandClassDecorators.js";
+import { areDurationsEqual } from "../lib/CommandRelationUtils.js";
 import { V } from "../lib/Values.js";
 import {
 	LevelChangeDirection,
@@ -657,6 +659,26 @@ export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
 	public targetValue: number;
 	public duration: Duration | undefined;
 
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (
+			!(other instanceof MultilevelSwitchCCSet)
+			&& !(other instanceof MultilevelSwitchCCStartLevelChange)
+		) {
+			return CommandRelation.Unrelated;
+		}
+		if (
+			other instanceof MultilevelSwitchCCSet
+			&& this.targetValue === other.targetValue
+			&& areDurationsEqual(
+				this.duration ?? Duration.default(),
+				other.duration ?? Duration.default(),
+			)
+		) {
+			return CommandRelation.Redundant;
+		}
+		return CommandRelation.Supersedes;
+	}
+
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		this.payload = Bytes.from([
 			this.targetValue,
@@ -743,6 +765,17 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 	public duration: Duration | undefined;
 
 	public currentValue: MaybeUnknown<number> | undefined;
+
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (!(other instanceof MultilevelSwitchCCReport)) {
+			return CommandRelation.Unrelated;
+		}
+		return this.currentValue === other.currentValue
+				&& this.targetValue === other.targetValue
+				&& areDurationsEqual(this.duration, other.duration)
+			? CommandRelation.Redundant
+			: CommandRelation.Supersedes;
+	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
 		const node = this.getNode(ctx);
@@ -837,7 +870,13 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 
 @CCCommand(MultilevelSwitchCommand.Get)
 @expectedCCResponse(MultilevelSwitchCCReport)
-export class MultilevelSwitchCCGet extends MultilevelSwitchCC {}
+export class MultilevelSwitchCCGet extends MultilevelSwitchCC {
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		return other instanceof MultilevelSwitchCCGet
+			? CommandRelation.Redundant
+			: CommandRelation.Unrelated;
+	}
+}
 
 // @publicAPI
 export type MultilevelSwitchCCStartLevelChangeOptions =
@@ -900,6 +939,28 @@ export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
 	public startLevel: number;
 	public ignoreStartLevel: boolean;
 	public direction: keyof typeof LevelChangeDirection;
+
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (
+			!(other instanceof MultilevelSwitchCCSet)
+			&& !(other instanceof MultilevelSwitchCCStartLevelChange)
+		) {
+			return CommandRelation.Unrelated;
+		}
+		if (
+			other instanceof MultilevelSwitchCCStartLevelChange
+			&& this.direction === other.direction
+			&& this.ignoreStartLevel === other.ignoreStartLevel
+			&& this.startLevel === other.startLevel
+			&& areDurationsEqual(
+				this.duration ?? Duration.default(),
+				other.duration ?? Duration.default(),
+			)
+		) {
+			return CommandRelation.Redundant;
+		}
+		return CommandRelation.Supersedes;
+	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		const controlByte = (LevelChangeDirection[this.direction] << 6)

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -659,7 +659,7 @@ export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
 	public targetValue: number;
 	public duration: Duration | undefined;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (
 			!(other instanceof MultilevelSwitchCCSet)
 			&& !(other instanceof MultilevelSwitchCCStartLevelChange)
@@ -766,7 +766,7 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 
 	public currentValue: MaybeUnknown<number> | undefined;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (!(other instanceof MultilevelSwitchCCReport)) {
 			return CommandRelation.Unrelated;
 		}
@@ -871,7 +871,7 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 @CCCommand(MultilevelSwitchCommand.Get)
 @expectedCCResponse(MultilevelSwitchCCReport)
 export class MultilevelSwitchCCGet extends MultilevelSwitchCC {
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		return other instanceof MultilevelSwitchCCGet
 			? CommandRelation.Redundant
 			: CommandRelation.Unrelated;
@@ -940,7 +940,7 @@ export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
 	public ignoreStartLevel: boolean;
 	public direction: keyof typeof LevelChangeDirection;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (
 			!(other instanceof MultilevelSwitchCCSet)
 			&& !(other instanceof MultilevelSwitchCCStartLevelChange)

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -1798,6 +1798,40 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 	protected override determineRelation(
 		other: CommandClass,
 	): CommandRelation {
+		if (!(other instanceof Security2CCMessageEncapsulation)) {
+			return CommandRelation.Unrelated;
+		}
+
+		// Both commands must be encrypted with the same security class
+		// and verify delivery the same way
+		if (
+			this.securityClass !== other.securityClass
+			|| this.verifyDelivery !== other.verifyDelivery
+		) {
+			return CommandRelation.Unrelated;
+		}
+
+		// S2 multicast frames are encrypted for one multicast group, so
+		// commands only match within the same group (or none at all)
+		if (
+			getMulticastGroupId(this.extensions)
+				!== getMulticastGroupId(other.extensions)
+		) {
+			return CommandRelation.Unrelated;
+		}
+
+		// Notifying the node about de-synced multicast state must not get
+		// lost when only one of the commands would do so
+		const hasMOSExtension = (
+			cc: Security2CCMessageEncapsulation,
+		): boolean =>
+			cc.extensions.some((extension) =>
+				extension instanceof MOSExtension
+			);
+		if (hasMOSExtension(this) !== hasMOSExtension(other)) {
+			return CommandRelation.Unrelated;
+		}
+
 		// Commands that establish or repair synchronization (SPAN/MPAN)
 		// must each be transmitted
 		const carriesSyncExtension = (
@@ -1807,31 +1841,17 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				extension instanceof SPANExtension
 				|| extension instanceof MPANExtension
 			);
-
-		if (
-			other instanceof Security2CCMessageEncapsulation
-			&& this.securityClass === other.securityClass
-			&& this.verifyDelivery === other.verifyDelivery
-			// S2 multicast frames are encrypted for one multicast group, so
-			// commands only match within the same group (or none at all)
-			&& getMulticastGroupId(this.extensions)
-				=== getMulticastGroupId(other.extensions)
-			// Notifying the node about de-synced multicast state must not get
-			// lost when only one of the commands would do so
-			&& this.extensions.some((extension) =>
-					extension instanceof MOSExtension
-				)
-				=== other.extensions.some((extension) =>
-					extension instanceof MOSExtension
-				)
-			&& !carriesSyncExtension(this)
-			&& !carriesSyncExtension(other)
-			&& this.encapsulated
-			&& other.encapsulated
-		) {
-			return this.encapsulated.getRelationTo(other.encapsulated);
+		if (carriesSyncExtension(this) || carriesSyncExtension(other)) {
+			return CommandRelation.Unrelated;
 		}
-		return CommandRelation.Unrelated;
+
+		// Only commands that transport another command can be related.
+		// Received commands do not have `encapsulated` set at this point.
+		if (!this.encapsulated || !other.encapsulated) {
+			return CommandRelation.Unrelated;
+		}
+
+		return this.encapsulated.getRelationTo(other.encapsulated);
 	}
 
 	public override prepareRetransmission(): void {

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -1798,18 +1798,34 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 	protected override determineRelation(
 		other: CommandClass,
 	): CommandRelation {
+		// Commands that establish or repair synchronization (SPAN/MPAN)
+		// must each be transmitted
+		const carriesSyncExtension = (
+			cc: Security2CCMessageEncapsulation,
+		): boolean =>
+			cc.extensions.some((extension) =>
+				extension instanceof SPANExtension
+				|| extension instanceof MPANExtension
+			);
+
 		if (
 			other instanceof Security2CCMessageEncapsulation
 			&& this.securityClass === other.securityClass
 			&& this.verifyDelivery === other.verifyDelivery
+			// S2 multicast frames are encrypted for one multicast group, so
+			// commands only match within the same group (or none at all)
 			&& getMulticastGroupId(this.extensions)
 				=== getMulticastGroupId(other.extensions)
+			// Notifying the node about de-synced multicast state must not get
+			// lost when only one of the commands would do so
 			&& this.extensions.some((extension) =>
 					extension instanceof MOSExtension
 				)
 				=== other.extensions.some((extension) =>
 					extension instanceof MOSExtension
 				)
+			&& !carriesSyncExtension(this)
+			&& !carriesSyncExtension(other)
 			&& this.encapsulated
 			&& other.encapsulated
 		) {

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -1834,14 +1834,16 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 
 		// Commands that establish or repair synchronization (SPAN/MPAN)
 		// must each be transmitted
-		const carriesSyncExtension = (
-			cc: Security2CCMessageEncapsulation,
-		): boolean =>
-			cc.extensions.some((extension) =>
+		if (
+			this.extensions.some((extension) =>
 				extension instanceof SPANExtension
 				|| extension instanceof MPANExtension
-			);
-		if (carriesSyncExtension(this) || carriesSyncExtension(other)) {
+			)
+			|| other.extensions.some((extension) =>
+				extension instanceof SPANExtension
+				|| extension instanceof MPANExtension
+			)
+		) {
 			return CommandRelation.Unrelated;
 		}
 

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -56,6 +56,7 @@ import {
 	type CCRaw,
 	type CCResponseRole,
 	CommandClass,
+	CommandRelation,
 	type InterviewContext,
 } from "../lib/CommandClass.js";
 import {
@@ -1793,6 +1794,29 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 
 	public encapsulated?: CommandClass;
 	public extensions: Security2Extension[];
+
+	protected override determineRelation(
+		other: CommandClass,
+	): CommandRelation {
+		if (
+			other instanceof Security2CCMessageEncapsulation
+			&& this.securityClass === other.securityClass
+			&& this.verifyDelivery === other.verifyDelivery
+			&& getMulticastGroupId(this.extensions)
+				=== getMulticastGroupId(other.extensions)
+			&& this.extensions.some((extension) =>
+					extension instanceof MOSExtension
+				)
+				=== other.extensions.some((extension) =>
+					extension instanceof MOSExtension
+				)
+			&& this.encapsulated
+			&& other.encapsulated
+		) {
+			return this.encapsulated.getRelationTo(other.encapsulated);
+		}
+		return CommandRelation.Unrelated;
+	}
 
 	public override prepareRetransmission(): void {
 		super.prepareRetransmission();

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -43,6 +43,7 @@ import { CCAPI, PhysicalCCAPI } from "../lib/API.js";
 import {
 	type CCRaw,
 	CommandClass,
+	CommandRelation,
 	type InterviewContext,
 } from "../lib/CommandClass.js";
 import {
@@ -736,6 +737,20 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 
 	public decryptedCCBytes: BytesView | undefined;
 	public encapsulated!: CommandClass;
+
+	protected override determineRelation(
+		other: CommandClass,
+	): CommandRelation {
+		if (
+			other instanceof SecurityCCCommandEncapsulation
+			&& this.ccCommand === other.ccCommand
+			&& this.encapsulated
+			&& other.encapsulated
+		) {
+			return this.encapsulated.getRelationTo(other.encapsulated);
+		}
+		return CommandRelation.Unrelated;
+	}
 
 	private alternativeNetworkKey?: BytesView;
 

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -744,6 +744,8 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 		if (
 			other instanceof SecurityCCCommandEncapsulation
 			&& this.ccCommand === other.ccCommand
+			// Only outgoing encapsulations have `encapsulated` set. Sequenced
+			// commands only exist on the receiving side, so they cannot appear here.
 			&& this.encapsulated
 			&& other.encapsulated
 		) {

--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -24,7 +24,11 @@ import {
 } from "@zwave-js/core";
 import { Bytes, getEnumMemberName } from "@zwave-js/shared";
 import { PhysicalCCAPI } from "../lib/API.js";
-import { type CCRaw, CommandClass } from "../lib/CommandClass.js";
+import {
+	type CCRaw,
+	CommandClass,
+	CommandRelation,
+} from "../lib/CommandClass.js";
 import {
 	API,
 	CCCommand,
@@ -438,6 +442,20 @@ export class SupervisionCCGet extends SupervisionCC {
 	public requestStatusUpdates: boolean;
 	public sessionId: number;
 	public encapsulated: CommandClass;
+
+	protected override determineRelation(
+		other: CommandClass,
+	): CommandRelation {
+		if (
+			other instanceof SupervisionCCGet
+			// Requesting status updates changes the expected response flow.
+			// Transactions with this flag are exempt from deduplication.
+			&& this.requestStatusUpdates === other.requestStatusUpdates
+		) {
+			return this.encapsulated.getRelationTo(other.encapsulated);
+		}
+		return CommandRelation.Unrelated;
+	}
 
 	public async serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		const encapCC = await this.encapsulated.serialize(ctx);

--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -448,8 +448,8 @@ export class SupervisionCCGet extends SupervisionCC {
 	): CommandRelation {
 		if (
 			other instanceof SupervisionCCGet
-			// Requesting status updates changes the expected response flow.
-			// Transactions with this flag are exempt from deduplication.
+			// Requesting status updates changes the expected response flow,
+			// so commands with different flags must not be related
 			&& this.requestStatusUpdates === other.requestStatusUpdates
 		) {
 			return this.encapsulated.getRelationTo(other.encapsulated);

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -36,6 +36,7 @@ import {
 import {
 	type CCRaw,
 	CommandClass,
+	CommandRelation,
 	type InterviewContext,
 	type PersistValuesContext,
 	type RefreshValuesContext,
@@ -605,6 +606,18 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 	public value: number;
 	public scale: number;
 
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (
+			!(other instanceof ThermostatSetpointCCSet)
+			|| this.setpointType !== other.setpointType
+		) {
+			return CommandRelation.Unrelated;
+		}
+		return this.value === other.value && this.scale === other.scale
+			? CommandRelation.Redundant
+			: CommandRelation.Supersedes;
+	}
+
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		// If a config file overwrites how the float should be encoded, use that information
 		const override = ctx.getDeviceConfig?.(this.nodeId as number)
@@ -713,6 +726,18 @@ export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
 	public scale: number;
 	public value: number;
 
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (
+			!(other instanceof ThermostatSetpointCCReport)
+			|| this.type !== other.type
+		) {
+			return CommandRelation.Unrelated;
+		}
+		return this.value === other.value && this.scale === other.scale
+			? CommandRelation.Redundant
+			: CommandRelation.Supersedes;
+	}
+
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		this.payload = Bytes.concat([
 			[this.type & 0b1111],
@@ -776,6 +801,15 @@ export class ThermostatSetpointCCGet extends ThermostatSetpointCC {
 	}
 
 	public setpointType: ThermostatSetpointType;
+
+	public override getRelationTo(other: CommandClass): CommandRelation {
+		if (!(other instanceof ThermostatSetpointCCGet)) {
+			return CommandRelation.Unrelated;
+		}
+		return this.setpointType === other.setpointType
+			? CommandRelation.Redundant
+			: CommandRelation.Unrelated;
+	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		this.payload = Bytes.from([this.setpointType & 0b1111]);

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -608,14 +608,14 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (
-			!(other instanceof ThermostatSetpointCCSet)
-			|| this.setpointType !== other.setpointType
+			other instanceof ThermostatSetpointCCSet
+			&& this.setpointType === other.setpointType
 		) {
-			return CommandRelation.Unrelated;
+			return this.value === other.value && this.scale === other.scale
+				? CommandRelation.Redundant
+				: CommandRelation.Supersedes;
 		}
-		return this.value === other.value && this.scale === other.scale
-			? CommandRelation.Redundant
-			: CommandRelation.Supersedes;
+		return CommandRelation.Unrelated;
 	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
@@ -728,14 +728,14 @@ export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (
-			!(other instanceof ThermostatSetpointCCReport)
-			|| this.type !== other.type
+			other instanceof ThermostatSetpointCCReport
+			&& this.type === other.type
 		) {
-			return CommandRelation.Unrelated;
+			return this.value === other.value && this.scale === other.scale
+				? CommandRelation.Redundant
+				: CommandRelation.Supersedes;
 		}
-		return this.value === other.value && this.scale === other.scale
-			? CommandRelation.Redundant
-			: CommandRelation.Supersedes;
+		return CommandRelation.Unrelated;
 	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
@@ -803,12 +803,13 @@ export class ThermostatSetpointCCGet extends ThermostatSetpointCC {
 	public setpointType: ThermostatSetpointType;
 
 	protected override determineRelation(other: CommandClass): CommandRelation {
-		if (!(other instanceof ThermostatSetpointCCGet)) {
-			return CommandRelation.Unrelated;
+		if (
+			other instanceof ThermostatSetpointCCGet
+			&& this.setpointType === other.setpointType
+		) {
+			return CommandRelation.Redundant;
 		}
-		return this.setpointType === other.setpointType
-			? CommandRelation.Redundant
-			: CommandRelation.Unrelated;
+		return CommandRelation.Unrelated;
 	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -606,7 +606,7 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 	public value: number;
 	public scale: number;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (
 			!(other instanceof ThermostatSetpointCCSet)
 			|| this.setpointType !== other.setpointType
@@ -726,7 +726,7 @@ export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
 	public scale: number;
 	public value: number;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (
 			!(other instanceof ThermostatSetpointCCReport)
 			|| this.type !== other.type
@@ -802,7 +802,7 @@ export class ThermostatSetpointCCGet extends ThermostatSetpointCC {
 
 	public setpointType: ThermostatSetpointType;
 
-	public override getRelationTo(other: CommandClass): CommandRelation {
+	protected override determineRelation(other: CommandClass): CommandRelation {
 		if (!(other instanceof ThermostatSetpointCCGet)) {
 			return CommandRelation.Unrelated;
 		}

--- a/packages/cc/src/lib/CommandClass.getCommandRelation.test.ts
+++ b/packages/cc/src/lib/CommandClass.getCommandRelation.test.ts
@@ -17,6 +17,7 @@ import { Security2CC } from "../cc/Security2CC.js";
 import { SecurityCC } from "../cc/SecurityCC.js";
 import { SupervisionCC } from "../cc/SupervisionCC.js";
 import { CommandRelation, getCommandRelation } from "./CommandClass.js";
+import { SPANExtension } from "./Security2/Extension.js";
 
 // Basic Set supplies the smallest command payload needed for relation semantics
 class RelatedBasicCCSet extends BasicCCSet {
@@ -315,6 +316,27 @@ describe("getCommandRelation", () => {
 				differentMulticastExtensions[1],
 			),
 		).toBe(CommandRelation.Unrelated);
+	});
+
+	test("transmits S2 synchronization commands individually", () => {
+		const securityManagers = {} as SecurityManagers;
+		const newer = Security2CC.encapsulate(
+			createSet(1),
+			1,
+			securityManagers,
+		);
+		const older = Security2CC.encapsulate(
+			createSet(1),
+			1,
+			securityManagers,
+		);
+		older.extensions.push(
+			new SPANExtension({ senderEI: new Uint8Array(16) }),
+		);
+
+		expect(getCommandRelation(newer, older)).toBe(
+			CommandRelation.Unrelated,
+		);
 	});
 
 	test("returns unrelated for multi-command encapsulation", () => {

--- a/packages/cc/src/lib/CommandClass.getCommandRelation.test.ts
+++ b/packages/cc/src/lib/CommandClass.getCommandRelation.test.ts
@@ -1,8 +1,21 @@
-import { EncapsulationFlags } from "@zwave-js/core";
+import {
+	EncapsulationFlags,
+	type SecurityManager,
+	type SecurityManagers,
+} from "@zwave-js/core";
 import { describe, expect, test } from "vitest";
 import { BasicCCGet, BasicCCSet } from "../cc/BasicCC.js";
 import { BinarySwitchCCSet } from "../cc/BinarySwitchCC.js";
+import { CRC16CC } from "../cc/CRC16CC.js";
+import {
+	MultiChannelCC,
+	MultiChannelCCCommandEncapsulation,
+	MultiChannelCCV1CommandEncapsulation,
+} from "../cc/MultiChannelCC.js";
 import { MultiCommandCC } from "../cc/MultiCommandCC.js";
+import { Security2CC } from "../cc/Security2CC.js";
+import { SecurityCC } from "../cc/SecurityCC.js";
+import { SupervisionCC } from "../cc/SupervisionCC.js";
 import { CommandRelation, getCommandRelation } from "./CommandClass.js";
 
 // Basic Set supplies the smallest command payload needed for relation semantics
@@ -127,6 +140,181 @@ describe("getCommandRelation", () => {
 		expect(getCommandRelation(newer, older)).toBe(
 			CommandRelation.Unrelated,
 		);
+	});
+
+	test("ignores generated fields on single-command wrappers", () => {
+		const newer = SupervisionCC.encapsulate(createSet(1), 2);
+		const older = SupervisionCC.encapsulate(createSet(1), 1);
+		expect(getCommandRelation(newer, older)).toBe(
+			CommandRelation.Redundant,
+		);
+	});
+
+	test("separates Supervision status update requests", () => {
+		const newer = SupervisionCC.encapsulate(createSet(1), 2, true);
+		const older = SupervisionCC.encapsulate(createSet(1), 1, false);
+		expect(getCommandRelation(newer, older)).toBe(
+			CommandRelation.Unrelated,
+		);
+	});
+
+	test("recurses through transparent nested wrappers", () => {
+		const securityManager = {} as SecurityManager;
+		const newer = CRC16CC.encapsulate(
+			SecurityCC.encapsulate(
+				1,
+				securityManager,
+				SupervisionCC.encapsulate(createSet(1), 2),
+			),
+		);
+		const older = CRC16CC.encapsulate(
+			SecurityCC.encapsulate(
+				1,
+				securityManager,
+				SupervisionCC.encapsulate(createSet(1), 1),
+			),
+		);
+
+		expect(getCommandRelation(newer, older)).toBe(
+			CommandRelation.Redundant,
+		);
+	});
+
+	test("preserves Multi Channel destinations while unwrapping", () => {
+		const newer = MultiChannelCC.encapsulate(
+			createSet(1, { endpointIndex: 2 }),
+		);
+		const older = MultiChannelCC.encapsulate(
+			createSet(1, { endpointIndex: 1 }),
+		);
+
+		// The wrapper endpoint cannot distinguish its logical destinations
+		expect(newer.endpointIndex).toBe(0);
+		expect(older.endpointIndex).toBe(0);
+		expect(getCommandRelation(newer, older)).toBe(
+			CommandRelation.Unrelated,
+		);
+	});
+
+	test("compares Multi Channel destination bit masks as sets", () => {
+		const newer = new MultiChannelCCCommandEncapsulation({
+			nodeId: 2,
+			destination: [1, 2],
+			encapsulated: createSet(1),
+		});
+		const older = new MultiChannelCCCommandEncapsulation({
+			nodeId: 2,
+			destination: [2, 1],
+			encapsulated: createSet(1),
+		});
+
+		expect(getCommandRelation(newer, older)).toBe(
+			CommandRelation.Redundant,
+		);
+	});
+
+	test("recurses through Multi Channel V1 encapsulation", () => {
+		const newer = new MultiChannelCCV1CommandEncapsulation({
+			nodeId: 2,
+			endpointIndex: 1,
+			encapsulated: createSet(1),
+		});
+		const older = new MultiChannelCCV1CommandEncapsulation({
+			nodeId: 2,
+			endpointIndex: 1,
+			encapsulated: createSet(1),
+		});
+
+		expect(getCommandRelation(newer, older)).toBe(
+			CommandRelation.Redundant,
+		);
+	});
+
+	test("preserves S2 multicast targets and groups while unwrapping", () => {
+		const securityManagers = {} as SecurityManagers;
+		const differentTargets = [
+			Security2CC.encapsulate(
+				createSet(1, { nodeId: [2, 3] }),
+				1,
+				securityManagers,
+				{ multicastGroupId: 1 },
+			),
+			Security2CC.encapsulate(
+				createSet(1, { nodeId: [2, 4] }),
+				1,
+				securityManagers,
+				{ multicastGroupId: 1 },
+			),
+		];
+		const differentGroups = [
+			Security2CC.encapsulate(
+				createSet(1, { nodeId: [2, 3] }),
+				1,
+				securityManagers,
+				{ multicastGroupId: 1 },
+			),
+			Security2CC.encapsulate(
+				createSet(1, { nodeId: [2, 3] }),
+				1,
+				securityManagers,
+				{ multicastGroupId: 2 },
+			),
+		];
+		const sameGroupAndTargets = [
+			Security2CC.encapsulate(
+				createSet(1, { nodeId: [2, 3] }),
+				1,
+				securityManagers,
+				{ multicastGroupId: 1 },
+			),
+			Security2CC.encapsulate(
+				createSet(1, { nodeId: [3, 2] }),
+				1,
+				securityManagers,
+				{ multicastGroupId: 1 },
+			),
+		];
+		const differentMulticastExtensions = [
+			Security2CC.encapsulate(
+				createSet(1, { nodeId: [2, 3] }),
+				1,
+				securityManagers,
+				{ multicastGroupId: 1 },
+			),
+			Security2CC.encapsulate(
+				createSet(1, { nodeId: [2, 3] }),
+				1,
+				securityManagers,
+				{
+					multicastGroupId: 1,
+					multicastOutOfSync: true,
+				},
+			),
+		];
+
+		// The wrapper node ID cannot distinguish its multicast target sets
+		expect(differentTargets[0].nodeId).toBe(
+			differentTargets[1].nodeId,
+		);
+		// Inner targets and S2 group metadata must all match
+		expect(
+			getCommandRelation(differentTargets[0], differentTargets[1]),
+		).toBe(CommandRelation.Unrelated);
+		expect(
+			getCommandRelation(differentGroups[0], differentGroups[1]),
+		).toBe(CommandRelation.Unrelated);
+		expect(
+			getCommandRelation(
+				sameGroupAndTargets[0],
+				sameGroupAndTargets[1],
+			),
+		).toBe(CommandRelation.Redundant);
+		expect(
+			getCommandRelation(
+				differentMulticastExtensions[0],
+				differentMulticastExtensions[1],
+			),
+		).toBe(CommandRelation.Unrelated);
 	});
 
 	test("returns unrelated for multi-command encapsulation", () => {

--- a/packages/cc/src/lib/CommandClass.getCommandRelation.test.ts
+++ b/packages/cc/src/lib/CommandClass.getCommandRelation.test.ts
@@ -26,6 +26,12 @@ class CrossCommandBasicCCSet extends BasicCCSet {
 	}
 }
 
+class UnrelatedBasicCCSet extends BasicCCSet {
+	public override getRelationTo(_other: BasicCCSet): CommandRelation {
+		return CommandRelation.Unrelated;
+	}
+}
+
 function createSet(
 	targetValue: number,
 	options: {
@@ -60,7 +66,7 @@ describe("getCommandRelation", () => {
 		).toBe(CommandRelation.Redundant);
 		expect(
 			getCommandRelation(
-				new BasicCCSet({ nodeId: 2, targetValue: 1 }),
+				new UnrelatedBasicCCSet({ nodeId: 2, targetValue: 1 }),
 				createSet(1),
 			),
 		).toBe(CommandRelation.Unrelated);

--- a/packages/cc/src/lib/CommandClass.getCommandRelation.test.ts
+++ b/packages/cc/src/lib/CommandClass.getCommandRelation.test.ts
@@ -26,12 +26,6 @@ class CrossCommandBasicCCSet extends BasicCCSet {
 	}
 }
 
-class UnrelatedBasicCCSet extends BasicCCSet {
-	public override getRelationTo(_other: BasicCCSet): CommandRelation {
-		return CommandRelation.Unrelated;
-	}
-}
-
 function createSet(
 	targetValue: number,
 	options: {
@@ -66,10 +60,10 @@ describe("getCommandRelation", () => {
 		).toBe(CommandRelation.Redundant);
 		expect(
 			getCommandRelation(
-				new UnrelatedBasicCCSet({ nodeId: 2, targetValue: 1 }),
+				new BasicCCSet({ nodeId: 2, targetValue: 1 }),
 				createSet(1),
 			),
-		).toBe(CommandRelation.Unrelated);
+		).toBe(CommandRelation.Redundant);
 	});
 
 	test("allows same-CC cross-command opt-in", () => {

--- a/packages/cc/src/lib/CommandRelationUtils.ts
+++ b/packages/cc/src/lib/CommandRelationUtils.ts
@@ -1,0 +1,8 @@
+import type { Duration } from "@zwave-js/core";
+
+export function areDurationsEqual(
+	first: Duration | undefined,
+	second: Duration | undefined,
+): boolean {
+	return first?.value === second?.value && first?.unit === second?.unit;
+}

--- a/packages/cc/src/lib/CommandRelationUtils.ts
+++ b/packages/cc/src/lib/CommandRelationUtils.ts
@@ -1,8 +1,0 @@
-import type { Duration } from "@zwave-js/core";
-
-export function areDurationsEqual(
-	first: Duration | undefined,
-	second: Duration | undefined,
-): boolean {
-	return first?.value === second?.value && first?.unit === second?.unit;
-}

--- a/packages/core/src/values/Duration.ts
+++ b/packages/core/src/values/Duration.ts
@@ -45,6 +45,11 @@ export class Duration {
 		return new Duration(0, "default");
 	}
 
+	/** Whether this duration is equal to another one */
+	public equals(other: Duration): boolean {
+		return this.value === other.value && this.unit === other.unit;
+	}
+
 	public static isDuration(value: any): value is DurationLike {
 		return typeof value === "object"
 			&& value != null

--- a/packages/zwave-js/src/lib/test/driver/commandDeduplication.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/commandDeduplication.test.ts
@@ -188,7 +188,8 @@ integrationTest.sequential(
 				TransactionState.Failed,
 			]);
 
-			// Fan out one successful physical result
+			// Fan out one successful physical result. Two identical polls
+			// deduplicate through the concrete Basic CC Get relation.
 			blockNextGet();
 			const successfulCount = control.getCount;
 			const successfulFirst = driver.sendCommand(
@@ -416,6 +417,7 @@ integrationTest.sequential(
 				priority: MessagePriority.Controller,
 			});
 			const unrelatedAfterReplacement = driver.sendCommand(
+				// The different endpoint keeps this Set unrelated to the ones being merged
 				new BasicCCSet({
 					nodeId: 2,
 					endpointIndex: 1,
@@ -595,6 +597,8 @@ integrationTest.sequential(
 			t.expect(control.setValues).toEqual([9, 9, 11, 11]);
 			await driver.waitForIdle(1000);
 
+			// Concrete Basic CC relations deduplicate identical commands
+			// without any test-specific relation overrides
 			blockNextGet();
 			const concreteBlocker = driver.sendCommand(
 				new BasicCCGet({ nodeId: 2 }),

--- a/packages/zwave-js/src/lib/test/driver/commandDeduplication.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/commandDeduplication.test.ts
@@ -410,7 +410,11 @@ integrationTest.sequential(
 				priority: MessagePriority.Controller,
 			});
 			const unrelatedAfterReplacement = driver.sendCommand(
-				new BasicCCSet({ nodeId: 2, targetValue: 14 }),
+				new BasicCCSet({
+					nodeId: 2,
+					endpointIndex: 1,
+					targetValue: 14,
+				}),
 				{
 					...commandOptions,
 					priority: MessagePriority.Normal,

--- a/packages/zwave-js/src/lib/test/driver/commandDeduplication.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/commandDeduplication.test.ts
@@ -193,12 +193,18 @@ integrationTest.sequential(
 			const successfulCount = control.getCount;
 			const successfulFirst = driver.sendCommand(
 				new BasicCCGet({ nodeId: 2 }),
-				commandOptions,
+				{
+					...commandOptions,
+					priority: MessagePriority.Poll,
+				},
 			);
 			await control.started;
 			const successfulSecond = driver.sendCommand(
 				new BasicCCGet({ nodeId: 2 }),
-				commandOptions,
+				{
+					...commandOptions,
+					priority: MessagePriority.Poll,
+				},
 			);
 			control.release.resolve();
 			const [successfulFirstResult, successfulSecondResult] =

--- a/packages/zwave-js/src/lib/test/driver/commandDeduplication.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/commandDeduplication.test.ts
@@ -192,12 +192,12 @@ integrationTest.sequential(
 			blockNextGet();
 			const successfulCount = control.getCount;
 			const successfulFirst = driver.sendCommand(
-				createGet(2),
+				new BasicCCGet({ nodeId: 2 }),
 				commandOptions,
 			);
 			await control.started;
 			const successfulSecond = driver.sendCommand(
-				createGet(2),
+				new BasicCCGet({ nodeId: 2 }),
 				commandOptions,
 			);
 			control.release.resolve();
@@ -586,12 +586,12 @@ integrationTest.sequential(
 			await driver.waitForIdle(1000);
 
 			blockNextGet();
-			const unannotatedBlocker = driver.sendCommand(
+			const concreteBlocker = driver.sendCommand(
 				new BasicCCGet({ nodeId: 2 }),
 				commandOptions,
 			);
 			await control.started;
-			const unannotated = Promise.all([
+			const concrete = Promise.all([
 				driver.sendCommand(
 					new BasicCCSet({ nodeId: 2, targetValue: 12 }),
 					commandOptions,
@@ -603,10 +603,10 @@ integrationTest.sequential(
 			]);
 			control.release.resolve();
 			await Promise.all([
-				unannotatedBlocker,
-				unannotated,
+				concreteBlocker,
+				concrete,
 			]);
-			t.expect(control.setValues).toEqual([9, 9, 11, 11, 12, 12]);
+			t.expect(control.setValues).toEqual([9, 9, 11, 11, 12]);
 
 			// Exclude completed transactions from synchronous deduplication
 			blockNextGet();

--- a/packages/zwave-js/src/lib/test/driver/pollTiming.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/pollTiming.test.ts
@@ -86,6 +86,8 @@ integrationTest(
 		testBody: async (t, _driver, node, _mockController, _mockNode) => {
 			const basicPoll = node.commandClasses.Basic.withOptions({
 				priority: MessagePriority.Poll,
+				// In normal operation, we want polls to be deduplicated too, but for these
+				// tests, we need each individual transaction
 				preventDeduplication: true,
 			});
 
@@ -250,6 +252,8 @@ integrationTest(
 		testBody: async (t, _driver, node, _mockController, mockNode) => {
 			const basicPoll = node.commandClasses.Basic.withOptions({
 				priority: MessagePriority.Poll,
+				// In normal operation, we want polls to be deduplicated too, but for these
+				// tests, we need each individual transaction
 				preventDeduplication: true,
 			});
 

--- a/packages/zwave-js/src/lib/test/driver/pollTiming.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/pollTiming.test.ts
@@ -86,6 +86,7 @@ integrationTest(
 		testBody: async (t, _driver, node, _mockController, _mockNode) => {
 			const basicPoll = node.commandClasses.Basic.withOptions({
 				priority: MessagePriority.Poll,
+				preventDeduplication: true,
 			});
 
 			// Queue all three without awaiting
@@ -249,6 +250,7 @@ integrationTest(
 		testBody: async (t, _driver, node, _mockController, mockNode) => {
 			const basicPoll = node.commandClasses.Basic.withOptions({
 				priority: MessagePriority.Poll,
+				preventDeduplication: true,
 			});
 
 			// Disable auto-ACK now that the driver is fully initialized.


### PR DESCRIPTION
fixes: https://github.com/zwave-js/zwave-js/issues/1482

This implements the actual command relation logic for encapsulation CCs, as well as Basic, Binary Switch, Multilevel Switch, and Thermostat Setpoint CC. Equivalent gets and payloads deduplicate. New state changes supersede older commands for the same resource. Thermostat setpoint types remain independent, and Multilevel Set and Start Level Change supersede each other.