### PR TITLE
fix(mcp): expose read-only tool annotations

### DIFF
--- a/packages/mcp-server-dev/src/index.ts
+++ b/packages/mcp-server-dev/src/index.ts
@@ -124,6 +124,7 @@ class DevMCPServer {
 					name: tool.name,
 					description: tool.description,
 					inputSchema: tool.inputSchema,
+					annotations: tool.annotations,
 				})),
 			};
 		});

--- a/packages/mcp-server-dev/src/tools/autofixConfig.ts
+++ b/packages/mcp-server-dev/src/tools/autofixConfig.ts
@@ -300,6 +300,12 @@ export const autofixConfigTool: ToolHandler<AutofixConfigArgs> = {
 		+ "unnecessary overrides of imported template properties, and report any "
 		+ "remaining import-override conflicts (allowed vs. minValue/maxValue) "
 		+ "that must be resolved manually.",
+	annotations: {
+		readOnlyHint: false,
+		destructiveHint: true,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
 	inputSchema: {
 		type: "object",
 		properties: {

--- a/packages/mcp-server-dev/src/tools/findSimilarParameters.ts
+++ b/packages/mcp-server-dev/src/tools/findSimilarParameters.ts
@@ -68,6 +68,12 @@ export function createFindSimilarParametersTool(
 			+ "model; the response may report "
 			+ "model_download_consent_required instead of results if the local "
 			+ "model needs a one-time download that the client cannot confirm.",
+		annotations: {
+			readOnlyHint: true,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		},
 		inputSchema: {
 			type: "object",
 			properties: {

--- a/packages/mcp-server-dev/src/tools/findTemplateDefinition.ts
+++ b/packages/mcp-server-dev/src/tools/findTemplateDefinition.ts
@@ -117,6 +117,12 @@ export const findTemplateDefinitionTool: ToolHandler<FindTemplateDefinitionArgs>
 			+ "and either an $import specifier or a parameter number that uses "
 			+ "$import, returns the target file and the line/column of the "
 			+ "definition (file start if the specifier has no #key).",
+		annotations: {
+			readOnlyHint: true,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
 		inputSchema: {
 			type: "object",
 			properties: {

--- a/packages/mcp-server-dev/src/tools/findTemplateReferences.ts
+++ b/packages/mcp-server-dev/src/tools/findTemplateReferences.ts
@@ -111,6 +111,12 @@ export const findTemplateReferencesTool: ToolHandler<FindTemplateReferencesArgs>
 			"Find all $import references to a template across every device config "
 			+ "file. Given the template file and the top-level template name, "
 			+ "returns each importing file with its line/column.",
+		annotations: {
+			readOnlyHint: true,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
 		inputSchema: {
 			type: "object",
 			properties: {

--- a/packages/mcp-server-dev/src/tools/format.ts
+++ b/packages/mcp-server-dev/src/tools/format.ts
@@ -41,6 +41,12 @@ async function handleFormat(): Promise<CallToolResult> {
 export const formatTool: ToolHandler = {
 	name: TOOL_NAME,
 	description: "Format all code according to the project's standards",
+	annotations: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
 	inputSchema: {
 		type: "object",
 		properties: {},

--- a/packages/mcp-server-dev/src/tools/lintConfig.ts
+++ b/packages/mcp-server-dev/src/tools/lintConfig.ts
@@ -136,6 +136,12 @@ async function handleLintConfig(args: LintConfigArgs): Promise<CallToolResult> {
 export const lintConfigTool: ToolHandler = {
 	name: TOOL_NAME,
 	description: "Check semantic correctness of configuration files",
+	annotations: {
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
 	inputSchema: {
 		type: "object",
 		properties: {

--- a/packages/mcp-server-dev/src/tools/resolveImport.ts
+++ b/packages/mcp-server-dev/src/tools/resolveImport.ts
@@ -43,6 +43,12 @@ export const resolveImportTool: ToolHandler<ResolveConfigImportArgs> = {
 		"Resolve an $import specifier to the JSON it pulls in, with the "
 		+ "imported file's own $imports resolved recursively. Mirrors the config "
 		+ "editor's import hover preview.",
+	annotations: {
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
 	inputSchema: {
 		type: "object",
 		properties: {

--- a/packages/mcp-server-dev/src/tools/resolveParam.ts
+++ b/packages/mcp-server-dev/src/tools/resolveParam.ts
@@ -135,6 +135,12 @@ export const resolveParamTool: ToolHandler<ResolveConfigParamArgs> = {
 		+ "as-is (matching the config editor preview); pass firmwareVersion to "
 		+ "fully evaluate conditionals for a specific firmware. Returns all "
 		+ "matching parameter variants when more than one exists.",
+	annotations: {
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
 	inputSchema: {
 		type: "object",
 		properties: {

--- a/packages/mcp-server-dev/src/tools/searchParameterDefinitions.ts
+++ b/packages/mcp-server-dev/src/tools/searchParameterDefinitions.ts
@@ -77,6 +77,12 @@ export function createSearchParameterDefinitionsTool(
 			+ "templates are returned separately. Uses the bundled local embedding "
 			+ "model; if it needs a one-time download, the response may report "
 			+ "model_download_consent_required instead of results.",
+		annotations: {
+			readOnlyHint: true,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		},
 		inputSchema: {
 			type: "object",
 			properties: {

--- a/packages/mcp-server-dev/src/tools/suggestParameterPurpose.ts
+++ b/packages/mcp-server-dev/src/tools/suggestParameterPurpose.ts
@@ -65,6 +65,12 @@ export function createSuggestParameterPurposeTool(
 			+ "Returns ranked purposes with similarity, sample size, confidence, "
 			+ "and representative parameter definitions; suggestions are evidence "
 			+ "for review and are never applied automatically.",
+		annotations: {
+			readOnlyHint: true,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		},
 		inputSchema: {
 			type: "object",
 			properties: {

--- a/packages/mcp-server-dev/src/types.ts
+++ b/packages/mcp-server-dev/src/types.ts
@@ -4,5 +4,6 @@ export interface ToolHandler<TArgs = any> {
 	name: string;
 	description: string;
 	inputSchema: Tool["inputSchema"];
+	annotations: NonNullable<Tool["annotations"]>;
 	handler: (args: TArgs) => Promise<CallToolResult>;
 }


### PR DESCRIPTION
## Summary

- Forward MCP tool annotations in the `tools/list` response.
- Mark the eight diagnostic, navigation, and semantic-search tools as read-only.
- Keep `format` and `autofix_config` classified as writable.
- Require every `ToolHandler` to declare annotations so new tools cannot silently disappear from read-only clients.

## Background

Copilot code review starts custom MCP servers with `COPILOT_MCP_READ_ONLY_MODE=true`. The review run for #9089 started `zwave-dev`, then logged `MCP server "zwave-dev" has no allowed tools after filtering — omitting from config` because none of its tool definitions included `readOnlyHint`.

The repository-level Copilot MCP configuration has also been enabled in repository settings.

## Validation

- `yarn build`
- `yarn workspace @zwave-js/mcp-server-dev build`
- `yarn test:ts packages/mcp-server-dev/src`
- `yarn eslint packages/mcp-server-dev/src`
- `yarn oxlint --type-aware packages/mcp-server-dev/src`
- MCP `tools/list` reports eight read-only tools and two writable tools