### PR TITLE
fix(cc): trim AGI command list reports

### DIFF
--- a/packages/cc/src/cc/AssociationGroupInfoCC.ts
+++ b/packages/cc/src/cc/AssociationGroupInfoCC.ts
@@ -868,6 +868,7 @@ export class AssociationGroupInfoCCCommandListReport
 			}
 		}
 		this.payload[1] = offset - 2; // list length
+		this.payload = this.payload.subarray(0, offset);
 
 		return super.serialize(ctx);
 	}

--- a/packages/zwave-js/src/lib/test/cc/AssociationGroupInfoCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/AssociationGroupInfoCC.test.ts
@@ -10,6 +10,7 @@ import {
 	AssociationGroupInfoProfile,
 	BasicCommand,
 	CommandClass,
+	DeviceResetLocallyCommand,
 } from "@zwave-js/cc";
 import { CommandClasses } from "@zwave-js/core";
 import { Bytes } from "@zwave-js/shared";
@@ -176,6 +177,31 @@ test("the CommandListGet command should serialize correctly", async (t) => {
 			AssociationGroupInfoCommand.CommandListGet, // CC Command
 			0b1000_0000, // allow cache
 			6, // group id
+		]),
+	);
+	await t.expect(cc.serialize({} as any)).resolves.toStrictEqual(
+		expected,
+	);
+});
+
+test("the CommandListReport command should serialize correctly", async (t) => {
+	const cc = new AssociationGroupInfoCCCommandListReport({
+		nodeId: 1,
+		groupId: 1,
+		commands: new Map([
+			[
+				CommandClasses["Device Reset Locally"],
+				[DeviceResetLocallyCommand.Notification],
+			],
+		]),
+	});
+	const expected = buildCCBuffer(
+		Uint8Array.from([
+			AssociationGroupInfoCommand.CommandListReport,
+			1, // group id
+			2, // list length in bytes
+			CommandClasses["Device Reset Locally"],
+			DeviceResetLocallyCommand.Notification,
 		]),
 	);
 	await t.expect(cc.serialize({} as any)).resolves.toStrictEqual(


### PR DESCRIPTION
`AssociationGroupInfoCCCommandListReport` allocates enough payload space for extended Command Class IDs. One-byte IDs left unused zero bytes in that allocation. The serializer now trims the payload to its tracked encoded length.

A regression test covers the certification frame `59 06 01 02 5A 01`.

Validation:
- `yarn test:ts packages/zwave-js/src/lib/test/cc/AssociationGroupInfoCC.test.ts`
- `yarn build`

Fixes #9145