### PR TITLE
fix(cc): handle Manufacturer Specific Device Specific Get

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -1247,9 +1247,10 @@ interface ZWaveOptions {
 		productId: number;
 		/**
 		 * A stable device identifier for Manufacturer Specific Device Specific Reports.
-		 * Prefix binary identifiers with "0x". The encoded identifier may be up to 31 bytes.
+		 * Strings are encoded as UTF-8. Uint8Arrays are encoded as binary.
+		 * The encoded identifier may be up to 31 bytes.
 		 */
-		deviceId?: string;
+		deviceId?: string | Uint8Array;
 
 		/** The version of the hardware the application is running on. Can be omitted if unknown. */
 		hardwareVersion?: number;

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -1245,6 +1245,11 @@ interface ZWaveOptions {
 		manufacturerId: number;
 		productType: number;
 		productId: number;
+		/**
+		 * A stable device identifier for Manufacturer Specific Device Specific Reports.
+		 * Prefix binary identifiers with "0x". The encoded identifier may be up to 31 bytes.
+		 */
+		deviceId?: string;
 
 		/** The version of the hardware the application is running on. Can be omitted if unknown. */
 		hardwareVersion?: number;

--- a/packages/cc/cc.api.md
+++ b/packages/cc/cc.api.md
@@ -12061,7 +12061,7 @@ export class ManufacturerSpecificCCDeviceSpecificReport extends ManufacturerSpec
 // @public (undocumented)
 export interface ManufacturerSpecificCCDeviceSpecificReportOptions {
     // (undocumented)
-    deviceId: string;
+    deviceId: string | Uint8Array;
     // (undocumented)
     type: DeviceIdType;
 }

--- a/packages/cc/cc.api.md
+++ b/packages/cc/cc.api.md
@@ -12024,7 +12024,7 @@ export class ManufacturerSpecificCCDeviceSpecificGet extends ManufacturerSpecifi
     // (undocumented)
     deviceIdType: DeviceIdType;
     // (undocumented)
-    static from(_raw: CCRaw, _ctx: CCParsingContext): ManufacturerSpecificCCDeviceSpecificGet;
+    static from(raw: CCRaw, ctx: CCParsingContext): ManufacturerSpecificCCDeviceSpecificGet;
     // (undocumented)
     serialize(ctx: CCEncodingContext): Promise<Bytes>;
     // (undocumented)
@@ -12048,6 +12048,8 @@ export class ManufacturerSpecificCCDeviceSpecificReport extends ManufacturerSpec
     readonly deviceId: string;
     // (undocumented)
     static from(raw: CCRaw, ctx: CCParsingContext): ManufacturerSpecificCCDeviceSpecificReport;
+    // (undocumented)
+    serialize(ctx: CCEncodingContext): Promise<Bytes>;
     // (undocumented)
     toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry;
     // (undocumented)

--- a/packages/cc/cc.api.md
+++ b/packages/cc/cc.api.md
@@ -12045,7 +12045,7 @@ export interface ManufacturerSpecificCCDeviceSpecificGetOptions {
 export class ManufacturerSpecificCCDeviceSpecificReport extends ManufacturerSpecificCC {
     constructor(options: WithAddress<ManufacturerSpecificCCDeviceSpecificReportOptions>);
     // (undocumented)
-    readonly deviceId: string;
+    readonly deviceId: string | Bytes;
     // (undocumented)
     static from(raw: CCRaw, ctx: CCParsingContext): ManufacturerSpecificCCDeviceSpecificReport;
     // (undocumented)

--- a/packages/cc/cc.api.md
+++ b/packages/cc/cc.api.md
@@ -5526,6 +5526,16 @@ export const defaultCCValueOptions: {
     readonly autoCreate: true;
 };
 
+// Warning: (ae-missing-release-tag) "DeviceIdDataFormat" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export enum DeviceIdDataFormat {
+    // (undocumented)
+    Binary = 1,
+    // (undocumented)
+    UTF8 = 0
+}
+
 // Warning: (ae-missing-release-tag) "DeviceIdType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/cc/src/cc/ManufacturerSpecificCC.ts
+++ b/packages/cc/src/cc/ManufacturerSpecificCC.ts
@@ -311,7 +311,7 @@ export class ManufacturerSpecificCCGet extends ManufacturerSpecificCC {}
 // @publicAPI
 export interface ManufacturerSpecificCCDeviceSpecificReportOptions {
 	type: DeviceIdType;
-	deviceId: string;
+	deviceId: string | Uint8Array;
 }
 
 @CCCommand(ManufacturerSpecificCommand.DeviceSpecificReport)
@@ -329,7 +329,15 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 		super(options);
 
 		this.type = options.type;
-		this.deviceId = options.deviceId;
+		if (typeof options.deviceId === "string") {
+			this.deviceId = options.deviceId;
+			this.deviceIdData = Bytes.from(options.deviceId, "utf8");
+			this.deviceIdDataFormat = 0;
+		} else {
+			this.deviceId = "0x" + Bytes.view(options.deviceId).toString("hex");
+			this.deviceIdData = Bytes.from(options.deviceId);
+			this.deviceIdDataFormat = 1;
+		}
 	}
 
 	public static from(
@@ -348,9 +356,9 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 			raw.payload.length >= 2 + dataLength,
 		);
 		const deviceIdData = raw.payload.subarray(2, 2 + dataLength);
-		const deviceId: string = dataFormat === 0
+		const deviceId: string | Uint8Array = dataFormat === 0
 			? deviceIdData.toString("utf8")
-			: "0x" + deviceIdData.toString("hex");
+			: deviceIdData;
 
 		return new this({
 			nodeId: ctx.sourceNodeId,
@@ -362,6 +370,8 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 	public readonly type: DeviceIdType;
 
 	public readonly deviceId: string;
+	private readonly deviceIdData: Bytes;
+	private readonly deviceIdDataFormat: 0 | 1;
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		if (
@@ -374,31 +384,9 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 			);
 		}
 
-		const isBinary = this.deviceId.startsWith("0x");
-		const encodedDeviceId = isBinary
-			? this.deviceId.slice(2)
-			: this.deviceId;
-
-		if (
-			isBinary
-			&& (
-				encodedDeviceId.length % 2 !== 0
-				|| !/^[0-9a-f]*$/i.test(encodedDeviceId)
-			)
-		) {
+		if (this.deviceIdData.length < 1 || this.deviceIdData.length > 31) {
 			throw new ZWaveError(
-				`deviceId must be a valid hexadecimal string, received "${this.deviceId}"`,
-				ZWaveErrorCodes.Argument_Invalid,
-			);
-		}
-
-		const deviceIdData = Bytes.from(
-			encodedDeviceId,
-			isBinary ? "hex" : "utf8",
-		);
-		if (deviceIdData.length < 1 || deviceIdData.length > 31) {
-			throw new ZWaveError(
-				`deviceId must encode to between 1 and 31 bytes, received ${deviceIdData.length}`,
+				`deviceId must encode to between 1 and 31 bytes, received ${this.deviceIdData.length}`,
 				ZWaveErrorCodes.Argument_Invalid,
 			);
 		}
@@ -406,9 +394,9 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 		this.payload = Bytes.concat([
 			[
 				this.type & 0b111,
-				(isBinary ? 0b001_00000 : 0) | deviceIdData.length,
+				(this.deviceIdDataFormat << 5) | this.deviceIdData.length,
 			],
-			deviceIdData,
+			this.deviceIdData,
 		]);
 		return super.serialize(ctx);
 	}

--- a/packages/cc/src/cc/ManufacturerSpecificCC.ts
+++ b/packages/cc/src/cc/ManufacturerSpecificCC.ts
@@ -376,13 +376,14 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 			? Bytes.from(this.deviceId, "utf8")
 			: this.deviceId;
 
+		const format = typeof this.deviceId === "string"
+			? DeviceIdDataFormat.UTF8
+			: DeviceIdDataFormat.Binary;
 		const length = Math.min(deviceIdData.length, 0b11111);
 		this.payload = Bytes.concat([
 			[
 				this.type & 0b111,
-				(typeof this.deviceId === "string"
-						? DeviceIdDataFormat.UTF8
-						: DeviceIdDataFormat.Binary) << 5
+				format << 5
 				| length,
 			],
 			deviceIdData.subarray(0, length),

--- a/packages/cc/src/cc/ManufacturerSpecificCC.ts
+++ b/packages/cc/src/cc/ManufacturerSpecificCC.ts
@@ -158,6 +158,23 @@ export class ManufacturerSpecificCCAPI extends PhysicalCCAPI {
 		});
 		await this.host.sendCommand(cc, this.commandOptions);
 	}
+
+	@validateArgs()
+	public async sendDeviceSpecificReport(
+		options: ManufacturerSpecificCCDeviceSpecificReportOptions,
+	): Promise<void> {
+		this.assertSupportsCommand(
+			ManufacturerSpecificCommand,
+			ManufacturerSpecificCommand.DeviceSpecificReport,
+		);
+
+		const cc = new ManufacturerSpecificCCDeviceSpecificReport({
+			nodeId: this.endpoint.nodeId,
+			endpointIndex: this.endpoint.index,
+			...options,
+		});
+		await this.host.sendCommand(cc, this.commandOptions);
+	}
 }
 
 @commandClass(CommandClasses["Manufacturer Specific"])
@@ -311,7 +328,6 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 	) {
 		super(options);
 
-		// TODO: Check implementation:
 		this.type = options.type;
 		this.deviceId = options.deviceId;
 	}
@@ -324,7 +340,13 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 		const type: DeviceIdType = raw.payload[0] & 0b111;
 		const dataFormat = raw.payload[1] >>> 5;
 		const dataLength = raw.payload[1] & 0b11111;
-		validatePayload(dataLength > 0, raw.payload.length >= 2 + dataLength);
+		validatePayload(
+			type === DeviceIdType.SerialNumber
+				|| type === DeviceIdType.PseudoRandom,
+			dataFormat <= 1,
+			dataLength > 0,
+			raw.payload.length >= 2 + dataLength,
+		);
 		const deviceIdData = raw.payload.subarray(2, 2 + dataLength);
 		const deviceId: string = dataFormat === 0
 			? deviceIdData.toString("utf8")
@@ -340,6 +362,56 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 	public readonly type: DeviceIdType;
 
 	public readonly deviceId: string;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		if (
+			this.type !== DeviceIdType.SerialNumber
+			&& this.type !== DeviceIdType.PseudoRandom
+		) {
+			throw new ZWaveError(
+				`type must be SerialNumber or PseudoRandom, received ${this.type}`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
+		const isBinary = this.deviceId.startsWith("0x");
+		const encodedDeviceId = isBinary
+			? this.deviceId.slice(2)
+			: this.deviceId;
+
+		if (
+			isBinary
+			&& (
+				encodedDeviceId.length % 2 !== 0
+				|| !/^[0-9a-f]*$/i.test(encodedDeviceId)
+			)
+		) {
+			throw new ZWaveError(
+				`deviceId must be a valid hexadecimal string, received "${this.deviceId}"`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
+		const deviceIdData = Bytes.from(
+			encodedDeviceId,
+			isBinary ? "hex" : "utf8",
+		);
+		if (deviceIdData.length < 1 || deviceIdData.length > 31) {
+			throw new ZWaveError(
+				`deviceId must encode to between 1 and 31 bytes, received ${deviceIdData.length}`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
+		this.payload = Bytes.concat([
+			[
+				this.type & 0b111,
+				(isBinary ? 0b001_00000 : 0) | deviceIdData.length,
+			],
+			deviceIdData,
+		]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
@@ -370,17 +442,16 @@ export class ManufacturerSpecificCCDeviceSpecificGet
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): ManufacturerSpecificCCDeviceSpecificGet {
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
+		validatePayload(raw.payload.length >= 1);
+		const deviceIdType: DeviceIdType = raw.payload[0] & 0b111;
 
-		// return new ManufacturerSpecificCCDeviceSpecificGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			deviceIdType,
+		});
 	}
 
 	public deviceIdType: DeviceIdType;

--- a/packages/cc/src/cc/ManufacturerSpecificCC.ts
+++ b/packages/cc/src/cc/ManufacturerSpecificCC.ts
@@ -6,8 +6,7 @@ import {
 	MessagePriority,
 	ValueMetadata,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
+	logBuffer,
 	validatePayload,
 } from "@zwave-js/core";
 import { Bytes, getEnumMemberName, num2hex, pick } from "@zwave-js/shared";
@@ -368,33 +367,18 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 	public readonly deviceId: string | Bytes;
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
-		if (
-			this.type !== DeviceIdType.SerialNumber
-			&& this.type !== DeviceIdType.PseudoRandom
-		) {
-			throw new ZWaveError(
-				`type must be SerialNumber or PseudoRandom, received ${this.type}`,
-				ZWaveErrorCodes.Argument_Invalid,
-			);
-		}
-
 		const deviceIdData = typeof this.deviceId === "string"
 			? Bytes.from(this.deviceId, "utf8")
 			: this.deviceId;
-		if (deviceIdData.length < 1 || deviceIdData.length > 31) {
-			throw new ZWaveError(
-				`deviceId must encode to between 1 and 31 bytes, received ${deviceIdData.length}`,
-				ZWaveErrorCodes.Argument_Invalid,
-			);
-		}
 
+		const length = Math.min(deviceIdData.length, 0b11111);
 		this.payload = Bytes.concat([
 			[
 				this.type & 0b111,
 				(typeof this.deviceId === "string" ? 0 : 0b001_00000)
-				| deviceIdData.length,
+				| length,
 			],
-			deviceIdData,
+			deviceIdData.subarray(0, length),
 		]);
 		return super.serialize(ctx);
 	}
@@ -406,7 +390,7 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 				"device id type": getEnumMemberName(DeviceIdType, this.type),
 				"device id": typeof this.deviceId === "string"
 					? this.deviceId
-					: "0x" + this.deviceId.toString("hex"),
+					: logBuffer(this.deviceId),
 			},
 		};
 	}

--- a/packages/cc/src/cc/ManufacturerSpecificCC.ts
+++ b/packages/cc/src/cc/ManufacturerSpecificCC.ts
@@ -27,7 +27,11 @@ import {
 	implementedVersion,
 } from "../lib/CommandClassDecorators.js";
 import { V } from "../lib/Values.js";
-import { DeviceIdType, ManufacturerSpecificCommand } from "../lib/_Types.js";
+import {
+	DeviceIdDataFormat,
+	DeviceIdType,
+	ManufacturerSpecificCommand,
+} from "../lib/_Types.js";
 import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
 
 export const ManufacturerSpecificCCValues = V.defineCCValues(
@@ -341,17 +345,18 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 	): ManufacturerSpecificCCDeviceSpecificReport {
 		validatePayload(raw.payload.length >= 2);
 		const type: DeviceIdType = raw.payload[0] & 0b111;
-		const dataFormat = raw.payload[1] >>> 5;
+		const dataFormat: DeviceIdDataFormat = raw.payload[1] >>> 5;
 		const dataLength = raw.payload[1] & 0b11111;
 		validatePayload(
 			type === DeviceIdType.SerialNumber
 				|| type === DeviceIdType.PseudoRandom,
-			dataFormat <= 1,
+			dataFormat === DeviceIdDataFormat.UTF8
+				|| dataFormat === DeviceIdDataFormat.Binary,
 			dataLength > 0,
 			raw.payload.length >= 2 + dataLength,
 		);
 		const deviceIdData = raw.payload.subarray(2, 2 + dataLength);
-		const deviceId: string | Bytes = dataFormat === 0
+		const deviceId: string | Bytes = dataFormat === DeviceIdDataFormat.UTF8
 			? deviceIdData.toString("utf8")
 			: deviceIdData;
 
@@ -375,7 +380,9 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 		this.payload = Bytes.concat([
 			[
 				this.type & 0b111,
-				(typeof this.deviceId === "string" ? 0 : 0b001_00000)
+				(typeof this.deviceId === "string"
+						? DeviceIdDataFormat.UTF8
+						: DeviceIdDataFormat.Binary) << 5
 				| length,
 			],
 			deviceIdData.subarray(0, length),

--- a/packages/cc/src/cc/ManufacturerSpecificCC.ts
+++ b/packages/cc/src/cc/ManufacturerSpecificCC.ts
@@ -122,7 +122,7 @@ export class ManufacturerSpecificCCAPI extends PhysicalCCAPI {
 	@validateArgs()
 	public async deviceSpecificGet(
 		deviceIdType: DeviceIdType,
-	): Promise<MaybeNotKnown<string>> {
+	): Promise<MaybeNotKnown<string | Bytes>> {
 		this.assertSupportsCommand(
 			ManufacturerSpecificCommand,
 			ManufacturerSpecificCommand.DeviceSpecificGet,
@@ -331,12 +331,8 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 		this.type = options.type;
 		if (typeof options.deviceId === "string") {
 			this.deviceId = options.deviceId;
-			this.deviceIdData = Bytes.from(options.deviceId, "utf8");
-			this.deviceIdDataFormat = 0;
 		} else {
-			this.deviceId = "0x" + Bytes.view(options.deviceId).toString("hex");
-			this.deviceIdData = Bytes.from(options.deviceId);
-			this.deviceIdDataFormat = 1;
+			this.deviceId = Bytes.from(options.deviceId);
 		}
 	}
 
@@ -356,7 +352,7 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 			raw.payload.length >= 2 + dataLength,
 		);
 		const deviceIdData = raw.payload.subarray(2, 2 + dataLength);
-		const deviceId: string | Uint8Array = dataFormat === 0
+		const deviceId: string | Bytes = dataFormat === 0
 			? deviceIdData.toString("utf8")
 			: deviceIdData;
 
@@ -369,9 +365,7 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 
 	public readonly type: DeviceIdType;
 
-	public readonly deviceId: string;
-	private readonly deviceIdData: Bytes;
-	private readonly deviceIdDataFormat: 0 | 1;
+	public readonly deviceId: string | Bytes;
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		if (
@@ -384,9 +378,12 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 			);
 		}
 
-		if (this.deviceIdData.length < 1 || this.deviceIdData.length > 31) {
+		const deviceIdData = typeof this.deviceId === "string"
+			? Bytes.from(this.deviceId, "utf8")
+			: this.deviceId;
+		if (deviceIdData.length < 1 || deviceIdData.length > 31) {
 			throw new ZWaveError(
-				`deviceId must encode to between 1 and 31 bytes, received ${this.deviceIdData.length}`,
+				`deviceId must encode to between 1 and 31 bytes, received ${deviceIdData.length}`,
 				ZWaveErrorCodes.Argument_Invalid,
 			);
 		}
@@ -394,9 +391,10 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 		this.payload = Bytes.concat([
 			[
 				this.type & 0b111,
-				(this.deviceIdDataFormat << 5) | this.deviceIdData.length,
+				(typeof this.deviceId === "string" ? 0 : 0b001_00000)
+				| deviceIdData.length,
 			],
-			this.deviceIdData,
+			deviceIdData,
 		]);
 		return super.serialize(ctx);
 	}
@@ -406,7 +404,9 @@ export class ManufacturerSpecificCCDeviceSpecificReport
 			...super.toLogEntry(ctx),
 			message: {
 				"device id type": getEnumMemberName(DeviceIdType, this.type),
-				"device id": this.deviceId,
+				"device id": typeof this.deviceId === "string"
+					? this.deviceId
+					: "0x" + this.deviceId.toString("hex"),
 			},
 		};
 	}

--- a/packages/cc/src/lib/_Types.ts
+++ b/packages/cc/src/lib/_Types.ts
@@ -1035,6 +1035,11 @@ export enum DeviceIdType {
 	PseudoRandom = 0x02,
 }
 
+export enum DeviceIdDataFormat {
+	UTF8 = 0x00,
+	Binary = 0x01,
+}
+
 export enum MeterCommand {
 	Get = 0x01,
 	Report = 0x02,

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -459,6 +459,11 @@ export interface ZWaveOptions {
 		manufacturerId: number;
 		productType: number;
 		productId: number;
+		/**
+		 * A stable device identifier for Manufacturer Specific Device Specific Reports.
+		 * Prefix binary identifiers with "0x". The encoded identifier may be up to 31 bytes.
+		 */
+		deviceId?: string;
 
 		/** The version of the hardware the application is running on. Can be omitted if unknown. */
 		hardwareVersion?: number;

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -461,9 +461,10 @@ export interface ZWaveOptions {
 		productId: number;
 		/**
 		 * A stable device identifier for Manufacturer Specific Device Specific Reports.
-		 * Prefix binary identifiers with "0x". The encoded identifier may be up to 31 bytes.
+		 * Strings are encoded as UTF-8. Uint8Arrays are encoded as binary.
+		 * The encoded identifier may be up to 31 bytes.
 		 */
-		deviceId?: string;
+		deviceId?: string | Uint8Array;
 
 		/** The version of the hardware the application is running on. Can be omitted if unknown. */
 		hardwareVersion?: number;

--- a/packages/zwave-js/src/lib/node/CCHandlers/ManufacturerSpecificCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/ManufacturerSpecificCC.ts
@@ -1,6 +1,8 @@
-import type {
-	ManufacturerSpecificCCGet,
-	PersistValuesContext,
+import {
+	DeviceIdType,
+	type ManufacturerSpecificCCDeviceSpecificGet,
+	type ManufacturerSpecificCCGet,
+	type PersistValuesContext,
 } from "@zwave-js/cc";
 import {
 	CommandClasses,
@@ -32,5 +34,34 @@ export async function handleManufacturerSpecificGet(
 		manufacturerId: vendorInfo?.manufacturerId ?? 0xffff,
 		productType: vendorInfo?.productType ?? 0xffff,
 		productId: vendorInfo?.productId ?? 0xffff,
+	});
+}
+
+export async function handleManufacturerSpecificDeviceSpecificGet(
+	ctx: PersistValuesContext & LogNode,
+	node: ZWaveNode,
+	command: ManufacturerSpecificCCDeviceSpecificGet,
+	vendorInfo: ZWaveOptions["vendor"],
+): Promise<void> {
+	if (!vendorInfo?.deviceId) {
+		ctx.logNode(node.id, {
+			message:
+				"Cannot respond to Device Specific Get because no vendor device ID is configured",
+			direction: "none",
+			level: "warn",
+		});
+		return;
+	}
+
+	const api = node
+		.createAPI(CommandClasses["Manufacturer Specific"], false)
+		.withOptions({
+			encapsulationFlags: command.encapsulationFlags
+				& ~EncapsulationFlags.Supervision,
+		});
+
+	await api.sendDeviceSpecificReport({
+		type: DeviceIdType.SerialNumber,
+		deviceId: vendorInfo.deviceId,
 	});
 }

--- a/packages/zwave-js/src/lib/node/CCHandlers/ManufacturerSpecificCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/ManufacturerSpecificCC.ts
@@ -8,6 +8,7 @@ import {
 	CommandClasses,
 	EncapsulationFlags,
 	type LogNode,
+	randomBytes,
 } from "@zwave-js/core";
 import type { ZWaveOptions } from "../../driver/ZWaveOptions.js";
 import type { ZWaveNode } from "../Node.js";
@@ -43,16 +44,6 @@ export async function handleManufacturerSpecificDeviceSpecificGet(
 	command: ManufacturerSpecificCCDeviceSpecificGet,
 	vendorInfo: ZWaveOptions["vendor"],
 ): Promise<void> {
-	if (!vendorInfo?.deviceId) {
-		ctx.logNode(node.id, {
-			message:
-				"Cannot respond to Device Specific Get because no vendor device ID is configured",
-			direction: "none",
-			level: "warn",
-		});
-		return;
-	}
-
 	const api = node
 		.createAPI(CommandClasses["Manufacturer Specific"], false)
 		.withOptions({
@@ -61,7 +52,9 @@ export async function handleManufacturerSpecificDeviceSpecificGet(
 		});
 
 	await api.sendDeviceSpecificReport({
-		type: DeviceIdType.SerialNumber,
-		deviceId: vendorInfo.deviceId,
+		type: vendorInfo?.deviceId
+			? DeviceIdType.SerialNumber
+			: DeviceIdType.PseudoRandom,
+		deviceId: vendorInfo?.deviceId ?? randomBytes(16),
 	});
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -58,7 +58,10 @@ import {
 	FirmwareUpdateMetaDataCCRequestGet,
 } from "@zwave-js/cc/FirmwareUpdateMetaDataCC";
 import { HailCC } from "@zwave-js/cc/HailCC";
-import { ManufacturerSpecificCCGet } from "@zwave-js/cc/ManufacturerSpecificCC";
+import {
+	ManufacturerSpecificCCDeviceSpecificGet,
+	ManufacturerSpecificCCGet,
+} from "@zwave-js/cc/ManufacturerSpecificCC";
 import { MultilevelSwitchCC } from "@zwave-js/cc/MultilevelSwitchCC";
 import { NodeNamingAndLocationCCValues } from "@zwave-js/cc/NodeNamingCC";
 import { NotificationCCReport } from "@zwave-js/cc/NotificationCC";
@@ -219,7 +222,10 @@ import {
 	handleIndicatorSet,
 	handleIndicatorSupportedGet,
 } from "./CCHandlers/IndicatorCC.js";
-import { handleManufacturerSpecificGet } from "./CCHandlers/ManufacturerSpecificCC.js";
+import {
+	handleManufacturerSpecificDeviceSpecificGet,
+	handleManufacturerSpecificGet,
+} from "./CCHandlers/ManufacturerSpecificCC.js";
 import {
 	handleMultiChannelAssociationGet,
 	handleMultiChannelAssociationRemove,
@@ -2946,6 +2952,15 @@ protocol version:      ${this.protocolVersion}`;
 			);
 		} else if (command instanceof VersionCCCapabilitiesGet) {
 			return handleVersionCapabilitiesGet(this.driver, this, command);
+		} else if (
+			command instanceof ManufacturerSpecificCCDeviceSpecificGet
+		) {
+			return handleManufacturerSpecificDeviceSpecificGet(
+				this.driver,
+				this,
+				command,
+				this.driver.options.vendor,
+			);
 		} else if (command instanceof ManufacturerSpecificCCGet) {
 			return handleManufacturerSpecificGet(
 				this.driver,

--- a/packages/zwave-js/src/lib/test/cc-specific/manufacturerSpecificDeviceSpecificGet.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/manufacturerSpecificDeviceSpecificGet.test.ts
@@ -3,6 +3,7 @@ import {
 	ManufacturerSpecificCCDeviceSpecificGet,
 	ManufacturerSpecificCCDeviceSpecificReport,
 } from "@zwave-js/cc";
+import { Bytes } from "@zwave-js/shared";
 import {
 	MockZWaveFrameType,
 	type MockZWaveRequestFrame,
@@ -86,7 +87,9 @@ integrationTest(
 			);
 
 			t.expect(response.type).toBe(DeviceIdType.SerialNumber);
-			t.expect(response.deviceId).toBe("0x12345678");
+			t.expect(response.deviceId).toStrictEqual(
+				Bytes.from([0x12, 0x34, 0x56, 0x78]),
+			);
 		},
 	},
 );
@@ -115,7 +118,8 @@ integrationTest(
 			);
 
 			t.expect(response.type).toBe(DeviceIdType.PseudoRandom);
-			t.expect(response.deviceId).toMatch(/^0x[0-9a-f]{32}$/);
+			t.expect(response.deviceId).toBeInstanceOf(Bytes);
+			t.expect(response.deviceId).toHaveLength(16);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/cc-specific/manufacturerSpecificDeviceSpecificGet.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/manufacturerSpecificDeviceSpecificGet.test.ts
@@ -1,0 +1,54 @@
+import {
+	DeviceIdType,
+	ManufacturerSpecificCCDeviceSpecificGet,
+	ManufacturerSpecificCCDeviceSpecificReport,
+} from "@zwave-js/cc";
+import {
+	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { integrationTest } from "../integrationTestSuite.js";
+
+const vendor = {
+	manufacturerId: 0x1234,
+	productType: 0x5678,
+	productId: 0x9abc,
+	deviceId: "0x1234567890abcdef",
+};
+
+integrationTest("Responses to Manufacturer Specific Device Specific Get", {
+	additionalDriverOptions: { vendor },
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		for (
+			const deviceIdType of [
+				DeviceIdType.FactoryDefault,
+				DeviceIdType.SerialNumber,
+				DeviceIdType.PseudoRandom,
+			]
+		) {
+			const request = new ManufacturerSpecificCCDeviceSpecificGet({
+				nodeId: mockController.ownNodeId,
+				deviceIdType,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(request),
+			);
+
+			const { payload: response } = await mockNode.expectControllerFrame(
+				(
+					frame,
+				): frame is MockZWaveRequestFrame & {
+					payload: ManufacturerSpecificCCDeviceSpecificReport;
+				} => frame.type === MockZWaveFrameType.Request
+					&& frame.payload
+						instanceof ManufacturerSpecificCCDeviceSpecificReport,
+				{ timeout: 1000 },
+			);
+
+			t.expect(response.type).toBe(DeviceIdType.SerialNumber);
+			t.expect(response.deviceId).toBe(vendor.deviceId);
+		}
+	},
+});

--- a/packages/zwave-js/src/lib/test/cc-specific/manufacturerSpecificDeviceSpecificGet.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/manufacturerSpecificDeviceSpecificGet.test.ts
@@ -10,15 +10,15 @@ import {
 } from "@zwave-js/testing";
 import { integrationTest } from "../integrationTestSuite.js";
 
-const vendor = {
+const vendorWithStringDeviceId = {
 	manufacturerId: 0x1234,
 	productType: 0x5678,
 	productId: 0x9abc,
-	deviceId: "0x1234567890abcdef",
+	deviceId: "test-device-id",
 };
 
-integrationTest("Responses to Manufacturer Specific Device Specific Get", {
-	additionalDriverOptions: { vendor },
+integrationTest("Device Specific Get returns a configured string device ID", {
+	additionalDriverOptions: { vendor: vendorWithStringDeviceId },
 
 	testBody: async (t, driver, node, mockController, mockNode) => {
 		for (
@@ -48,7 +48,74 @@ integrationTest("Responses to Manufacturer Specific Device Specific Get", {
 			);
 
 			t.expect(response.type).toBe(DeviceIdType.SerialNumber);
-			t.expect(response.deviceId).toBe(vendor.deviceId);
+			t.expect(response.deviceId).toBe(
+				vendorWithStringDeviceId.deviceId,
+			);
 		}
 	},
 });
+
+integrationTest(
+	"Device Specific Get returns a configured binary device ID",
+	{
+		additionalDriverOptions: {
+			vendor: {
+				...vendorWithStringDeviceId,
+				deviceId: Uint8Array.from([0x12, 0x34, 0x56, 0x78]),
+			},
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const request = new ManufacturerSpecificCCDeviceSpecificGet({
+				nodeId: mockController.ownNodeId,
+				deviceIdType: DeviceIdType.FactoryDefault,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(request),
+			);
+
+			const { payload: response } = await mockNode.expectControllerFrame(
+				(
+					frame,
+				): frame is MockZWaveRequestFrame & {
+					payload: ManufacturerSpecificCCDeviceSpecificReport;
+				} => frame.type === MockZWaveFrameType.Request
+					&& frame.payload
+						instanceof ManufacturerSpecificCCDeviceSpecificReport,
+				{ timeout: 1000 },
+			);
+
+			t.expect(response.type).toBe(DeviceIdType.SerialNumber);
+			t.expect(response.deviceId).toBe("0x12345678");
+		},
+	},
+);
+
+integrationTest(
+	"Device Specific Get returns a pseudo-random fallback device ID",
+	{
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const request = new ManufacturerSpecificCCDeviceSpecificGet({
+				nodeId: mockController.ownNodeId,
+				deviceIdType: DeviceIdType.FactoryDefault,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(request),
+			);
+
+			const { payload: response } = await mockNode.expectControllerFrame(
+				(
+					frame,
+				): frame is MockZWaveRequestFrame & {
+					payload: ManufacturerSpecificCCDeviceSpecificReport;
+				} => frame.type === MockZWaveFrameType.Request
+					&& frame.payload
+						instanceof ManufacturerSpecificCCDeviceSpecificReport,
+				{ timeout: 1000 },
+			);
+
+			t.expect(response.type).toBe(DeviceIdType.PseudoRandom);
+			t.expect(response.deviceId).toMatch(/^0x[0-9a-f]{32}$/);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/cc/ManufacturerSpecificCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ManufacturerSpecificCC.test.ts
@@ -1,5 +1,8 @@
 import {
 	CommandClass,
+	DeviceIdType,
+	ManufacturerSpecificCCDeviceSpecificGet,
+	ManufacturerSpecificCCDeviceSpecificReport,
 	ManufacturerSpecificCCGet,
 	ManufacturerSpecificCCReport,
 	ManufacturerSpecificCommand,
@@ -50,4 +53,41 @@ test("the Report command (v1) should be deserialized correctly", async (t) => {
 	t.expect(cc.manufacturerId).toBe(0x0102);
 	t.expect(cc.productType).toBe(0x0304);
 	t.expect(cc.productId).toBe(0x0506);
+});
+
+test("the Device Specific Get command should be deserialized correctly", async (t) => {
+	const ccData = buildCCBuffer(
+		Uint8Array.from([
+			ManufacturerSpecificCommand.DeviceSpecificGet,
+			DeviceIdType.PseudoRandom,
+		]),
+	);
+	const cc = await CommandClass.parse(
+		ccData,
+		{ sourceNodeId: 2 } as any,
+	) as ManufacturerSpecificCCDeviceSpecificGet;
+
+	t.expect(cc.constructor).toBe(ManufacturerSpecificCCDeviceSpecificGet);
+	t.expect(cc.deviceIdType).toBe(DeviceIdType.PseudoRandom);
+});
+
+test("the Device Specific Report command should serialize a binary ID correctly", async (t) => {
+	const cc = new ManufacturerSpecificCCDeviceSpecificReport({
+		nodeId: 1,
+		type: DeviceIdType.SerialNumber,
+		deviceId: "0x12345678",
+	});
+	const expected = buildCCBuffer(
+		Uint8Array.from([
+			ManufacturerSpecificCommand.DeviceSpecificReport,
+			DeviceIdType.SerialNumber,
+			0b001_00100,
+			0x12,
+			0x34,
+			0x56,
+			0x78,
+		]),
+	);
+
+	await t.expect(cc.serialize({} as any)).resolves.toStrictEqual(expected);
 });

--- a/packages/zwave-js/src/lib/test/cc/ManufacturerSpecificCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ManufacturerSpecificCC.test.ts
@@ -75,7 +75,7 @@ test("the Device Specific Report command should serialize a binary ID correctly"
 	const cc = new ManufacturerSpecificCCDeviceSpecificReport({
 		nodeId: 1,
 		type: DeviceIdType.SerialNumber,
-		deviceId: "0x12345678",
+		deviceId: Uint8Array.from([0x12, 0x34, 0x56, 0x78]),
 	});
 	const expected = buildCCBuffer(
 		Uint8Array.from([
@@ -86,6 +86,27 @@ test("the Device Specific Report command should serialize a binary ID correctly"
 			0x34,
 			0x56,
 			0x78,
+		]),
+	);
+
+	await t.expect(cc.serialize({} as any)).resolves.toStrictEqual(expected);
+});
+
+test("the Device Specific Report command should serialize a string ID as UTF-8", async (t) => {
+	const cc = new ManufacturerSpecificCCDeviceSpecificReport({
+		nodeId: 1,
+		type: DeviceIdType.SerialNumber,
+		deviceId: "0x12",
+	});
+	const expected = buildCCBuffer(
+		Uint8Array.from([
+			ManufacturerSpecificCommand.DeviceSpecificReport,
+			DeviceIdType.SerialNumber,
+			0b000_00100,
+			0x30,
+			0x78,
+			0x31,
+			0x32,
 		]),
 	);
 

--- a/packages/zwave-js/zwave-js.api.md
+++ b/packages/zwave-js/zwave-js.api.md
@@ -3303,6 +3303,7 @@ export interface ZWaveOptions {
         manufacturerId: number;
         productType: number;
         productId: number;
+        deviceId?: string;
         hardwareVersion?: number;
         installerIcon?: number;
         userIcon?: number;

--- a/packages/zwave-js/zwave-js.api.md
+++ b/packages/zwave-js/zwave-js.api.md
@@ -3303,7 +3303,7 @@ export interface ZWaveOptions {
         manufacturerId: number;
         productType: number;
         productId: number;
-        deviceId?: string;
+        deviceId?: string | Uint8Array;
         hardwareVersion?: number;
         installerIcon?: number;
         userIcon?: number;


### PR DESCRIPTION
Fixes #9144

## Root cause

`ManufacturerSpecificCCDeviceSpecificGet.from()` always threw `Deserialization_NotImplemented`. The node command dispatcher also handled only the v1 Manufacturer Specific Get. A received Device Specific Get was dropped before the application could answer it.

## Changes

- Deserialize Device Specific Get commands and validate Device Specific Report fields.
- Serialize string IDs as UTF-8 and `Uint8Array` IDs as binary data.
- Return a configured `vendor.deviceId` as the Serial Number.
- Return a 16-byte binary Pseudo Random ID when no device ID is configured.
- Cover raw inbound receipt and response handling with integration regressions. Add focused command serialization and deserialization tests.

## Validation

- `yarn test:ts packages/zwave-js/src/lib/test/cc/ManufacturerSpecificCC.test.ts packages/zwave-js/src/lib/test/cc-specific/manufacturerSpecificDeviceSpecificGet.test.ts`
- `yarn build`
- `yarn fmt`