### PR TITLE
feat(config): add Aeotec ZWA056 Water Sensor 8

### DIFF
--- a/packages/config/config/devices/0x0371/zwa056.json
+++ b/packages/config/config/devices/0x0371/zwa056.json
@@ -202,48 +202,47 @@
 		{
 			"#": "10",
 			"label": "Notification Type",
-  		"valueSize": 1,
-  		"defaultValue": 6,
-  		"unsigned": true,
-  		"allowManualEntry": false,
-  		"options": [
-  			{
-  				"label": "Water alarm",
-  				"value": 0
-  			},
-  			{
-  				"label": "Smoke alarm",
-  				"value": 1
-  			},
-  			{
-  				"label": "CO alarm",
-  				"value": 2
-  			},
-  			{
-  				"label": "CO2 alarm",
-  				"value": 3
-  			},
-  			{
-  				"label": "Access Control (Door/Window)",
-  				"value": 4
-  			},
-  			{
-  				"label": "Access Control (Tilt)",
-  				"value": 5
-  			},
-  			{
-  				"label": "Home Security (Motion)",
-  				"value": 6
-  			},
-  			{
-  				"label": "Home Security (Glass Break)",
-  				"value": 7
-  			},
-  			{
-  				"label": "Emergency alarm notification",
-  				"value": 8
-  			}
-  		]
+			"valueSize": 1,
+			"defaultValue": 6,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Water alarm",
+					"value": 0
+				},
+				{
+					"label": "Smoke alarm",
+					"value": 1
+				},
+				{
+					"label": "CO alarm",
+					"value": 2
+				},
+				{
+					"label": "CO2 alarm",
+					"value": 3
+				},
+				{
+					"label": "Access control (Door/Window)",
+					"value": 4
+				},
+				{
+					"label": "Access control (Tilt)",
+					"value": 5
+				},
+				{
+					"label": "Home security (Motion)",
+					"value": 6
+				},
+				{
+					"label": "Home security (Glass break)",
+					"value": 7
+				},
+				{
+					"label": "Emergency alarm notification",
+					"value": 8
+				}
+			]
 		},
 		{
 			"#": "12[0x01]",

--- a/packages/config/config/devices/0x0371/zwa056.json
+++ b/packages/config/config/devices/0x0371/zwa056.json
@@ -1,0 +1,428 @@
+{
+	"manufacturer": "Aeotec Ltd.",
+	"manufacturerId": "0x0371",
+	"label": "ZWA056",
+	"description": "Water Sensor 8",
+	"devices": [
+		{
+			// EU version
+			"productType": "0x0002",
+			"productId": "0x0038"
+		},
+		{
+			// AU version
+			"productType": "0x0102",
+			"productId": "0x0038"
+		},
+		{
+			// US version
+			"productType": "0x0202",
+			"productId": "0x0038"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Control",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Alarm",
+			"maxNodes": 5
+		},
+		"4": {
+			"label": "Tamper",
+			"maxNodes": 5
+		},
+		"5": {
+			"label": "High Temperature",
+			"maxNodes": 5
+		},
+		"6": {
+			"label": "Low Temperature",
+			"maxNodes": 5
+		},
+		"7": {
+			"label": "High Humidity",
+			"maxNodes": 5
+		},
+		"8": {
+			"label": "Low Humidity",
+			"maxNodes": 5
+		},
+		"9": {
+			"label": "Mold Danger",
+			"maxNodes": 5
+		},
+		"10": {
+			"label": "Air Temperature",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Threshold Check Interval",
+			"description": "Sets how often the device checks the thresholds in parameters 2, 3, and 14-17.",
+			"valueSize": 4,
+			"unit": "seconds",
+			"allowed": [
+				{ "value": 0 },
+				{ "range": [30, 2678400] }
+			],
+			"defaultValue": 900,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "2",
+			"$if": "productType === 0x0202",
+			"$purpose": "reporting_threshold.temperature",
+			"label": "Temperature Change Report Threshold",
+			"valueSize": 1,
+			"unit": "0.1 °C/°F",
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 36,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "2",
+			"$purpose": "reporting_threshold.temperature",
+			"label": "Temperature Change Report Threshold",
+			"valueSize": 1,
+			"unit": "0.1 °C/°F",
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 20,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "3",
+			"$purpose": "reporting_threshold.humidity",
+			"label": "Humidity Change Report Threshold",
+			"valueSize": 1,
+			"unit": "0.1 %",
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 50,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "4[0x01]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "LED Indication: Periodic Reports",
+			"defaultValue": 1
+		},
+		{
+			"#": "4[0x02]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "LED Indication: Wakeup Reports",
+			"defaultValue": 1
+		},
+		{
+			"#": "4[0x04]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "LED Indication: Mold Danger Alarm",
+			"defaultValue": 1
+		},
+		{
+			"#": "4[0x08]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "LED Indication: Tamper Alarm",
+			"defaultValue": 1
+		},
+		{
+			"#": "4[0x10]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "LED Indication: Dry Contact Change Report",
+			"defaultValue": 1
+		},
+		{
+			"#": "5",
+			"$import": "~/templates/master_template.json#base_options_nounit",
+			"label": "State When Alarm Is Triggered",
+			"options": [
+				{
+					"label": "Closed",
+					"value": 0
+				},
+				{
+					"label": "Opened",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "6",
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_trigger"
+		},
+		{
+			"#": "7",
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_command_type"
+		},
+		{
+			"#": "8",
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
+		},
+		{
+			"#": "9",
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
+		},
+		{
+			"#": "10",
+			"label": "Notification Type",
+  		"valueSize": 1,
+  		"defaultValue": 6,
+  		"unsigned": true,
+  		"allowManualEntry": false,
+  		"options": [
+  			{
+  				"label": "Water alarm",
+  				"value": 0
+  			},
+  			{
+  				"label": "Smoke alarm",
+  				"value": 1
+  			},
+  			{
+  				"label": "CO alarm",
+  				"value": 2
+  			},
+  			{
+  				"label": "CO2 alarm",
+  				"value": 3
+  			},
+  			{
+  				"label": "Access Control (Door/Window)",
+  				"value": 4
+  			},
+  			{
+  				"label": "Access Control (Tilt)",
+  				"value": 5
+  			},
+  			{
+  				"label": "Home Security (Motion)",
+  				"value": 6
+  			},
+  			{
+  				"label": "Home Security (Glass Break)",
+  				"value": 7
+  			},
+  			{
+  				"label": "Emergency alarm notification",
+  				"value": 8
+  			}
+  		]
+		},
+		{
+			"#": "12[0x01]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Sensor Limit: High Temperature"
+		},
+		{
+			"#": "12[0x02]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Sensor Limit: High Humidity"
+		},
+		{
+			"#": "12[0x04]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Sensor Limit: Low Temperature"
+		},
+		{
+			"#": "12[0x08]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Sensor Limit: Low Humidity"
+		},
+		{
+			"#": "13",
+			"label": "Mold Danger Humidity Offset",
+			"description": "Sets the trigger threshold using 95 - 5 * |1 + value| %.",
+			"valueSize": 1,
+			"minValue": -10,
+			"maxValue": 10,
+			"defaultValue": 0
+		},
+		{
+			"#": "14",
+			"$if": "productType === 0x0102",
+			"label": "High Temperature Threshold",
+			"description": "Sends a Basic Set to association group 6 when this threshold is exceeded.",
+			"valueSize": 2,
+			"unit": "0.1 °F",
+			"minValue": 32,
+			"maxValue": 2120,
+			"defaultValue": 860
+		},
+		{
+			"#": "14",
+			"label": "High Temperature Threshold",
+			"description": "Sends a Basic Set to association group 6 when this threshold is exceeded.",
+			"valueSize": 2,
+			"unit": "0.1 °C",
+			"minValue": 0,
+			"maxValue": 1000,
+			"defaultValue": 300
+		},
+		{
+			"#": "15",
+			"$if": "productType === 0x0102",
+			"label": "Low Temperature Threshold",
+			"description": "Sends a Basic Set to association group 7 when the temperature falls below this threshold.",
+			"valueSize": 2,
+			"unit": "0.1 °F",
+			"minValue": -40,
+			"maxValue": 2120,
+			"defaultValue": 320
+		},
+		{
+			"#": "15",
+			"label": "Low Temperature Threshold",
+			"description": "Sends a Basic Set to association group 7 when the temperature falls below this threshold.",
+			"valueSize": 2,
+			"unit": "0.1 °C",
+			"minValue": -200,
+			"maxValue": 1000,
+			"defaultValue": 0
+		},
+		{
+			"#": "16",
+			"label": "High Humidity Threshold",
+			"description": "Sends a Basic Set to association group 8 when this threshold is exceeded.",
+			"valueSize": 2,
+			"unit": "0.1 %",
+			"minValue": 0,
+			"maxValue": 1000,
+			"defaultValue": 700
+		},
+		{
+			"#": "17",
+			"label": "Low Humidity Threshold",
+			"description": "Sends a Basic Set to association group 9 when the humidity falls below this threshold.",
+			"valueSize": 2,
+			"unit": "0.1 %",
+			"minValue": 0,
+			"maxValue": 1000,
+			"defaultValue": 300
+		},
+		{
+			"#": "18",
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off",
+			"label": "Association Group 6: Basic Set Value"
+		},
+		{
+			"#": "19",
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on",
+			"label": "Association Group 7: Basic Set Value"
+		},
+		{
+			"#": "20",
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off",
+			"label": "Association Group 8: Basic Set Value"
+		},
+		{
+			"#": "21",
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on",
+			"label": "Association Group 9: Basic Set Value"
+		},
+		{
+			"#": "22",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Binary Sensor Reports",
+			"description": "Enables Binary Sensor reports for door, tilt, and mold danger states."
+		},
+		{
+			"#": "23",
+			"$import": "~/0x0086/templates/aeotec_template.json#reporting_threshold.low_battery",
+			"defaultValue": 20
+		},
+		{
+			"#": "24",
+			"label": "Periodic Reporting Interval",
+			"description": "Sets the interval for battery, temperature, humidity, and acceleration reports.",
+			"valueSize": 4,
+			"unit": "seconds",
+			"allowed": [
+				{ "value": 0 },
+				{ "range": [30, 2678400] }
+			],
+			"defaultValue": 43200,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "25",
+			"$purpose": "calibration.temperature",
+			"label": "Temperature Calibration",
+			"valueSize": 2,
+			"unit": "0.1 °C/°F",
+			"minValue": -200,
+			"maxValue": 200,
+			"defaultValue": 0
+		},
+		{
+			"#": "26",
+			"$purpose": "calibration.humidity",
+			"label": "Humidity Calibration",
+			"valueSize": 2,
+			"unit": "0.1 %",
+			"minValue": -200,
+			"maxValue": 200,
+			"defaultValue": 0
+		},
+		{
+			"#": "64",
+			"$if": "productType === 0x0202",
+			"$import": "~/templates/master_template.json#temperature_scale_celsius_fahrenheit",
+			"label": "Temperature and Dew Point Scale",
+			"defaultValue": 1
+		},
+		{
+			"#": "64",
+			"$import": "~/templates/master_template.json#temperature_scale_celsius_fahrenheit",
+			"label": "Temperature and Dew Point Scale"
+		}
+	],
+	"metadata": {
+		"wakeup": "Press the Action Button once. The green LED turns on for 1 second. The device remains awake for 15 seconds.",
+		"inclusion": "Press the Action Button twice within 1 second. The green LED flashes for up to 30 seconds. The green LED stays on for 2 seconds when successful. The red LED stays on for 1 second when unsuccessful.",
+		"exclusion": "Press the Action Button twice within 1 second. The green LED flashes for up to 30 seconds. The green LED stays on for 2 seconds when successful. The red LED stays on for 1 second when unsuccessful.",
+		"reset": "Press and hold the Action Button for more than 12 seconds. The green LED stays on for 1 second, then breathes to confirm the reset.",
+		"manual": "https://aeotec.freshdesk.com/support/solutions/folders/6000244700"
+	}
+}

--- a/packages/config/config/devices/0x0371/zwa056.json
+++ b/packages/config/config/devices/0x0371/zwa056.json
@@ -359,16 +359,14 @@
 		{
 			"#": "22",
 			"$import": "~/0x0086/templates/aeotec_template.json#enable_binary_report",
-			"description": "Backward-compatible Binary Sensor reports for the alarm and mold danger states."
+			"description": "Backward-compatible Binary Sensor reports for the alarm and mold danger states.",
+			// Z-Wave JS reads these states from the Notification CC, so the
+			// backward-compatible reports must stay off.
+			"recommendedValue": 0
 		},
 		{
 			"#": "23",
-			"$purpose": "reporting_threshold.low_battery",
-			"label": "Low Battery Threshold",
-			"valueSize": 1,
-			"unit": "%",
-			"minValue": 10,
-			"maxValue": 50,
+			"$import": "~/0x0086/templates/aeotec_template.json#low_battery_threshold",
 			"defaultValue": 20
 		},
 		{

--- a/packages/config/config/devices/0x0371/zwa056.json
+++ b/packages/config/config/devices/0x0371/zwa056.json
@@ -360,8 +360,7 @@
 			"#": "22",
 			"$import": "~/0x0086/templates/aeotec_template.json#enable_binary_report",
 			"description": "Backward-compatible Binary Sensor reports for the alarm and mold danger states.",
-			// Z-Wave JS reads these states from the Notification CC, so the
-			// backward-compatible reports must stay off.
+			// Z-Wave JS supports Notification CC
 			"recommendedValue": 0
 		},
 		{

--- a/packages/config/config/devices/0x0371/zwa056.json
+++ b/packages/config/config/devices/0x0371/zwa056.json
@@ -10,12 +10,12 @@
 			"productId": "0x0038"
 		},
 		{
-			// AU version
+			// US version
 			"productType": "0x0102",
 			"productId": "0x0038"
 		},
 		{
-			// US version
+			// AU version
 			"productType": "0x0202",
 			"productId": "0x0038"
 		}
@@ -43,19 +43,19 @@
 			"maxNodes": 5
 		},
 		"5": {
-			"label": "High Temperature",
+			"label": "Temperature High Trigger",
 			"maxNodes": 5
 		},
 		"6": {
-			"label": "Low Temperature",
+			"label": "Temperature Low Trigger",
 			"maxNodes": 5
 		},
 		"7": {
-			"label": "High Humidity",
+			"label": "Humidity High Trigger",
 			"maxNodes": 5
 		},
 		"8": {
-			"label": "Low Humidity",
+			"label": "Humidity Low Trigger",
 			"maxNodes": 5
 		},
 		"9": {
@@ -70,29 +70,17 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Threshold Check Interval",
-			"description": "Sets how often the device checks the thresholds in parameters 2, 3, and 14-17.",
-			"valueSize": 4,
-			"unit": "seconds",
-			"allowed": [
-				{ "value": 0 },
-				{ "range": [30, 2678400] }
-			],
-			"defaultValue": 900,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				}
-			]
+			"$import": "~/0x0086/templates/aeotec_template.json#threshold_check_time",
+			"description": "Sets how often the thresholds in parameters 2, 3 and 14 to 17 are checked."
 		},
 		{
 			"#": "2",
-			"$if": "productType === 0x0202",
+			// US-specific:
+			"$if": "productType === 0x0102",
 			"$purpose": "reporting_threshold.temperature",
-			"label": "Temperature Change Report Threshold",
+			"label": "Temperature Reports: Change Threshold",
 			"valueSize": 1,
-			"unit": "0.1 °C/°F",
+			"unit": "0.1 (°C/°F)",
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 36,
@@ -106,10 +94,11 @@
 		},
 		{
 			"#": "2",
+			// Other regions:
 			"$purpose": "reporting_threshold.temperature",
-			"label": "Temperature Change Report Threshold",
+			"label": "Temperature Reports: Change Threshold",
 			"valueSize": 1,
-			"unit": "0.1 °C/°F",
+			"unit": "0.1 (°C/°F)",
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 20,
@@ -124,7 +113,7 @@
 		{
 			"#": "3",
 			"$purpose": "reporting_threshold.humidity",
-			"label": "Humidity Change Report Threshold",
+			"label": "Humidity Reports: Change Threshold",
 			"valueSize": 1,
 			"unit": "0.1 %",
 			"minValue": 0,
@@ -140,52 +129,60 @@
 		},
 		{
 			"#": "4[0x01]",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "LED Indication: Periodic Reports",
-			"defaultValue": 1
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_periodic_reports"
 		},
 		{
 			"#": "4[0x02]",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "LED Indication: Wakeup Reports",
-			"defaultValue": 1
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_wake"
 		},
 		{
 			"#": "4[0x04]",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "LED Indication: Mold Danger Alarm",
-			"defaultValue": 1
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_mold_danger"
 		},
 		{
 			"#": "4[0x08]",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "LED Indication: Tamper Alarm",
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper",
 			"defaultValue": 1
 		},
 		{
 			"#": "4[0x10]",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "LED Indication: Dry Contact Change Report",
+			"label": "LED Indicator: Dry Contact Status Change",
 			"defaultValue": 1
 		},
 		{
 			"#": "5",
 			"$import": "~/templates/master_template.json#base_options_nounit",
-			"label": "State When Alarm Is Triggered",
+			"label": "Dry Contact Polarity",
 			"options": [
 				{
-					"label": "Closed",
+					"label": "Alarm when closed",
 					"value": 0
 				},
 				{
-					"label": "Opened",
+					"label": "Alarm when open",
 					"value": 1
 				}
 			]
 		},
 		{
 			"#": "6",
-			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_trigger"
+			"$import": "~/templates/master_template.json#base_options_nounit",
+			"label": "Association Group 2: Trigger",
+			"options": [
+				{
+					"label": "Switch after dry contact closed and open",
+					"value": 0
+				},
+				{
+					"label": "Switch after dry contact closed",
+					"value": 1
+				},
+				{
+					"label": "Switch after dry contact open",
+					"value": 2
+				}
+			]
 		},
 		{
 			"#": "7",
@@ -193,17 +190,22 @@
 		},
 		{
 			"#": "8",
-			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Association Group 2: Basic Set Value (On)",
+			"defaultValue": 255
 		},
 		{
 			"#": "9",
-			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Association Group 2: Basic Set Value (Off)",
+			"defaultValue": 0
 		},
 		{
 			"#": "10",
 			"label": "Notification Type",
+			"description": "Changing this parameter alters the capabilities of the device. Exclude and re-include the device afterwards.",
 			"valueSize": 1,
-			"defaultValue": 6,
+			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -239,157 +241,148 @@
 					"value": 7
 				},
 				{
-					"label": "Emergency alarm notification",
+					"label": "Emergency alarm (Panic)",
 					"value": 8
 				}
 			]
 		},
 		{
+			// The spec marks this parameter read-only, but a bit field that enables
+			// per-sensor limit reporting cannot sensibly be read-only; treated as writable.
 			"#": "12[0x01]",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Sensor Limit: High Temperature"
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_limit_enable_temperature_upper"
 		},
 		{
 			"#": "12[0x02]",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Sensor Limit: High Humidity"
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_limit_enable_humidity_upper"
 		},
 		{
 			"#": "12[0x04]",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Sensor Limit: Low Temperature"
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_limit_enable_temperature_lower"
 		},
 		{
 			"#": "12[0x08]",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Sensor Limit: Low Humidity"
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_limit_enable_humidity_lower"
 		},
 		{
 			"#": "13",
-			"label": "Mold Danger Humidity Offset",
-			"description": "Sets the trigger threshold using 95 - 5 * |1 + value| %.",
+			"label": "Mold Danger: Humidity Offset",
+			"description": "Increases the humidity threshold that triggers the mold danger alarm, whose baseline is 60%.",
 			"valueSize": 1,
-			"minValue": -10,
-			"maxValue": 10,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 40,
 			"defaultValue": 0
 		},
 		{
 			"#": "14",
+			// US-specific:
 			"$if": "productType === 0x0102",
-			"label": "High Temperature Threshold",
-			"description": "Sends a Basic Set to association group 6 when this threshold is exceeded.",
+			"label": "Temperature Reports: Upper Limit",
+			"description": "Devices in Group 5 will receive a Basic Set command if the temperature exceeds this value.",
 			"valueSize": 2,
-			"unit": "0.1 °F",
-			"minValue": 32,
+			"unit": "0.1 (°C/°F)",
+			// The spec prints 0x0020 (32) here, but the max/default values only convert
+			// cleanly between °C and °F at 320 (32.0°F = 0.0°C, matching the EU/AU minimum).
+			"minValue": 320,
 			"maxValue": 2120,
 			"defaultValue": 860
 		},
 		{
 			"#": "14",
-			"label": "High Temperature Threshold",
-			"description": "Sends a Basic Set to association group 6 when this threshold is exceeded.",
+			// Other regions:
+			"label": "Temperature Reports: Upper Limit",
+			"description": "Devices in Group 5 will receive a Basic Set command if the temperature exceeds this value.",
 			"valueSize": 2,
-			"unit": "0.1 °C",
+			"unit": "0.1 (°C/°F)",
 			"minValue": 0,
 			"maxValue": 1000,
 			"defaultValue": 300
 		},
 		{
 			"#": "15",
+			// US-specific:
 			"$if": "productType === 0x0102",
-			"label": "Low Temperature Threshold",
-			"description": "Sends a Basic Set to association group 7 when the temperature falls below this threshold.",
+			"label": "Temperature Reports: Lower Limit",
+			"description": "Devices in Group 6 will receive a Basic Set command if the temperature drops below this value.",
 			"valueSize": 2,
-			"unit": "0.1 °F",
+			"unit": "0.1 (°C/°F)",
 			"minValue": -40,
 			"maxValue": 2120,
 			"defaultValue": 320
 		},
 		{
 			"#": "15",
-			"label": "Low Temperature Threshold",
-			"description": "Sends a Basic Set to association group 7 when the temperature falls below this threshold.",
+			// Other regions:
+			"label": "Temperature Reports: Lower Limit",
+			"description": "Devices in Group 6 will receive a Basic Set command if the temperature drops below this value.",
 			"valueSize": 2,
-			"unit": "0.1 °C",
+			"unit": "0.1 (°C/°F)",
 			"minValue": -200,
 			"maxValue": 1000,
 			"defaultValue": 0
 		},
 		{
 			"#": "16",
-			"label": "High Humidity Threshold",
-			"description": "Sends a Basic Set to association group 8 when this threshold is exceeded.",
-			"valueSize": 2,
-			"unit": "0.1 %",
-			"minValue": 0,
-			"maxValue": 1000,
-			"defaultValue": 700
+			"$import": "~/0x0086/templates/aeotec_template.json#watermark_humidity_upper",
+			"description": "Devices in Group 7 will receive a Basic Set command if the humidity exceeds this value."
 		},
 		{
 			"#": "17",
-			"label": "Low Humidity Threshold",
-			"description": "Sends a Basic Set to association group 9 when the humidity falls below this threshold.",
-			"valueSize": 2,
-			"unit": "0.1 %",
-			"minValue": 0,
-			"maxValue": 1000,
-			"defaultValue": 300
+			"$import": "~/0x0086/templates/aeotec_template.json#watermark_humidity_lower",
+			"description": "Devices in Group 8 will receive a Basic Set command if the humidity drops below this value."
 		},
 		{
 			"#": "18",
-			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off",
-			"label": "Association Group 6: Basic Set Value"
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Temperature Reports: Basic Set Value (Above Upper Limit)",
+			"defaultValue": 0
 		},
 		{
 			"#": "19",
-			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on",
-			"label": "Association Group 7: Basic Set Value"
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Temperature Reports: Basic Set Value (Below Lower Limit)",
+			"defaultValue": 255
 		},
 		{
 			"#": "20",
-			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off",
-			"label": "Association Group 8: Basic Set Value"
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Humidity Reports: Basic Set Value (Above Upper Limit)",
+			"defaultValue": 0
 		},
 		{
 			"#": "21",
-			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on",
-			"label": "Association Group 9: Basic Set Value"
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Humidity Reports: Basic Set Value (Below Lower Limit)",
+			"defaultValue": 255
 		},
 		{
 			"#": "22",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Binary Sensor Reports",
-			"description": "Enables Binary Sensor reports for door, tilt, and mold danger states."
+			"$import": "~/0x0086/templates/aeotec_template.json#enable_binary_report",
+			"description": "Backward-compatible Binary Sensor reports for the alarm and mold danger states."
 		},
 		{
 			"#": "23",
-			"$import": "~/0x0086/templates/aeotec_template.json#reporting_threshold.low_battery",
+			"$purpose": "reporting_threshold.low_battery",
+			"label": "Low Battery Threshold",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 10,
+			"maxValue": 50,
 			"defaultValue": 20
 		},
 		{
 			"#": "24",
-			"label": "Periodic Reporting Interval",
-			"description": "Sets the interval for battery, temperature, humidity, and acceleration reports.",
-			"valueSize": 4,
-			"unit": "seconds",
-			"allowed": [
-				{ "value": 0 },
-				{ "range": [30, 2678400] }
-			],
-			"defaultValue": 43200,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				}
-			]
+			"$import": "~/0x0086/templates/aeotec_template.json#periodic_reports_interval",
+			"description": "Sets the interval for battery, temperature and humidity reports."
 		},
 		{
 			"#": "25",
 			"$purpose": "calibration.temperature",
 			"label": "Temperature Calibration",
+			"description": "Scale is defined by parameter 64.",
 			"valueSize": 2,
-			"unit": "0.1 °C/°F",
+			"unit": "0.1 (°C/°F)",
 			"minValue": -200,
 			"maxValue": 200,
 			"defaultValue": 0
@@ -406,15 +399,17 @@
 		},
 		{
 			"#": "64",
-			"$if": "productType === 0x0202",
-			"$import": "~/templates/master_template.json#temperature_scale_celsius_fahrenheit",
-			"label": "Temperature and Dew Point Scale",
+			// US-specific:
+			"$if": "productType === 0x0102",
+			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit_0",
+			"valueSize": 1,
 			"defaultValue": 1
 		},
 		{
 			"#": "64",
-			"$import": "~/templates/master_template.json#temperature_scale_celsius_fahrenheit",
-			"label": "Temperature and Dew Point Scale"
+			// Other regions:
+			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit_0",
+			"valueSize": 1
 		}
 	],
 	"metadata": {
@@ -422,6 +417,6 @@
 		"inclusion": "Press the Action Button twice within 1 second. The green LED flashes for up to 30 seconds. The green LED stays on for 2 seconds when successful. The red LED stays on for 1 second when unsuccessful.",
 		"exclusion": "Press the Action Button twice within 1 second. The green LED flashes for up to 30 seconds. The green LED stays on for 2 seconds when successful. The red LED stays on for 1 second when unsuccessful.",
 		"reset": "Press and hold the Action Button for more than 12 seconds. The green LED stays on for 1 second, then breathes to confirm the reset.",
-		"manual": "https://aeotec.freshdesk.com/support/solutions/folders/6000244700"
+		"manual": "https://products.z-wavealliance.org/wp-content/uploads/products/80652/EngineeringSpec-WaterSensor820251219B.pdf"
 	}
 }


### PR DESCRIPTION
Adds the Aeotec ZWA056 Water Sensor 8 configuration for the EU, US, and AU product types.

The configuration includes all documented parameters, association groups, regional temperature defaults, device instructions, and the manufacturer manual link.

Source: https://aeotec.freshdesk.com/support/solutions/articles/6000278049-water-sensor-8-user-guide-zwa056-

