### PR TITLE
feat(config): add Simon 100 Battery Master Roller Blind

### DIFF
--- a/packages/config/config/devices/0x0267/10002181-13x.json
+++ b/packages/config/config/devices/0x0267/10002181-13x.json
@@ -30,11 +30,11 @@
 			"writeOnly": true,
 			"options": [
 				{
-					"label": "Parameters, groups, and Z-Wave status are restored to default",
+					"label": "Reset parameters, groups, and Z-Wave status to default",
 					"value": 39015
 				},
 				{
-					"label": "Parameters, except lock long press are restored to default",
+					"label": "Reset parameters, except lock long press",
 					"value": 17170
 				}
 			]
@@ -95,9 +95,9 @@
 		}
 	],
 	"metadata": {
-		"inclusion": "Set the Z-Wave Controller to inclusion mode.\nPress the button for between 2 and 10 seconds.",
-		"exclusion": "Set the Z-Wave Controller to exclusion mode.\nPress the button for between 2 and 10 seconds.",
-		"reset": "Press and hold the button for between 30 and 33 seconds to restore factory defaults.",
+		"inclusion": "Press the button for between 2 and 10 seconds.",
+		"exclusion": "Press the button for between 2 and 10 seconds.",
+		"reset": "Press and hold the button for between 30 and 33 seconds.",
 		"manual": "https://www.simonelectric.com/es-es/10002181-230-tecla-master-simon-io-persianas-bateria-blanco-mate-simon-100"
 	}
 }

--- a/packages/config/config/devices/0x0267/10002181-13x.json
+++ b/packages/config/config/devices/0x0267/10002181-13x.json
@@ -1,0 +1,103 @@
+{
+	"manufacturer": "SimonTech S.L.U",
+	"manufacturerId": "0x0267",
+	"label": "10002181-13x",
+	"description": "Simon 100: Battery Master Roller Blind",
+	"devices": [
+		{
+			"productType": "0x0006",
+			"productId": "0x0000"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "13",
+			"$import": "~/templates/master_template.json#base_enable_disable_255",
+			"label": "Buttons Lock"
+		},
+		{
+			"#": "15",
+			"label": "Reset to Default",
+			"valueSize": 2,
+			"minValue": 17170,
+			"maxValue": 39015,
+			"defaultValue": 39015,
+			"unsigned": true,
+			"writeOnly": true,
+			"options": [
+				{
+					"label": "Parameters, groups, and Z-Wave status are restored to default",
+					"value": 39015
+				},
+				{
+					"label": "Parameters, except lock long press are restored to default",
+					"value": 17170
+				}
+			]
+		},
+		{
+			"#": "18",
+			"$import": "~/templates/master_template.json#base_enable_disable_255",
+			"label": "Manual Association Lock"
+		},
+		{
+			"#": "19",
+			"label": "Short Press Action",
+			"valueSize": 1,
+			"defaultValue": 7,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Toggle on/off",
+					"value": 0
+				},
+				{
+					"label": "Turn on",
+					"value": 1
+				},
+				{
+					"label": "Turn off",
+					"value": 2
+				},
+				{
+					"label": "Roller blind up/down/stop",
+					"value": 7
+				}
+			]
+		},
+		{
+			"#": "27",
+			"$import": "~/templates/master_template.json#base_enable_disable_255",
+			"label": "Long Press Lock",
+			"description": "Prevents sending Node Info on a long press (2-10 seconds)"
+		},
+		{
+			"#": "29",
+			"label": "No Associated Devices Mode",
+			"valueSize": 1,
+			"defaultValue": 255,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Send error signal",
+					"value": 0
+				},
+				{
+					"label": "Send Central Scene Notification",
+					"value": 255
+				}
+			]
+		}
+	],
+	"metadata": {
+		"inclusion": "Set the Z-Wave Controller to inclusion mode.\nPress the button for between 2 and 10 seconds.",
+		"exclusion": "Set the Z-Wave Controller to exclusion mode.\nPress the button for between 2 and 10 seconds.",
+		"reset": "Press and hold the button for between 30 and 33 seconds to restore factory defaults.",
+		"manual": "https://www.simonelectric.com/es-es/10002181-230-tecla-master-simon-io-persianas-bateria-blanco-mate-simon-100"
+	}
+}


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

Adds device configuration for the Simon 100 Battery Master Roller Blind (10002181-13x).

Device identification:
- Manufacturer: SimonTech S.L.U
- Manufacturer ID: 0x0267
- Product Type: 0x0006
- Product ID: 0x0000

The configuration is based on the manufacturer's documentation and has been tested with a physical 10002181-130 device.

The configuration parameters included are:
- 13: Buttons Lock
- 15: Reset to Default
- 18: Manual Association Lock
- 19: Short Press Action
- 27: Long Press Lock
- 29: No Associated Devices Mode

Parameter 29 defaults to 0xFF on this model to enable Central Scene notifications when no nodes are associated with the control group, as specified in the manufacturer's documentation and verified on the physical device.