### PR TITLE
fix: handle S0 Commands Supported Get on S2 nodes

### DIFF
--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -739,17 +739,6 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 
 	private alternativeNetworkKey?: BytesView;
 
-	public isEncapsulatingSecurityCommand(command: SecurityCommand): boolean {
-		if (this.encapsulated) {
-			return this.encapsulated.ccId === CommandClasses.Security
-				&& this.encapsulated.ccCommand === command;
-		}
-
-		return !this.sequenced
-			&& this.decryptedCCBytes?.[0] === CommandClasses.Security
-			&& this.decryptedCCBytes[1] === command;
-	}
-
 	public get nonceId(): number | undefined {
 		return this.nonce?.[0];
 	}

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -734,7 +734,7 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 	private secondFrame: boolean | undefined;
 	private sequenceCounter: number | undefined;
 
-	private decryptedCCBytes: BytesView | undefined;
+	public decryptedCCBytes: BytesView | undefined;
 	public encapsulated!: CommandClass;
 
 	private alternativeNetworkKey?: BytesView;

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -739,6 +739,17 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 
 	private alternativeNetworkKey?: BytesView;
 
+	public isEncapsulatingSecurityCommand(command: SecurityCommand): boolean {
+		if (this.encapsulated) {
+			return this.encapsulated.ccId === CommandClasses.Security
+				&& this.encapsulated.ccCommand === command;
+		}
+
+		return !this.sequenced
+			&& this.decryptedCCBytes?.[0] === CommandClasses.Security
+			&& this.decryptedCCBytes[1] === command;
+	}
+
 	public get nonceId(): number | undefined {
 		return this.nonce?.[0];
 	}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -32,7 +32,6 @@ import {
 	SecurityCCCommandEncapsulation,
 	SecurityCCCommandEncapsulationNonceGet,
 	SecurityCCCommandsSupportedGet,
-	SecurityCCCommandsSupportedReport,
 	SecurityCCNonceGet,
 	SecurityCCNonceReport,
 	SecurityCommand,
@@ -5650,10 +5649,12 @@ ${handlers.length} left`,
 					// CommandsSupportedReport is always accepted to be able to learn security classes and interview nodes
 					// CommandsSupportedGet is always accepted, so others can learn our security classes
 					if (
-						cmd.encapsulated
-							instanceof SecurityCCCommandsSupportedReport
-						|| cmd.encapsulated
-							instanceof SecurityCCCommandsSupportedGet
+						cmd.isEncapsulatingSecurityCommand(
+							SecurityCommand.CommandsSupportedReport,
+						)
+						|| cmd.isEncapsulatingSecurityCommand(
+							SecurityCommand.CommandsSupportedGet,
+						)
 					) {
 						return true;
 					}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5663,6 +5663,21 @@ ${handlers.length} left`,
 						return true;
 					}
 
+					// The same is true before the command has been assembled, when the encapsulated command
+					// is still only in binary form
+					if (
+						cmd.decryptedCCBytes
+						&& cmd.decryptedCCBytes[0] === CommandClasses.Security
+						&& [
+							SecurityCommand.CommandsSupportedGet,
+							SecurityCommand.CommandsSupportedReport,
+						].includes(
+							cmd.decryptedCCBytes[1],
+						)
+					) {
+						return true;
+					}
+
 					// Other S0 commands are only accepted if S0 is the highest security class
 					return secClass === SecurityClass.S0_Legacy;
 				}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -32,6 +32,7 @@ import {
 	SecurityCCCommandEncapsulation,
 	SecurityCCCommandEncapsulationNonceGet,
 	SecurityCCCommandsSupportedGet,
+	SecurityCCCommandsSupportedReport,
 	SecurityCCNonceGet,
 	SecurityCCNonceReport,
 	SecurityCommand,
@@ -4268,8 +4269,13 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				msg = completeMsg;
 
 				// Now that the command is complete, the checks that depend on the actual payload can be done
-				if (this.shouldDiscardCC(completeMsg.command)) {
-					this.driverLog.logMessage(msg, {
+				if (
+					// This includes re-checking the security level, because
+					// S0 encapsulated frames are only decrypted in assemblePartialCCs
+					this.isSecurityLevelTooLow(completeMsg.command)
+					|| this.shouldDiscardCC(completeMsg.command)
+				) {
+					this.driverLog.logMessage(completeMsg, {
 						direction: "inbound",
 						secondaryTags: ["discarded"],
 					});
@@ -5649,12 +5655,10 @@ ${handlers.length} left`,
 					// CommandsSupportedReport is always accepted to be able to learn security classes and interview nodes
 					// CommandsSupportedGet is always accepted, so others can learn our security classes
 					if (
-						cmd.isEncapsulatingSecurityCommand(
-							SecurityCommand.CommandsSupportedReport,
-						)
-						|| cmd.isEncapsulatingSecurityCommand(
-							SecurityCommand.CommandsSupportedGet,
-						)
+						cmd.encapsulated
+							instanceof SecurityCCCommandsSupportedReport
+						|| cmd.encapsulated
+							instanceof SecurityCCCommandsSupportedGet
 					) {
 						return true;
 					}

--- a/packages/zwave-js/src/lib/test/cc-specific/securityS0CommandsSupportedGet.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/securityS0CommandsSupportedGet.test.ts
@@ -99,3 +99,45 @@ integrationTest(
 		},
 	},
 );
+
+integrationTest(
+	"S0 Commands Supported Report is accepted from an S2-enabled node",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Security,
+				CommandClasses["Security 2"],
+			],
+			securityClasses: new Set([
+				SecurityClass.S2_Unauthenticated,
+				SecurityClass.S0_Legacy,
+			]),
+		},
+
+		additionalDriverOptions: {
+			testingHooks: {
+				skipNodeInterview: true,
+			},
+		},
+
+		testBody: async (t, _driver, node) => {
+			node.addCC(CommandClasses.Security, {
+				isSupported: true,
+				version: 1,
+			});
+			node.addCC(CommandClasses["Security 2"], {
+				isSupported: true,
+				version: 1,
+			});
+			node.setSecurityClass(SecurityClass.S0_Legacy, true);
+			node.setSecurityClass(SecurityClass.S2_Unauthenticated, true);
+
+			await t.expect(
+				node.commandClasses.Security.getSupportedCommands(),
+			).resolves.toStrictEqual({
+				supportedCCs: [],
+				controlledCCs: [],
+			});
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/cc-specific/securityS0CommandsSupportedGet.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/securityS0CommandsSupportedGet.test.ts
@@ -1,0 +1,101 @@
+import {
+	SecurityCC,
+	SecurityCCCommandEncapsulation,
+	SecurityCCCommandsSupportedGet,
+	SecurityCCCommandsSupportedReport,
+	SecurityCCNonceGet,
+	SecurityCCNonceReport,
+} from "@zwave-js/cc";
+import { CommandClasses, SecurityClass } from "@zwave-js/core";
+import {
+	type MockZWaveFrame,
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"S0 Commands Supported Get is answered on an S2-enabled node",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Security,
+				CommandClasses["Security 2"],
+			],
+			securityClasses: new Set([
+				SecurityClass.S2_AccessControl,
+				SecurityClass.S0_Legacy,
+			]),
+		},
+
+		additionalDriverOptions: {
+			testingHooks: {
+				skipNodeInterview: true,
+			},
+		},
+
+		testBody: async (_t, _driver, node, mockController, mockNode) => {
+			node.addCC(CommandClasses.Security, {
+				isSupported: true,
+				version: 1,
+			});
+			node.addCC(CommandClasses["Security 2"], {
+				isSupported: true,
+				version: 1,
+			});
+			node.setSecurityClass(SecurityClass.S0_Legacy, true);
+			node.setSecurityClass(SecurityClass.S2_AccessControl, true);
+
+			const nonceGet = new SecurityCCNonceGet({
+				nodeId: mockController.ownNodeId,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(nonceGet, {
+					ackRequested: false,
+				}),
+			);
+			const nonceReport = await mockNode.expectControllerFrame(
+				(
+					frame,
+				): frame is MockZWaveFrame & {
+					type: MockZWaveFrameType.Request;
+					payload: SecurityCCNonceReport;
+				} => frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof SecurityCCNonceReport,
+			);
+
+			mockNode.clearReceivedControllerFrames();
+
+			const command = SecurityCC.encapsulate(
+				mockNode.id,
+				mockNode.securityManagers.securityManager!,
+				new SecurityCCCommandsSupportedGet({
+					nodeId: mockController.ownNodeId,
+				}),
+			);
+			command.nonce = nonceReport.payload.nonce;
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(command, {
+					ackRequested: false,
+				}),
+			);
+			await wait(500);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload
+						instanceof SecurityCCCommandEncapsulation
+					&& frame.payload.encapsulated
+						instanceof SecurityCCCommandsSupportedReport
+					&& frame.payload.encapsulated.supportedCCs.length === 0
+					&& frame.payload.encapsulated.controlledCCs.length === 0,
+				{
+					errorMessage:
+						"Expected an empty S0 Commands Supported Report",
+				},
+			);
+		},
+	},
+);


### PR DESCRIPTION
## Root cause

S0 decryption authenticates the wrapper and stores the inner command as raw bytes. The inner command is parsed during partial CC assembly. The initial downgrade check runs before this step. Its typed Commands Supported exceptions therefore cannot match the incoming wrapper.

## Changes

- Expose the authenticated decrypted S0 payload for receive-path validation.
- Allow S0 Commands Supported Get and Report through the initial downgrade check when their raw command header matches.
- Re-run security-level validation after partial CC assembly has parsed the inner command.
- Cover both directions on nodes with S2 and S0 grants: an inbound S0 Get receives an empty Report and an S0 Report completes a controller query.

## Validation

- `yarn test:ts packages/zwave-js/src/lib/test/cc-specific/securityS0CommandsSupportedGet.test.ts` (2 tests)

Fixes #9141