### PR TITLE
ci: trigger the Z-Wave JS UI dependency bump after each release

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -479,10 +479,22 @@ jobs:
     - name: Bump zwave-js in Z-Wave JS UI
       # Prereleases are not rolled out to Z-Wave JS UI automatically
       if: ${{ !contains(steps.extract_release.outputs.VERSION, '-') }}
+      timeout-minutes: 15
       env:
         GH_TOKEN: ${{ secrets.BOT_TOKEN }}
         VERSION: ${{ steps.extract_release.outputs.VERSION }}
       run: |
+        # The dispatched workflow installs zwave-js@$VERSION right away. Publishing
+        # and the registry serving the new version are not the same moment, so wait
+        # for it instead of opening a bump PR that cannot resolve the dependency.
+        for _ in $(seq 60); do
+          if npm view "zwave-js@$VERSION" version > /dev/null 2>&1; then break; fi
+          echo "zwave-js@$VERSION is not available on npm yet, waiting..."
+          sleep 10
+        done
+        # Fail loudly instead of dispatching a workflow that is bound to fail
+        npm view "zwave-js@$VERSION" version
+
         gh workflow run update-dep.yml \
           --repo zwave-js/zwave-js-ui \
           --ref master \

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -476,6 +476,19 @@ jobs:
         prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
         body: ${{ steps.extract_release.outputs.BODY }}
 
+    - name: Bump zwave-js in Z-Wave JS UI
+      # Prereleases are not rolled out to Z-Wave JS UI automatically
+      if: ${{ !contains(steps.extract_release.outputs.VERSION, '-') }}
+      env:
+        GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        VERSION: ${{ steps.extract_release.outputs.VERSION }}
+      run: |
+        gh workflow run update-dep.yml \
+          --repo zwave-js/zwave-js-ui \
+          --ref master \
+          -f dep=zwave-js \
+          -f version="$VERSION"
+
     # - name: Notify Sentry.io about the release
     #   run: |
     #     npm i -g @sentry/cli


### PR DESCRIPTION
Z-Wave JS UI already has an on-demand `Update dependency On-Demand` workflow (`update-dep.yml`) that bumps a dependency and opens a PR. Until now somebody had to start it by hand after every `zwave-js` release.

This adds a step at the end of the `deploy` job that dispatches that workflow with the version that was just published:

```
gh workflow run update-dep.yml --repo zwave-js/zwave-js-ui --ref master \
  -f dep=zwave-js -f version="$VERSION"
```

Notes:

- Runs only after the npm publish and the GitHub release succeeded, so a bump PR is never opened for a release that did not happen.
- Waits for the registry to actually serve `zwave-js@$VERSION` before dispatching. `npm publish` returning and the version being resolvable are not the same moment, and the dispatched workflow runs `npm install --save-exact zwave-js@<version>` immediately — without the wait a slow propagation turns into a failed bump run over in the UI repo, where the cause is much harder to see. Polls every 10s for up to 10 minutes, then fails the step loudly rather than dispatching a run that cannot succeed. `timeout-minutes: 15` caps the step.
- Prereleases are skipped — Z-Wave JS UI pins an exact `zwave-js` version and should not be moved to a `-beta`/`-rc` build automatically.
- Uses `secrets.BOT_TOKEN`, which is already used elsewhere in this workflow, because `GITHUB_TOKEN` cannot dispatch workflows in another repository.

https://claude.ai/code/session_017Ai6n3wiRtNXiBdT17189a