### PR TITLE
feat: include node ID in invalid payload warnings

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4366,18 +4366,20 @@ export class Driver
 				case ZWaveErrorCodes.PacketFormat_InvalidPayload:
 					if (msg) {
 						const nodeId = msg.getNodeId();
-						this.driverLog.print(
-							`Dropping message with invalid payload${
-								nodeId != undefined
-									? ` from node ${nodeId}`
-									: ""
-							}${
-								typeof e.context === "string"
-									? ` (Reason: ${e.context})`
-									: ""
-							}`,
-							"warn",
-						);
+						const message = `Dropping message with invalid payload${
+							typeof e.context === "string"
+								? ` (Reason: ${e.context})`
+								: ""
+						}`;
+						if (nodeId != undefined) {
+							this.controllerLog.logNode(nodeId, {
+								message,
+								direction: "inbound",
+								level: "warn",
+							});
+						} else {
+							this.driverLog.print(message, "warn");
+						}
 						try {
 							this.driverLog.logMessage(msg, {
 								direction: "inbound",

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4365,8 +4365,17 @@ export class Driver
 
 				case ZWaveErrorCodes.PacketFormat_InvalidPayload:
 					if (msg) {
+						const nodeId = msg.getNodeId();
 						this.driverLog.print(
-							`Dropping message with invalid payload`,
+							`Dropping message with invalid payload${
+								nodeId != undefined
+									? ` from node ${nodeId}`
+									: ""
+							}${
+								typeof e.context === "string"
+									? ` (Reason: ${e.context})`
+									: ""
+							}`,
 							"warn",
 						);
 						try {

--- a/packages/zwave-js/src/lib/test/driver/invalidPayloadLog.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/invalidPayloadLog.test.ts
@@ -47,6 +47,10 @@ integrationTest("when an invalid CC is received, this is printed in the logs", {
 
 		await wait(100);
 		assertMessage(t.expect, spyTransport, {
+			callNumber: 0,
+			message: "  Dropping message with invalid payload from node 33",
+		});
+		assertMessage(t.expect, spyTransport, {
 			callNumber: 1,
 			message: `« [Node 033] [REQ] [ApplicationCommand]
   └─[BinarySensorCCReport] [INVALID]`,

--- a/packages/zwave-js/src/lib/test/driver/invalidPayloadLog.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/invalidPayloadLog.test.ts
@@ -48,7 +48,7 @@ integrationTest("when an invalid CC is received, this is printed in the logs", {
 		await wait(100);
 		assertMessage(t.expect, spyTransport, {
 			callNumber: 0,
-			message: "  Dropping message with invalid payload from node 33",
+			message: "« [Node 033] Dropping message with invalid payload",
 		});
 		assertMessage(t.expect, spyTransport, {
 			callNumber: 1,


### PR DESCRIPTION
Invalid-payload warnings now include the source node ID when it is available from the parsed message. They also include string validation reasons from the existing error context. Messages that fail before parsing keep the current raw-buffer fallback.

Tested with `yarn vitest run packages/zwave-js/src/lib/test/driver/invalidPayloadLog.test.ts`.

Closes #9195