### PR TITLE
chore: ignore oxfmt migration in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Switched from Prettier to dprint
 13ab1142c38eae2cb04d6e85e62dd57d6587b468
+
+# Switched from dprint to oxfmt
+7bb01213b0f30b70cf65d1925e42232a108375a7


### PR DESCRIPTION
Follows #8596 and adds its squash commit to `.git-blame-ignore-revs`.