### PR TITLE
fix(config): add remapNotifications to fix malformed notifications sent by HomeSeer FS100 devices.

### DIFF
--- a/packages/config/config/devices/0x000c/hs-fs100-l.json
+++ b/packages/config/config/devices/0x000c/hs-fs100-l.json
@@ -30,5 +30,28 @@
 			"#": "4",
 			"$import": "templates/homeseer_template.json#enable_notification_buzzer"
 		}
-	]
+	],
+	"compat": {
+		// This device signals that light is no longer detected by sending an "idle"
+		// notification (Light sensor, event 0x00) whose event parameter is 0x02
+		// ("Light color transition detected"). That event is not a state variable, so
+		// Z-Wave JS cannot tell which variable to reset and the "Light detection status"
+		// value stays stuck on "Light detected" forever.
+		// The parameter should have been 0x01 ("Light detected"), so we translate the
+		// idle notification into an explicit idle for that variable.
+		"remapNotifications": [
+			{
+				"from": {
+					"notificationType": 20,
+					"notificationEvent": 0
+				},
+				"idle": [
+					{
+						"notificationType": 20,
+						"notificationEvent": 1
+					}
+				]
+			}
+		]
+	}
 }

--- a/packages/config/config/devices/0x000c/hs-fs100_flex.json
+++ b/packages/config/config/devices/0x000c/hs-fs100_flex.json
@@ -42,6 +42,29 @@
 			"defaultValue": 0
 		}
 	],
+	"compat": {
+		// This device signals that light is no longer detected by sending an "idle"
+		// notification (Light sensor, event 0x00) whose event parameter is 0x02
+		// ("Light color transition detected"). That event is not a state variable, so
+		// Z-Wave JS cannot tell which variable to reset and the "Light detection status"
+		// value stays stuck on "Light detected" forever.
+		// The parameter should have been 0x01 ("Light detected"), so we translate the
+		// idle notification into an explicit idle for that variable.
+		"remapNotifications": [
+			{
+				"from": {
+					"notificationType": 20,
+					"notificationEvent": 0
+				},
+				"idle": [
+					{
+						"notificationType": 20,
+						"notificationEvent": 1
+					}
+				]
+			}
+		]
+	},
 	"metadata": {
 		"inclusion": "Press and release the button once.",
 		"exclusion": "Press and release the button once.",


### PR DESCRIPTION
The HomeSeer FS100 firmware sends a malformed idle notification..
When light goes away, the FS-100L sends Notification type 0x14 (Light sensor), event 0x00 (idle), event parameter 0x02. The event parameter is supposed to name the state variable being cleared, and should be 0x01 ("Light detected"). Instead the device sends 0x02, which is registered as an event, not a state.

This has been reported [here](https://community.home-assistant.io/t/hs-fs100-l-not-coming-over-to-zwavejs-from-deprecated-z-wave/320824/14) and more recently [here](https://forums.homeseer.com/forum/hs4-products/hs4-plugins/lighting-primary-technology-plug-ins-aa/z-wave-plus-homeseer/1759349-fs-100l-device-in-hs4-acting-strange-after-upgrading-from-zwave-zwave-plus-plugin)

The fix is to use a `remapNotifications`  to rewrite the broken idle into an explicit idle for the right variable:

```
"remapNotifications": [
  { "from": { "notificationType": 20, "notificationEvent": 0 },
    "idle": [ { "notificationType": 20, "notificationEvent": 1 } ] }
]
```
