### PR TITLE
ci(copilot): cache semantic model

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Enable Corepack
         shell: bash

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,9 +7,19 @@ on:
   push:
     paths:
       - .github/workflows/copilot-setup-steps.yml
+      - packages/mcp-server-dev/package.json
+      - packages/mcp-server-dev/src/semantic/embedding.ts
+      - packages/mcp-server-dev/src/semantic/env.ts
+      - packages/mcp-server-dev/src/semantic/prefetchModel.ts
+      - packages/mcp-server-dev/src/semantic/printModelCacheKey.ts
   pull_request:
     paths:
       - .github/workflows/copilot-setup-steps.yml
+      - packages/mcp-server-dev/package.json
+      - packages/mcp-server-dev/src/semantic/embedding.ts
+      - packages/mcp-server-dev/src/semantic/env.ts
+      - packages/mcp-server-dev/src/semantic/prefetchModel.ts
+      - packages/mcp-server-dev/src/semantic/printModelCacheKey.ts
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
@@ -46,3 +56,23 @@ jobs:
         run: |
           yarn install --immutable
           yarn bootstrap
+
+      - name: Resolve semantic model cache
+        id: semantic-model
+        shell: bash
+        run: |
+          echo "key=$(yarn workspace @zwave-js/mcp-server-dev print-semantic-model-cache-key)" >> "$GITHUB_OUTPUT"
+          echo "ZWAVE_DEV_SEMANTIC_MODEL_CACHE_DIR=$HOME/.cache/zwave-js-bot/models" >> "$GITHUB_ENV"
+
+      - name: Restore semantic model
+        id: semantic-model-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/zwave-js-bot/models
+          key: ${{ steps.semantic-model.outputs.key }}
+          restore-keys: embedding-model-
+
+      - name: Prefetch semantic model
+        if: steps.semantic-model-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: yarn workspace @zwave-js/mcp-server-dev prefetch-semantic-model

--- a/packages/mcp-server-dev/package.json
+++ b/packages/mcp-server-dev/package.json
@@ -56,7 +56,9 @@
   "scripts": {
     "build": "tsgo -b",
     "bootstrap": "yarn build",
-    "clean": "del-cli build/ *.tsbuildinfo"
+    "clean": "del-cli build/ *.tsbuildinfo",
+    "prefetch-semantic-model": "node build/semantic/prefetchModel.js",
+    "print-semantic-model-cache-key": "node build/semantic/printModelCacheKey.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mcp-server-dev/src/semantic/embedding.ts
+++ b/packages/mcp-server-dev/src/semantic/embedding.ts
@@ -11,6 +11,7 @@ import type { EmbeddingCacheKey } from "./embeddingCache.js";
 import {
 	EMBEDDING_SCHEMA_VERSION,
 	LOCAL_MODEL_APPROX_SIZE_MB,
+	LOCAL_MODEL_DTYPE,
 	LOCAL_MODEL_DIMENSIONS,
 	LOCAL_MODEL_ID,
 	LOCAL_MODEL_LICENSE,
@@ -133,7 +134,7 @@ export class LocalEmbeddingProvider {
 			cache_dir: this.config.modelCacheDir,
 			local_files_only: localFilesOnly,
 			revision: LOCAL_MODEL_REVISION,
-			dtype: "q8",
+			dtype: LOCAL_MODEL_DTYPE,
 		});
 	}
 

--- a/packages/mcp-server-dev/src/semantic/env.test.ts
+++ b/packages/mcp-server-dev/src/semantic/env.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import { SemanticEnvError, parseSemanticEnv } from "./env.js";
+import {
+	LOCAL_MODEL_CACHE_KEY,
+	SemanticEnvError,
+	parseSemanticEnv,
+} from "./env.js";
+
+describe("LOCAL_MODEL_CACHE_KEY", () => {
+	it("matches the cache key used by the shared bot workflows", () => {
+		expect(LOCAL_MODEL_CACHE_KEY).toBe(
+			"Xenova_all-MiniLM-L6-v2@751bff37182d3f1213fa05d7196b954e230abad9@q8",
+		);
+	});
+});
 
 describe("parseSemanticEnv", () => {
 	it("defaults to enabled with an interactive download policy", () => {

--- a/packages/mcp-server-dev/src/semantic/env.ts
+++ b/packages/mcp-server-dev/src/semantic/env.ts
@@ -12,6 +12,12 @@ export const LOCAL_MODEL_REVISION = "751bff37182d3f1213fa05d7196b954e230abad9";
 export const LOCAL_MODEL_LICENSE = "Apache-2.0";
 export const LOCAL_MODEL_SOURCE =
 	"https://huggingface.co/Xenova/all-MiniLM-L6-v2";
+export const LOCAL_MODEL_DTYPE = "q8";
+export const LOCAL_MODEL_CACHE_KEY =
+	`${LOCAL_MODEL_ID}@${LOCAL_MODEL_REVISION}@${LOCAL_MODEL_DTYPE}`.replaceAll(
+		"/",
+		"_",
+	);
 /** Approximate size of the quantized (q8) ONNX weights plus tokenizer metadata */
 export const LOCAL_MODEL_APPROX_SIZE_MB = 24;
 export const LOCAL_MODEL_DIMENSIONS = 384;

--- a/packages/mcp-server-dev/src/semantic/prefetchModel.ts
+++ b/packages/mcp-server-dev/src/semantic/prefetchModel.ts
@@ -1,0 +1,17 @@
+import { LocalEmbeddingProvider } from "./embedding.js";
+import {
+	LOCAL_MODEL_ID,
+	LOCAL_MODEL_REVISION,
+	parseSemanticEnv,
+} from "./env.js";
+
+const config = {
+	...parseSemanticEnv(),
+	downloadPolicy: "allow" as const,
+};
+const provider = new LocalEmbeddingProvider(config, undefined);
+
+await provider.embed(["Z-Wave JS device configuration parameter"]);
+console.error(
+	`Cached ${LOCAL_MODEL_ID}@${LOCAL_MODEL_REVISION} in ${config.modelCacheDir}`,
+);

--- a/packages/mcp-server-dev/src/semantic/printModelCacheKey.ts
+++ b/packages/mcp-server-dev/src/semantic/printModelCacheKey.ts
@@ -1,0 +1,3 @@
+import { LOCAL_MODEL_CACHE_KEY } from "./env.js";
+
+console.log(`embedding-model-${LOCAL_MODEL_CACHE_KEY}`);


### PR DESCRIPTION
## Summary

- Reuse the MiniLM model cache produced by the shared `zwave-js/bot-workflows` embedding jobs.
- Export the shared cache path for the `zwave-dev` MCP process.
- Prefetch the pinned q8 model on an exact-key cache miss so headless Copilot reviews do not require MCP elicitation.
- Derive the cache key from the MCP model, revision, and dtype.
- Stop `actions/checkout` from persisting its token before setup runs checked-out code.

## Intent

#8958 introduced the semantic tools with cache-first loading and explicit headless download controls. #8971 then required semantic discovery for config authoring and declared the MCP configuration compatible with Copilot. #8985 explicitly established local CPU embeddings on GitHub runners and a shared model-weights cache. The current `zwave-js/bot-workflows` setup action stores that cache at `~/.cache/zwave-js-bot/models` under `embedding-model-<model>@<revision>@<dtype>`.

This change follows that existing GitHub behavior. Copilot restores the same cache and downloads the pinned model only when the exact shared key is unavailable.

## Workflow

```mermaid
flowchart TD
    Manual[workflow_dispatch] --> Setup
    Push[Push changing setup or model files] --> Setup
    PR[Pull request changing setup or model files<br/>May contain untrusted code] --> Setup
    Copilot[Copilot code review or cloud agent] --> Setup
    Nightly[Shared docs and posts embedding workflows] --> Cache[(Repository model cache)]

    Setup[Copilot setup job<br/>permissions: contents read] --> Checkout[Checkout<br/>credentials are not persisted]
    Checkout --> Build[Install dependencies and bootstrap<br/>Runs checked-out code]
    Build --> Key[Resolve shared model cache key<br/>Export MCP model cache path]
    Key --> Restore[Restore shared model cache]
    Cache --> Restore
    Restore --> Hit{Exact cache hit?}
    Hit -- Yes --> Agent[Start Copilot and zwave-dev]
    Hit -- No --> Prefetch[Prefetch pinned q8 model on CPU]
    Prefetch --> Save[Save model cache after the job]
    Save --> Cache
    Prefetch --> Agent

    classDef changed fill:#fff3cd,stroke:#b08800,stroke-width:2px;
    class Key,Restore,Prefetch,Save changed;
```

The pull-request path has no secrets and only `contents: read`. The checkout token is removed before dependency installation and bootstrap execute repository code.

## Validation

- `yarn workspace @zwave-js/mcp-server-dev build`
- `yarn test:ts packages/mcp-server-dev/src`
- `yarn eslint packages/mcp-server-dev/src`
- `yarn oxlint --type-aware packages/mcp-server-dev/src`
- Parsed `.github/workflows/copilot-setup-steps.yml` with `js-yaml`.
- Verified a cold prefetch downloads a 23 MB cache.
- Verified the generated key is `embedding-model-Xenova_all-MiniLM-L6-v2@751bff37182d3f1213fa05d7196b954e230abad9@q8`, matching `zwave-js/bot-workflows`.