### PR TITLE
feat: persist the last time a node was awake

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -935,7 +935,7 @@ This property tracks when the node was last seen, meaning a command was either r
 readonly lastAwake: MaybeNotKnown<Date>
 ```
 
-This property tracks when the node last woke up. It is only tracked for nodes that can sleep and, like `lastSeen`, is preserved across restarts.
+This property tracks when the node was last known to be awake. It is only tracked for nodes that can sleep and, like `lastSeen`, is preserved across restarts.
 
 ### `isControllerNode`
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -935,7 +935,7 @@ This property tracks when the node was last seen, meaning a command was either r
 readonly lastAwake: MaybeNotKnown<Date>
 ```
 
-This property tracks when the node was last observed to be awake. It is only tracked for nodes that can sleep and, like `lastSeen`, is preserved across restarts.
+This property tracks when the node was last observed to be awake. It is only tracked for nodes that are known to be able to sleep and, like `lastSeen`, is preserved across restarts.
 
 ### `isControllerNode`
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -935,7 +935,7 @@ This property tracks when the node was last seen, meaning a command was either r
 readonly lastAwake: MaybeNotKnown<Date>
 ```
 
-This property tracks when the node was last known to be awake. It is only tracked for nodes that can sleep and, like `lastSeen`, is preserved across restarts.
+This property tracks when the node was last observed to be awake. It is only tracked for nodes that can sleep and, like `lastSeen`, is preserved across restarts.
 
 ### `isControllerNode`
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -935,7 +935,7 @@ This property tracks when the node was last seen, meaning a command was either r
 readonly lastAwake: MaybeNotKnown<Date>
 ```
 
-This property tracks when the node was last observed to be awake. It is only tracked for nodes that are known to be able to sleep and, like `lastSeen`, is preserved across restarts.
+This property tracks when the node last sent a Wake Up notification, so it is only known for nodes that can sleep. Like `lastSeen`, it is preserved across restarts.
 
 ### `isControllerNode`
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -929,6 +929,14 @@ readonly lastSeen: MaybeNotKnown<Date>
 
 This property tracks when the node was last seen, meaning a command was either received from the node or successfully sent to it.
 
+### `lastAwake`
+
+```ts
+readonly lastAwake: MaybeNotKnown<Date>
+```
+
+This property tracks when the node last woke up. It is only tracked for nodes that can sleep and, like `lastSeen`, is preserved across restarts.
+
 ### `isControllerNode`
 
 ```ts

--- a/packages/zwave-js/src/lib/driver/NetworkCache.test.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.test.ts
@@ -1,6 +1,9 @@
 import { InterviewStage, NodeType } from "@zwave-js/core";
 import { test } from "vitest";
-import { deserializeNetworkCacheValue } from "./NetworkCache.js";
+import {
+	deserializeNetworkCacheValue,
+	serializeNetworkCacheValue,
+} from "./NetworkCache.js";
 
 test("deserializeNetworkCacheValue() accepts zero-valued enum members", (t) => {
 	// InterviewStage.None and NodeType.Controller are both 0
@@ -16,4 +19,14 @@ test("deserializeNetworkCacheValue() still rejects unknown enum members", (t) =>
 	).toThrow();
 	t.expect(() => deserializeNetworkCacheValue("node.1.nodeType", "Nonsense"))
 		.toThrow();
+});
+
+test("Date properties survive a serialization round-trip", (t) => {
+	const date = new Date(2026, 0, 1, 12, 34, 56);
+	for (const key of ["node.1.lastSeen", "node.1.lastAwake"]) {
+		const serialized = serializeNetworkCacheValue(key, date);
+		t.expect(serialized).toBe(date.getTime());
+		t.expect(deserializeNetworkCacheValue(key, serialized))
+			.toStrictEqual(date);
+	}
 });

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -104,6 +104,7 @@ export const cacheKeys = {
 				`${nodeBaseKey}defaultTransitionDuration`,
 			defaultVolume: `${nodeBaseKey}defaultVolume`,
 			lastSeen: `${nodeBaseKey}lastSeen`,
+			lastAwake: `${nodeBaseKey}lastAwake`,
 			deviceConfigHash: `${nodeBaseKey}deviceConfigHash`,
 		};
 	},
@@ -484,7 +485,8 @@ export function deserializeNetworkCacheValue(
 			fail();
 		}
 
-		case "lastSeen": {
+		case "lastSeen":
+		case "lastAwake": {
 			value = tryParseDate(value);
 			if (value) return value;
 			fail();
@@ -572,7 +574,8 @@ export function serializeNetworkCacheValue(
 		case "dsk": {
 			return dskToString(value as BytesView);
 		}
-		case "lastSeen": {
+		case "lastSeen":
+		case "lastAwake": {
 			// Dates are stored as timestamps
 			return (value as Date).getTime();
 		}

--- a/packages/zwave-js/src/lib/node/CCHandlers/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/WakeUpCC.ts
@@ -14,23 +14,11 @@ import { getErrorMessage } from "@zwave-js/shared";
 import { isObject } from "alcalzone-shared/typeguards";
 import type { ZWaveNode } from "../Node.js";
 
-export interface WakeUpHandlerStore {
-	/** The timestamp of the last received wakeup notification */
-	lastWakeUp: number | undefined;
-}
-
-export function getDefaultWakeUpHandlerStore(): WakeUpHandlerStore {
-	return {
-		lastWakeUp: undefined,
-	};
-}
-
 /** Handles the receipt of a Wake Up notification */
 export function handleWakeUpNotification(
 	ctx: PersistValuesContext & LogNode,
 	node: ZWaveNode,
 	_command: WakeUpCC,
-	store: WakeUpHandlerStore,
 ): void {
 	ctx.logNode(node.id, {
 		message: `received wakeup notification`,
@@ -52,8 +40,9 @@ export function handleWakeUpNotification(
 	// From the specs:
 	// A controlling node SHOULD read the Wake Up Interval of a supporting node when the delays between
 	// Wake Up periods are larger than what was last set at the supporting node.
-	const now = Date.now();
-	if (store.lastWakeUp) {
+	const now = new Date();
+	const lastWakeUp = node.lastAwake;
+	if (lastWakeUp) {
 		// we've already measured the wake up interval, so we can check whether a refresh is necessary
 		const wakeUpInterval =
 			node.getValue<number>(WakeUpCCValues.wakeUpInterval.id) ?? 1;
@@ -62,14 +51,15 @@ export function handleWakeUpNotification(
 		// so the interval shouldn't be verified
 		if (
 			wakeUpInterval > 0
-			&& (now - store.lastWakeUp) / 1000 > wakeUpInterval + 5 * 60
+			&& (now.getTime() - lastWakeUp.getTime()) / 1000
+				> wakeUpInterval + 5 * 60
 		) {
 			node.commandClasses["Wake Up"].getInterval().catch(() => {
 				// Don't throw if there's an error
 			});
 		}
 	}
-	store.lastWakeUp = now;
+	node.lastAwake = now;
 
 	// Some legacy devices expect us to query them on wake up in order to function correctly
 	if (node.deviceConfig?.compat?.queryOnWakeup) {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -266,10 +266,7 @@ import {
 	handleVersionCommandClassGet,
 	handleVersionGet,
 } from "./CCHandlers/VersionCC.js";
-import {
-	getDefaultWakeUpHandlerStore,
-	handleWakeUpNotification,
-} from "./CCHandlers/WakeUpCC.js";
+import { handleWakeUpNotification } from "./CCHandlers/WakeUpCC.js";
 import { handleZWavePlusGet } from "./CCHandlers/ZWavePlusCC.js";
 import { DeviceClass } from "./DeviceClass.js";
 import type { NodeDump, ValueDump } from "./Dump.js";
@@ -438,6 +435,15 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			...cur,
 			lastSeen: value,
 		}));
+	}
+
+	/** The last time this node sent a Wake Up notification */
+	public get lastAwake(): MaybeNotKnown<Date> {
+		return this.driver.cacheGet(cacheKeys.node(this.id).lastAwake);
+	}
+	/** @internal */
+	public set lastAwake(value: MaybeNotKnown<Date>) {
+		this.driver.cacheSet(cacheKeys.node(this.id).lastAwake, value);
 	}
 
 	/**
@@ -1195,9 +1201,7 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 				this.isListening = false;
 				this.isFrequentListening = false;
 
-				// The node was already observed to be awake before the re-interview,
-				// so restoring the status must not move lastAwake
-				this.restoreAwakeStatus();
+				this.markAsAwake();
 			}
 
 			// Queue a fresh interview
@@ -2785,7 +2789,6 @@ protocol version:      ${this.protocolVersion}`;
 	private hailHandlerStore = getDefaultHailHandlerStore();
 	private notificationHandlerStore = getDefaultNotificationHandlerStore();
 	private soundSwitchHandlerStore = getDefaultSoundSwitchHandlerStore();
-	private wakeUpHandlerStore = getDefaultWakeUpHandlerStore();
 	private entryControlHandlerStore = getDefaultEntryControlHandlerStore();
 
 	/**
@@ -2862,7 +2865,6 @@ protocol version:      ${this.protocolVersion}`;
 				this.driver,
 				this,
 				command,
-				this.wakeUpHandlerStore,
 			);
 		} else if (command instanceof NotificationCCReport) {
 			return handleNotificationReport(

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1195,13 +1195,9 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 				this.isListening = false;
 				this.isFrequentListening = false;
 
-				if (didWakeUp) {
-					this.markAsAwake();
-				} else {
-					// Restoring a remembered status is not a new observation of
-					// the node being awake, so lastAwake must not move
-					this.updateStatusMachine({ value: "AWAKE" });
-				}
+				// The node was already observed to be awake before the re-interview,
+				// so restoring the status must not move lastAwake
+				this.restoreAwakeStatus();
 			}
 
 			// Queue a fresh interview

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1195,11 +1195,13 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 				this.isListening = false;
 				this.isFrequentListening = false;
 
-				// Restoring a remembered status is not a new observation of the
-				// node being awake, so the timestamp must not move
-				const lastAwake = this.lastAwake;
-				this.markAsAwake();
-				if (!didWakeUp) this.lastAwake = lastAwake;
+				if (didWakeUp) {
+					this.markAsAwake();
+				} else {
+					// Restoring a remembered status is not a new observation of
+					// the node being awake, so lastAwake must not move
+					this.updateStatusMachine({ value: "AWAKE" });
+				}
 			}
 
 			// Queue a fresh interview

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1195,7 +1195,11 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 				this.isListening = false;
 				this.isFrequentListening = false;
 
+				// Restoring a remembered status is not a new observation of the
+				// node being awake, so the timestamp must not move
+				const lastAwake = this.lastAwake;
 				this.markAsAwake();
+				if (!didWakeUp) this.lastAwake = lastAwake;
 			}
 
 			// Queue a fresh interview

--- a/packages/zwave-js/src/lib/node/mixins/20_Status.ts
+++ b/packages/zwave-js/src/lib/node/mixins/20_Status.ts
@@ -1,8 +1,4 @@
-import {
-	type CommandClasses,
-	InterviewStage,
-	type MaybeNotKnown,
-} from "@zwave-js/core";
+import { type CommandClasses, InterviewStage } from "@zwave-js/core";
 import type { Driver } from "../../driver/Driver.js";
 import { cacheKeys } from "../../driver/NetworkCache.js";
 import type { DeviceClass } from "../DeviceClass.js";
@@ -54,17 +50,6 @@ export interface NodeWithStatus {
 	 * Marks this node as awake (if applicable)
 	 */
 	markAsAwake(): void;
-
-	/**
-	 * @internal
-	 * Restores a previously known awake status without recording a new observation
-	 */
-	restoreAwakeStatus(): void;
-
-	/**
-	 * The last time this node was observed to be awake. Only tracked for nodes that are known to be able to sleep.
-	 */
-	readonly lastAwake: MaybeNotKnown<Date>;
 
 	/**
 	 * Which interview stage was last completed
@@ -179,19 +164,6 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 	 * Marks this node as awake (if applicable)
 	 */
 	public markAsAwake(): void {
-		// Record every observation, not just the ones that change the status: a node
-		// that is kept awake or whose transition to sleep was missed keeps waking up
-		// while we already believe it to be awake. For always-listening nodes there
-		// is no wake-up to record.
-		if (this.canSleep) this.lastAwake = new Date();
-		this.restoreAwakeStatus();
-	}
-
-	/**
-	 * @internal
-	 * Restores a previously known awake status without recording a new observation
-	 */
-	public restoreAwakeStatus(): void {
 		this.updateStatusMachine({ value: "AWAKE" });
 	}
 
@@ -230,13 +202,6 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 	}
 	protected set ready(ready: boolean) {
 		this._ready = ready;
-	}
-
-	public get lastAwake(): MaybeNotKnown<Date> {
-		return this.driver.cacheGet(cacheKeys.node(this.id).lastAwake);
-	}
-	private set lastAwake(value: MaybeNotKnown<Date>) {
-		this.driver.cacheSet(cacheKeys.node(this.id).lastAwake, value);
 	}
 
 	public get interviewStage(): InterviewStage {

--- a/packages/zwave-js/src/lib/node/mixins/20_Status.ts
+++ b/packages/zwave-js/src/lib/node/mixins/20_Status.ts
@@ -56,7 +56,7 @@ export interface NodeWithStatus {
 	markAsAwake(): void;
 
 	/**
-	 * The last time this node was awake. Only tracked for nodes that can sleep.
+	 * The last time this node was known to be awake. Only tracked for nodes that can sleep.
 	 */
 	lastAwake: MaybeNotKnown<Date>;
 
@@ -124,7 +124,6 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 		if (this._status === NodeStatus.Asleep) {
 			this._emit("sleep", this, oldStatus);
 		} else if (this._status === NodeStatus.Awake) {
-			this.lastAwake = new Date();
 			this._emit("wake up", this, oldStatus);
 		} else if (this._status === NodeStatus.Dead) {
 			this._emit("dead", this, oldStatus);
@@ -174,6 +173,10 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 	 * Marks this node as awake (if applicable)
 	 */
 	public markAsAwake(): void {
+		// Nodes are marked awake whenever we observe them being awake, which may
+		// happen repeatedly while we already believe them to be. Remember the
+		// most recent observation, not just the one that changed the status.
+		if (this.canSleep) this.lastAwake = new Date();
 		this.updateStatusMachine({ value: "AWAKE" });
 	}
 
@@ -214,7 +217,7 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 		this._ready = ready;
 	}
 
-	/** The last time this node was awake. Only tracked for nodes that can sleep. */
+	/** The last time this node was known to be awake. Only tracked for nodes that can sleep. */
 	public get lastAwake(): MaybeNotKnown<Date> {
 		return this.driver.cacheGet(cacheKeys.node(this.id).lastAwake);
 	}

--- a/packages/zwave-js/src/lib/node/mixins/20_Status.ts
+++ b/packages/zwave-js/src/lib/node/mixins/20_Status.ts
@@ -62,7 +62,7 @@ export interface NodeWithStatus {
 	restoreAwakeStatus(): void;
 
 	/**
-	 * The last time this node was observed to be awake. Only tracked for nodes that can sleep.
+	 * The last time this node was observed to be awake. Only tracked for nodes that are known to be able to sleep.
 	 */
 	readonly lastAwake: MaybeNotKnown<Date>;
 
@@ -184,7 +184,7 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 		// while we already believe it to be awake. For always-listening nodes there
 		// is no wake-up to record.
 		if (this.canSleep) this.lastAwake = new Date();
-		this.updateStatusMachine({ value: "AWAKE" });
+		this.restoreAwakeStatus();
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/mixins/20_Status.ts
+++ b/packages/zwave-js/src/lib/node/mixins/20_Status.ts
@@ -1,4 +1,8 @@
-import { type CommandClasses, InterviewStage } from "@zwave-js/core";
+import {
+	type CommandClasses,
+	InterviewStage,
+	type MaybeNotKnown,
+} from "@zwave-js/core";
 import type { Driver } from "../../driver/Driver.js";
 import { cacheKeys } from "../../driver/NetworkCache.js";
 import type { DeviceClass } from "../DeviceClass.js";
@@ -50,6 +54,11 @@ export interface NodeWithStatus {
 	 * Marks this node as awake (if applicable)
 	 */
 	markAsAwake(): void;
+
+	/**
+	 * The last time this node was awake. Only tracked for nodes that can sleep.
+	 */
+	lastAwake: MaybeNotKnown<Date>;
 
 	/**
 	 * Which interview stage was last completed
@@ -115,6 +124,7 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 		if (this._status === NodeStatus.Asleep) {
 			this._emit("sleep", this, oldStatus);
 		} else if (this._status === NodeStatus.Awake) {
+			this.lastAwake = new Date();
 			this._emit("wake up", this, oldStatus);
 		} else if (this._status === NodeStatus.Dead) {
 			this._emit("dead", this, oldStatus);
@@ -202,6 +212,15 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 	}
 	protected set ready(ready: boolean) {
 		this._ready = ready;
+	}
+
+	/** The last time this node was awake. Only tracked for nodes that can sleep. */
+	public get lastAwake(): MaybeNotKnown<Date> {
+		return this.driver.cacheGet(cacheKeys.node(this.id).lastAwake);
+	}
+	/** @internal */
+	public set lastAwake(value: MaybeNotKnown<Date>) {
+		this.driver.cacheSet(cacheKeys.node(this.id).lastAwake, value);
 	}
 
 	public get interviewStage(): InterviewStage {

--- a/packages/zwave-js/src/lib/node/mixins/20_Status.ts
+++ b/packages/zwave-js/src/lib/node/mixins/20_Status.ts
@@ -58,7 +58,7 @@ export interface NodeWithStatus {
 	/**
 	 * The last time this node was known to be awake. Only tracked for nodes that can sleep.
 	 */
-	lastAwake: MaybeNotKnown<Date>;
+	readonly lastAwake: MaybeNotKnown<Date>;
 
 	/**
 	 * Which interview stage was last completed
@@ -176,6 +176,8 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 		// Nodes are marked awake whenever we observe them being awake, which may
 		// happen repeatedly while we already believe them to be. Remember the
 		// most recent observation, not just the one that changed the status.
+		// The guard mirrors the status machine, which only enters "awake" for
+		// nodes that can sleep.
 		if (this.canSleep) this.lastAwake = new Date();
 		this.updateStatusMachine({ value: "AWAKE" });
 	}
@@ -221,8 +223,7 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 	public get lastAwake(): MaybeNotKnown<Date> {
 		return this.driver.cacheGet(cacheKeys.node(this.id).lastAwake);
 	}
-	/** @internal */
-	public set lastAwake(value: MaybeNotKnown<Date>) {
+	protected set lastAwake(value: MaybeNotKnown<Date>) {
 		this.driver.cacheSet(cacheKeys.node(this.id).lastAwake, value);
 	}
 

--- a/packages/zwave-js/src/lib/node/mixins/20_Status.ts
+++ b/packages/zwave-js/src/lib/node/mixins/20_Status.ts
@@ -56,6 +56,12 @@ export interface NodeWithStatus {
 	markAsAwake(): void;
 
 	/**
+	 * @internal
+	 * Restores a previously known awake status without recording a new observation
+	 */
+	restoreAwakeStatus(): void;
+
+	/**
 	 * The last time this node was observed to be awake. Only tracked for nodes that can sleep.
 	 */
 	readonly lastAwake: MaybeNotKnown<Date>;
@@ -178,6 +184,14 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 		// while we already believe it to be awake. For always-listening nodes there
 		// is no wake-up to record.
 		if (this.canSleep) this.lastAwake = new Date();
+		this.updateStatusMachine({ value: "AWAKE" });
+	}
+
+	/**
+	 * @internal
+	 * Restores a previously known awake status without recording a new observation
+	 */
+	public restoreAwakeStatus(): void {
 		this.updateStatusMachine({ value: "AWAKE" });
 	}
 

--- a/packages/zwave-js/src/lib/node/mixins/20_Status.ts
+++ b/packages/zwave-js/src/lib/node/mixins/20_Status.ts
@@ -56,7 +56,7 @@ export interface NodeWithStatus {
 	markAsAwake(): void;
 
 	/**
-	 * The last time this node was known to be awake. Only tracked for nodes that can sleep.
+	 * The last time this node was observed to be awake. Only tracked for nodes that can sleep.
 	 */
 	readonly lastAwake: MaybeNotKnown<Date>;
 
@@ -173,11 +173,10 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 	 * Marks this node as awake (if applicable)
 	 */
 	public markAsAwake(): void {
-		// Nodes are marked awake whenever we observe them being awake, which may
-		// happen repeatedly while we already believe them to be. Remember the
-		// most recent observation, not just the one that changed the status.
-		// The guard mirrors the status machine, which only enters "awake" for
-		// nodes that can sleep.
+		// Record every observation, not just the ones that change the status: a node
+		// that is kept awake or whose transition to sleep was missed keeps waking up
+		// while we already believe it to be awake. For always-listening nodes there
+		// is no wake-up to record.
 		if (this.canSleep) this.lastAwake = new Date();
 		this.updateStatusMachine({ value: "AWAKE" });
 	}
@@ -219,11 +218,10 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 		this._ready = ready;
 	}
 
-	/** The last time this node was known to be awake. Only tracked for nodes that can sleep. */
 	public get lastAwake(): MaybeNotKnown<Date> {
 		return this.driver.cacheGet(cacheKeys.node(this.id).lastAwake);
 	}
-	protected set lastAwake(value: MaybeNotKnown<Date>) {
+	private set lastAwake(value: MaybeNotKnown<Date>) {
 		this.driver.cacheSet(cacheKeys.node(this.id).lastAwake, value);
 	}
 

--- a/packages/zwave-js/src/lib/test/node/Node.lastAwake.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.lastAwake.test.ts
@@ -1,3 +1,4 @@
+import { WakeUpCCWakeUpNotification } from "@zwave-js/cc";
 import { MockController } from "@zwave-js/testing";
 import { test as baseTest } from "vitest";
 import { createDefaultMockControllerBehaviors } from "../../../Testing.js";
@@ -45,46 +46,45 @@ const test = baseTest.extend<LocalTestContext>({
 	],
 });
 
-function createNode(driver: Driver, canSleep: boolean): ZWaveNode {
+function createNode(driver: Driver): ZWaveNode {
 	// Not node 1, which is the controller and can never sleep
 	const node = new ZWaveNode(2, driver);
-	node["isListening"] = !canSleep;
+	node["isListening"] = false;
 	node["isFrequentListening"] = false;
 	return node;
 }
 
-const longAgo = new Date(2020, 0, 1);
+function wakeUpNotification(node: ZWaveNode): WakeUpCCWakeUpNotification {
+	return new WakeUpCCWakeUpNotification({ nodeId: node.id });
+}
 
-test("Marking a sleeping node as awake remembers when it was observed", ({ context, expect }) => {
-	const node = createNode(context.driver, true);
-	node.markAsAwake();
+const longAgo = new Date(1970, 0, 1);
+
+test("A Wake Up notification records when the node was awake", async ({ context, expect }) => {
+	const node = createNode(context.driver);
+	expect(node.lastAwake).toBeUndefined();
+
+	await node.handleCommand(wakeUpNotification(node));
 	expect(node.lastAwake).toBeInstanceOf(Date);
 	node.destroy();
 });
 
-test("Nodes that are always listening do not track when they were awake", ({ context, expect }) => {
-	const node = createNode(context.driver, false);
-	node.markAsAwake();
-	expect(node.lastAwake).toBeUndefined();
-	node.destroy();
-});
-
-test("Marking an already awake node as awake updates when it was observed", ({ context, expect }) => {
-	const node = createNode(context.driver, true);
-	node.markAsAwake();
-	node["lastAwake"] = longAgo;
+test("Repeated Wake Up notifications update when the node was last awake", async ({ context, expect }) => {
+	const node = createNode(context.driver);
+	await node.handleCommand(wakeUpNotification(node));
+	node.lastAwake = longAgo;
 
 	// The node is already considered awake, so this does not change its status
-	node.markAsAwake();
+	await node.handleCommand(wakeUpNotification(node));
 	expect(node.lastAwake.getTime()).toBeGreaterThan(longAgo.getTime());
 	node.destroy();
 });
 
-test("Restoring the awake status does not count as an observation", ({ context, expect }) => {
-	const node = createNode(context.driver, true);
-	node["lastAwake"] = longAgo;
+test("Marking a node as awake does not count as an observation", ({ context, expect }) => {
+	const node = createNode(context.driver);
+	node.lastAwake = longAgo;
 
-	node.restoreAwakeStatus();
+	node.markAsAwake();
 	expect(node.lastAwake).toStrictEqual(longAgo);
 	node.destroy();
 });

--- a/packages/zwave-js/src/lib/test/node/Node.lastAwake.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.lastAwake.test.ts
@@ -1,5 +1,6 @@
 import { WakeUpCCWakeUpNotification } from "@zwave-js/cc";
 import { MockController } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
 import { test as baseTest } from "vitest";
 import { createDefaultMockControllerBehaviors } from "../../../Testing.js";
 import type { Driver } from "../../driver/Driver.js";
@@ -16,7 +17,6 @@ interface LocalTestContext {
 const test = baseTest.extend<LocalTestContext>({
 	context: [
 		async ({}, use) => {
-			// Setup
 			const context = {} as LocalTestContext["context"];
 
 			const { driver } = await createAndStartTestingDriver({
@@ -35,10 +35,8 @@ const test = baseTest.extend<LocalTestContext>({
 			});
 			context.driver = driver;
 
-			// Run tests
 			await use(context);
 
-			// Teardown
 			driver.removeAllListeners();
 			await driver.destroy();
 		},
@@ -47,7 +45,6 @@ const test = baseTest.extend<LocalTestContext>({
 });
 
 function createNode(driver: Driver): ZWaveNode {
-	// Not node 1, which is the controller and can never sleep
 	const node = new ZWaveNode(2, driver);
 	node["isListening"] = false;
 	node["isFrequentListening"] = false;
@@ -72,11 +69,11 @@ test("A Wake Up notification records when the node was awake", async ({ context,
 test("Repeated Wake Up notifications update when the node was last awake", async ({ context, expect }) => {
 	const node = createNode(context.driver);
 	await node.handleCommand(wakeUpNotification(node));
-	node.lastAwake = longAgo;
+	const firstAwake = node.lastAwake!;
 
-	// The node is already considered awake, so this does not change its status
+	await wait(5);
 	await node.handleCommand(wakeUpNotification(node));
-	expect(node.lastAwake.getTime()).toBeGreaterThan(longAgo.getTime());
+	expect(node.lastAwake!.getTime()).toBeGreaterThan(firstAwake.getTime());
 	node.destroy();
 });
 

--- a/packages/zwave-js/src/lib/test/node/Node.lastAwake.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.lastAwake.test.ts
@@ -1,0 +1,90 @@
+import { MockController } from "@zwave-js/testing";
+import { test as baseTest } from "vitest";
+import { createDefaultMockControllerBehaviors } from "../../../Testing.js";
+import type { Driver } from "../../driver/Driver.js";
+import { createAndStartTestingDriver } from "../../driver/DriverMock.js";
+import { ZWaveNode } from "../../node/Node.js";
+
+interface LocalTestContext {
+	context: {
+		driver: Driver;
+		controller: MockController;
+	};
+}
+
+const test = baseTest.extend<LocalTestContext>({
+	context: [
+		async ({}, use) => {
+			// Setup
+			const context = {} as LocalTestContext["context"];
+
+			const { driver } = await createAndStartTestingDriver({
+				skipNodeInterview: true,
+				loadConfiguration: false,
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
+						mockPort,
+						serial,
+					});
+					controller.defineBehavior(
+						...createDefaultMockControllerBehaviors(),
+					);
+					context.controller = controller;
+				},
+			});
+			context.driver = driver;
+
+			// Run tests
+			await use(context);
+
+			// Teardown
+			driver.removeAllListeners();
+			await driver.destroy();
+		},
+		{ auto: true },
+	],
+});
+
+function createNode(driver: Driver, canSleep: boolean): ZWaveNode {
+	// Not node 1, which is the controller and can never sleep
+	const node = new ZWaveNode(2, driver);
+	node["isListening"] = !canSleep;
+	node["isFrequentListening"] = false;
+	return node;
+}
+
+const longAgo = new Date(2020, 0, 1);
+
+test("Marking a sleeping node as awake remembers when it was observed", ({ context, expect }) => {
+	const node = createNode(context.driver, true);
+	node.markAsAwake();
+	expect(node.lastAwake).toBeInstanceOf(Date);
+	node.destroy();
+});
+
+test("Nodes that are always listening do not track when they were awake", ({ context, expect }) => {
+	const node = createNode(context.driver, false);
+	node.markAsAwake();
+	expect(node.lastAwake).toBeUndefined();
+	node.destroy();
+});
+
+test("Marking an already awake node as awake updates when it was observed", ({ context, expect }) => {
+	const node = createNode(context.driver, true);
+	node.markAsAwake();
+	node["lastAwake"] = longAgo;
+
+	// The node is already considered awake, so this does not change its status
+	node.markAsAwake();
+	expect(node.lastAwake.getTime()).toBeGreaterThan(longAgo.getTime());
+	node.destroy();
+});
+
+test("Restoring the awake status does not count as an observation", ({ context, expect }) => {
+	const node = createNode(context.driver, true);
+	node["lastAwake"] = longAgo;
+
+	node.restoreAwakeStatus();
+	expect(node.lastAwake).toStrictEqual(longAgo);
+	node.destroy();
+});


### PR DESCRIPTION
Fixes #9153

`Last Awake` was only tracked in Z-Wave JS UI's memory, so it was lost on every restart and stayed empty until the node woke up again — exactly when the information is most useful for diagnosing an unresponsive node.

The driver now tracks it itself and stores it in the network cache, next to `lastSeen`:

```ts
node.lastAwake; // Date | undefined — the last time the node sent a Wake Up notification
```

- Written when a Wake Up notification is received, which replaces the in-memory `lastWakeUp` timestamp the Wake Up handler kept for its wake-up-interval check. That handler now reads `node.lastAwake` instead, so the `WakeUpHandlerStore` is gone.
- Only sleeping nodes send Wake Up notifications, so the value stays empty for nodes that are never "awake" in the status sense.
- `markAsAwake()` does not touch it. The driver marks nodes as awake for reasons other than an observation, e.g. `keepAwake` during interviews and firmware updates, and a node kept awake that way has not told us anything new about when it was last up.
- Serialized like `lastSeen` (timestamp), so no new cache format, and old cache files stay readable in both directions.
- Deliberately not mirrored into `NodeStatistics`: it is a node property, not a communication statistic, and Z-Wave JS UI already updates its own value from the `wake up` event — what it was missing is the restored value at startup.

https://claude.ai/code/session_017Ai6n3wiRtNXiBdT17189a
