### PR TITLE
fix: await network cache switch before secondary controller bootstrapping

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1832,7 +1832,7 @@ This is emitted after joining another network, once security bootstrapping is do
 
 ### `"joining network failed"`
 
-This is emitted if joining another network failed. In this case, the `"network found"` and `"network joined"` events will not be emitted.
+This is emitted if joining another network failed. The `"network found"` event may already have been emitted before initialization failed. In that case, the controller already belongs to the new network. The `"network joined"` event will not be emitted for the failed attempt.
 
 ### `"network left"`
 

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -9603,22 +9603,15 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
 		) {
 			if (wasJoining) {
 				this._currentLearnMode = undefined;
-				this.driver["_securityManager"] = undefined;
-				this.driver["_securityManager2"] =
-					await SecurityManager2.create();
-				this.driver["_securityManagerLR"] =
-					await SecurityManager2.create();
 				this._nodes.clear();
 
-				process.nextTick(() => {
-					void this.afterJoiningNetwork().catch((e: unknown) => {
-						this._joinNetworkOptions = undefined;
-						this.driver.controllerLog.print(
-							`Joining network failed: ${getErrorMessage(e)}`,
-							"error",
-						);
-						this.emit("joining network failed");
-					});
+				void this.afterJoiningNetwork().catch((e: unknown) => {
+					this._joinNetworkOptions = undefined;
+					this.driver.controllerLog.print(
+						`Joining network failed: ${getErrorMessage(e)}`,
+						"error",
+					);
+					this.emit("joining network failed");
 				});
 				return true;
 			} else if (wasLeaving) {
@@ -10389,6 +10382,16 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
 		};
 
 		const identifySelf = async () => {
+			// Bootstrap reception must be armed before asynchronous crypto initialization
+			this.driver["_securityManager"] = undefined;
+			const [securityManager2, securityManagerLR] = await Promise.all([
+				SecurityManager2.create(),
+				SecurityManager2.create(),
+			]);
+			assertInitializationCanContinue();
+			this.driver["_securityManager2"] = securityManager2;
+			this.driver["_securityManagerLR"] = securityManagerLR;
+
 			// Update own node ID and other controller flags.
 			await this.identify();
 			assertInitializationCanContinue();

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -3,6 +3,7 @@ import {
 	AssociationCC,
 	type AssociationCheckResult,
 	type AssociationGroup,
+	type CommandClass,
 	ECDHProfiles,
 	FLiRS2WakeUpTime,
 	type FirmwareUpdateOptions,
@@ -298,6 +299,7 @@ import {
 	noop,
 	num2hex,
 	pick,
+	setTimer,
 } from "@zwave-js/shared";
 import { waitFor } from "@zwave-js/waddle";
 import { distinct } from "alcalzone-shared/arrays";
@@ -9608,7 +9610,16 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
 					await SecurityManager2.create();
 				this._nodes.clear();
 
-				process.nextTick(() => this.afterJoiningNetwork().catch(noop));
+				process.nextTick(() => {
+					void this.afterJoiningNetwork().catch((e: unknown) => {
+						this._joinNetworkOptions = undefined;
+						this.driver.controllerLog.print(
+							`Joining network failed: ${getErrorMessage(e)}`,
+							"error",
+						);
+						this.emit("joining network failed");
+					});
+				});
 				return true;
 			} else if (wasLeaving) {
 				this._currentLearnMode = undefined;
@@ -10275,6 +10286,19 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
 		}
 	}
 
+	private _securityBootstrapInitiation:
+		| {
+				handleCommand: (command: CommandClass) => boolean;
+				cancel: () => void;
+		  }
+		| undefined;
+
+	private handleSecurityBootstrapCommand(command: CommandClass): boolean {
+		return (
+			this._securityBootstrapInitiation?.handleCommand(command) ?? false
+		);
+	}
+
 	private async afterJoiningNetwork(): Promise<void> {
 		this.driver.driverLog.print("waiting for security bootstrapping...");
 
@@ -10308,34 +10332,94 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
 			initPredicate = () => false;
 		}
 
-		const bootstrapInitPromise = this.driver
-			.waitForCommand<Security2CCKEXGet | SecurityCCSchemeGet>(
-				initPredicate,
-				initTimeout,
-			)
-			.catch(() => "timeout" as const);
+		const bootstrapInitPromise = createDeferredPromise<
+			Security2CCKEXGet | SecurityCCSchemeGet | "timeout"
+		>();
+		let bootstrapInitReceivedAt: number | undefined;
+		let accepting = true;
+		let canceled = false;
+		const timeout = setTimer(() => {
+			accepting = false;
+			bootstrapInitPromise.resolve("timeout");
+		}, initTimeout);
+		this._securityBootstrapInitiation = {
+			handleCommand: (command) => {
+				if (
+					!accepting
+					|| command.frameType !== "singlecast"
+					|| !(
+						command instanceof Security2CCKEXGet
+						|| command instanceof SecurityCCSchemeGet
+					)
+					|| !initPredicate(command)
+				) {
+					return false;
+				}
+				bootstrapInitReceivedAt = Date.now();
+				timeout.clear();
+				accepting = false;
+				bootstrapInitPromise.resolve(command);
+				return true;
+			},
+			cancel: () => {
+				canceled = true;
+				accepting = false;
+				timeout.clear();
+				bootstrapInitPromise.resolve("timeout");
+			},
+		};
+
+		const assertInitializationCanContinue = () => {
+			if (canceled) {
+				throw new ZWaveError(
+					"Driver destroyed during network joining",
+					ZWaveErrorCodes.Driver_Destroyed,
+				);
+			}
+			// The including controller's response deadline starts when it sends bootstrap initiation
+			if (
+				bootstrapInitReceivedAt !== undefined
+				&& Date.now() - bootstrapInitReceivedAt >= 10000
+			) {
+				throw new ZWaveError(
+					"Network initialization exceeded the security bootstrap response deadline",
+					ZWaveErrorCodes.Controller_NodeTimeout,
+				);
+			}
+		};
 
 		const identifySelf = async () => {
 			// Update own node ID and other controller flags.
-			await this.identify().catch(noop);
+			await this.identify();
+			assertInitializationCanContinue();
 
 			// Notify applications that we're now part of a new network
-			// The driver will point the databases to the new home ID
 			this.emit("network found", this._homeId!, this._ownNodeId!);
 
-			// Figure out the controller's network role
-			await this.getControllerCapabilities().catch(noop);
-
-			// Create new node instances
-			const { nodeIds } = await this.getSerialApiInitData();
+			const [, { nodeIds }] = await Promise.all([
+				this.driver["prepareForJoinedNetwork"](this._homeId!),
+				(async () => {
+					await this.getControllerCapabilities();
+					return this.getSerialApiInitData();
+				})(),
+			]);
+			assertInitializationCanContinue();
+			// Nodes must capture the new databases after all three stores have opened
 			await this.initNodes(nodeIds, [], () => Promise.resolve());
 		};
 
 		// Do the self-identification while waiting for the bootstrap init command
-		const [bootstrapInit] = await Promise.all([
-			bootstrapInitPromise,
-			identifySelf(),
-		]);
+		let bootstrapInit: Awaited<typeof bootstrapInitPromise>;
+		try {
+			[bootstrapInit] = await Promise.all([
+				bootstrapInitPromise,
+				identifySelf(),
+			]);
+			assertInitializationCanContinue();
+		} finally {
+			timeout.clear();
+			this._securityBootstrapInitiation = undefined;
+		}
 
 		if (bootstrapInit === "timeout") {
 			this.driver.controllerLog.print(
@@ -10350,7 +10434,7 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
 						"Received S2 bootstrap initiation from unknown node, ignoring...",
 					level: "warn",
 				});
-			} else if (Date.now() - bootstrapInitStart > 10000) {
+			} else if (bootstrapInitReceivedAt! - bootstrapInitStart > 10000) {
 				// Received too late, S0 bootstrapping must not continue
 				this.driver.controllerLog.print(
 					"Security S0 bootstrapping command received too late, continuing without encryption...",
@@ -10469,6 +10553,8 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
 	}
 
 	public destroy(): void {
+		this._securityBootstrapInitiation?.cancel();
+		this._securityBootstrapInitiation = undefined;
 		this._nodes.forEach((node) => node.destroy());
 		this._nodes.clear();
 		this.removeAllListeners();

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -10372,7 +10372,7 @@ export class ZWaveController extends TypedEventTarget<ControllerEventCallbacks> 
 		const assertInitializationCanContinue = () => {
 			if (canceled) {
 				throw new ZWaveError(
-					"Driver destroyed during network joining",
+					"Controller destroyed during network joining",
 					ZWaveErrorCodes.Driver_Destroyed,
 				);
 			}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2065,7 +2065,6 @@ export class Driver
 			.on("node added", this.onNodeAdded.bind(this))
 			.on("node removed", this.onNodeRemoved.bind(this))
 			.on("status changed", this.onControllerStatusChanged.bind(this))
-			.on("network found", this.onNetworkFound.bind(this))
 			.on("network joined", this.onNetworkJoined.bind(this))
 			.on("network left", this.onNetworkLeft.bind(this))
 			// Re-evaluate the send queues, which hold back interview traffic
@@ -3080,25 +3079,13 @@ export class Driver
 		this.triggerQueues();
 	}
 
-	private async onNetworkFound(
-		homeId: number,
-		_ownNodeId: number,
-	): Promise<void> {
-		try {
-			this.driverLog.print(
-				`Joined network with home ID ${num2hex(
-					homeId,
-				)}, switching to new network cache...`,
-			);
-			await this.recreateNetworkCacheAndValueDBs();
-		} catch (e) {
-			this.driverLog.print(
-				`Recreating the network cache and value DBs failed: ${getErrorMessage(
-					e,
-				)}`,
-				"error",
-			);
-		}
+	private async prepareForJoinedNetwork(homeId: number): Promise<void> {
+		this.driverLog.print(
+			`Joined network with home ID ${num2hex(
+				homeId,
+			)}, switching to new network cache...`,
+		);
+		await this.recreateNetworkCacheAndValueDBs();
 	}
 
 	private onNetworkJoined(): void {
@@ -4193,6 +4180,16 @@ export class Driver
 		// If the message could be decoded, forward it to the send thread
 		if (msg) {
 			if (isCommandRequest(msg) && containsCC(msg)) {
+				// Bootstrap initiation can arrive before the joining controller has created its nodes
+				if (
+					this._controller?.["handleSecurityBootstrapCommand"](
+						msg.command,
+					)
+				) {
+					this.driverLog.logMessage(msg, { direction: "inbound" });
+					return;
+				}
+
 				// SecurityCCCommandEncapsulationNonceGet is two commands in one, but
 				// we're not set up to handle things like this. Reply to the nonce get
 				// and handle the encapsulation part normally


### PR DESCRIPTION
Await the network cache and value database switch before constructing nodes after joining a network. This prevents nodes from retaining references to closed databases on slower filesystems.

Capture the first supported, unencrypted, singlecast S0 SchemeGet or S2 KEXGet during initialization. Capture runs before the normal unknown-node rejection. The response deadline includes the time spent waiting for initialization. S0 initiation timing uses the command's reception time.

Propagate cache-switch failures to the joining flow. Log unexpected joining failures and emit `joining network failed`. Remove the temporary receiver on initialization completion or failure. Cancel it when the controller is destroyed.

Fixes: https://github.com/zwave-js/zwave-js/issues/9193