### PR TITLE
fix: remove proxy-excluded nodes from controller

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -3858,6 +3858,7 @@ export class ZWaveController
 				);
 
 				this.emit("node removed", node, RemoveNodeReason.ProxyExcluded);
+				this._nodes.delete(node.id);
 			}
 		} else if (msg instanceof ApplicationUpdateRequestNodeAdded) {
 			// A node was included by another controller

--- a/packages/zwave-js/src/lib/test/node/proxyExclusionRemovesNode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/proxyExclusionRemovesNode.test.ts
@@ -1,0 +1,36 @@
+import {
+	ApplicationUpdateRequest,
+	ApplicationUpdateTypes,
+} from "@zwave-js/serial/serialapi";
+import { Bytes } from "@zwave-js/shared";
+import { RemoveNodeReason } from "../../controller/Inclusion.js";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"A node excluded by another controller is removed from the node list",
+	{
+		testBody: async (t, driver, node, mockController) => {
+			const nodeRemoved = new Promise<RemoveNodeReason>((resolve) => {
+				driver.controller.once(
+					"node removed",
+					(removedNode, reason) => {
+						t.expect(removedNode).toBe(node);
+						resolve(reason);
+					},
+				);
+			});
+
+			await mockController.sendMessageToHost(
+				new ApplicationUpdateRequest({
+					updateType: ApplicationUpdateTypes.Node_Removed,
+					payload: Bytes.from([node.id, 0]),
+				}),
+			);
+
+			await t.expect(nodeRemoved).resolves.toBe(
+				RemoveNodeReason.ProxyExcluded,
+			);
+			t.expect(driver.controller.nodes.has(node.id)).toBe(false);
+		},
+	},
+);


### PR DESCRIPTION
Fixes #9143

`ApplicationUpdateRequestNodeRemoved` emitted the removal event but left the node in the controller map. Delete the node after the event so driver cleanup runs in the same order as normal exclusion.

The integration test sends the proxy-exclusion Serial API update. It verifies the `ProxyExcluded` event and the removal from `controller.nodes`.

Validation:
- `yarn test:ts packages/zwave-js/src/lib/test/node/proxyExclusionRemovesNode.test.ts`
- `yarn build`