### PR TITLE
fix(zniffer): parse PTI captures from Z-Wave CTT

### DIFF
--- a/packages/zwave-js/src/lib/test/zniffer/parseZLFEntry.test.ts
+++ b/packages/zwave-js/src/lib/test/zniffer/parseZLFEntry.test.ts
@@ -38,6 +38,18 @@ test("parse complete data frame", async (t) => {
 	t.expect(parsed.entries[0].msg).toBeInstanceOf(ZnifferDataMessage);
 });
 
+test("parse CTT PTI frame with zeroed DCH header", async (t) => {
+	const rawMsg = Bytes.from(
+		"8013fa7c93addd8801220000005b20000000000000000000000000f8c4dae60701410a0c02008f68f9000f0006515df5",
+		"hex",
+	);
+	const parsed = parseZLFEntry(rawMsg, 0);
+	t.expect(parsed.complete).toBe(true);
+	t.expect(parsed.entries).toHaveLength(1);
+	t.expect(parsed.entries[0].msg).toBeInstanceOf(ZnifferDataMessage);
+	t.expect(parsed.entries[0].msg).toHaveProperty("checksumOK", true);
+});
+
 test("parse incomplete data frame", async (t) => {
 	let rawMsg = Bytes.from("0c0b3e6713addd88010100000021fe", "hex");
 	let parsed = parseZLFEntry(rawMsg, 0);

--- a/packages/zwave-js/src/lib/zniffer/ZLFEntry.ts
+++ b/packages/zwave-js/src/lib/zniffer/ZLFEntry.ts
@@ -235,9 +235,15 @@ function parsePTIFrame(
 	const body = Bytes.view(frame.subarray(3, -1));
 	if (body.length < 2) return;
 	const version = body.readUInt16LE(0);
-	let messageType: DCHMessageType;
+	let messageType: DCHMessageType | undefined;
 	let ptiOffset: number;
-	if (version === 2) {
+	if (version === 0) {
+		// Z-Wave CTT uses the v2 header size with zeroed version and message type fields.
+		if (body.length < 11) return;
+		if (body.readUInt16LE(8) !== 0) return;
+		messageType = undefined;
+		ptiOffset = 11;
+	} else if (version === 2) {
 		if (body.length < 11) return;
 		messageType = body.readUInt16LE(8);
 		ptiOffset = 11;
@@ -251,7 +257,8 @@ function parsePTIFrame(
 
 	// Only Tx and Rx packets contain radio frames
 	if (
-		messageType !== DCHMessageType.EFRTxPacket
+		messageType !== undefined
+		&& messageType !== DCHMessageType.EFRTxPacket
 		&& messageType !== DCHMessageType.EFRRxPacket
 	) {
 		return;


### PR DESCRIPTION
Fixes #9139

Z-Wave CTT 4.0.3 writes a v2-sized DCH header with zero values for the version and message type. `parsePTIFrame` rejected the version before it examined the valid PTI hardware marker. Every captured frame was omitted.

The parser now accepts this exact zeroed header variant. Modern DCH version and message-type validation remains unchanged. The PTI marker and payload validation still apply.

Validation:
- `yarn fmt`
- `yarn workspace zwave-js test:ts run src/lib/test/zniffer/parseZLFEntry.test.ts --reporter=dot`
- `yarn build`