### PR TITLE
docs: add AI contribution policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,80 @@
+# Z-Wave JS AI Policy
+
+We support using AI tools, including large language models, when contributing
+to Z-Wave JS projects. However, you are responsible for any contributions you
+submit, and we are responsible for any contributions we merge and release. We
+hold a high bar for all contributions to our projects.
+
+Our maintainers dedicate their time and expertise to reviewing contributions.
+Submitting AI-generated content that you have not personally reviewed and
+understood wastes that time and will not be accepted.
+
+## Autonomous agents
+
+**We do not allow autonomous agents to be used for contributing to our
+projects.** We will close any pull requests or issues that we believe were
+created autonomously, and may mark automated comments as spam. This includes
+contributions that bypass the provided issue or pull request templates.
+
+## Communication on issues, pull requests, and code reviews
+
+We don't mind if you use AI tools to help you write. However, do not have tools
+post unreviewed content on your behalf. Keep responses to the minimum needed to
+communicate your intent. We may hide any comments that we believe are
+unreviewed AI output.
+
+If you are opening a pull request, we expect you to be able to explain the
+proposed changes in your own words. This includes the pull request description
+and responses to questions. If you use AI to help generate the pull request
+summary, you must review it for technical accuracy.
+
+**Do not use AI to generate answers to questions from maintainers.** You should
+understand and be able to explain your own work. Using AI to improve grammar or
+clarity is fine, but the substance of your responses must be your own.
+
+If you wish to include context from an interaction with AI in your comments, it
+must be in a quote block and disclosed as such. It must be accompanied by your
+own commentary explaining the relevance and implications of the context. Do
+not share long snippets.
+
+## Non-native English speakers
+
+We understand that AI is useful when communicating as a non-native English
+speaker. Using AI to improve the grammar or clarity of text you have written
+yourself is fine. If you are using AI to translate your comments, please ensure
+the translation accurately reflects your intent. Including your original text
+in a details block shows the effort behind your contribution, helps maintainers
+verify the translation if needed, and keeps the conversation readable.
+
+## Code and documentation contributions
+
+AI can be a helpful tool for writing code and documentation. However, due to
+the foundational open source nature of our projects, we require a human in the
+loop who understands the work produced by AI.
+
+All contributions must be reviewed and understood by the contributor before
+submission. You should be able to explain every change in a pull request you
+submit. Pull requests that appear to be unreviewed AI output will be closed
+without review.
+
+## Our use of AI
+
+Some of our projects use AI tools to assist with code reviews, issue triaging,
+reporting, and other project management tasks. These tools may leave comments
+on pull requests or issues. As with any automated tooling, these comments are
+not always correct.
+
+If an AI tool leaves a comment on your contribution, treat it as you would any
+other review comment. If you believe it is incorrect, say so; a brief
+explanation is sufficient. Maintainers always have the final say. If in doubt,
+ask a maintainer.
+
+## Enforcement
+
+Contributions that do not follow this policy will be closed. Repeated
+violations may result in being blocked from contributing to Z-Wave JS projects.
+If you believe your contribution was closed in error, you are welcome to reach
+out to a maintainer to discuss.
+
+This policy is adapted from the
+[Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,13 @@ First of all, welcome!
 
 We're happy that you're considering helping us out. Although the goal of this project is to be(come) the best Z-Wave driver out there, it is developed in our free time. So every bit of support helps. There are many ways to contribute, but also a few rules to follow, so we can use our precious time to make `zwave-js` better instead of wading through issues in GitHub.
 
+## AI policy
+
+This project follows the [Z-Wave JS AI Policy](AI_POLICY.md). In short, AI tools
+are welcome as an aid, but you must fully understand and be able to explain
+every change you submit. Contributions made by autonomous agents are not
+accepted.
+
 ## Do you have a problem? Something not working? Configuration missing?
 
 Please read the [troubleshooting](https://zwave-js.github.io/zwave-js/#/troubleshooting/index) section of the documentation. Your problem might already be answered there.


### PR DESCRIPTION
Adopts an AI contribution policy based on the Open Home Foundation policy used by Home Assistant.

The policy welcomes AI assistance when contributors review, understand, and can explain their work. It prohibits autonomous contributions and unreviewed AI communication. It also covers translation support, maintainer use of fallible AI tools, and enforcement.

`CONTRIBUTING.md` now links to the policy and summarizes its core requirements. The policy credits the Open Home Foundation source.