### PR TITLE
fix(ci): precompute Copilot semantic index

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,18 +8,14 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
       - packages/mcp-server-dev/package.json
-      - packages/mcp-server-dev/src/semantic/embedding.ts
-      - packages/mcp-server-dev/src/semantic/env.ts
-      - packages/mcp-server-dev/src/semantic/prefetchModel.ts
-      - packages/mcp-server-dev/src/semantic/printModelCacheKey.ts
+      - packages/mcp-server-dev/src/semantic/**
+      - packages/config/config/devices/**/*.json
   pull_request:
     paths:
       - .github/workflows/copilot-setup-steps.yml
       - packages/mcp-server-dev/package.json
-      - packages/mcp-server-dev/src/semantic/embedding.ts
-      - packages/mcp-server-dev/src/semantic/env.ts
-      - packages/mcp-server-dev/src/semantic/prefetchModel.ts
-      - packages/mcp-server-dev/src/semantic/printModelCacheKey.ts
+      - packages/mcp-server-dev/src/semantic/**
+      - packages/config/config/devices/**/*.json
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
@@ -59,22 +55,36 @@ jobs:
           yarn install --immutable
           yarn bootstrap
 
-      - name: Resolve semantic model cache
-        id: semantic-model
+      - name: Resolve semantic caches
+        id: semantic-caches
         shell: bash
         run: |
-          echo "key=$(yarn workspace @zwave-js/mcp-server-dev print-semantic-model-cache-key)" >> "$GITHUB_OUTPUT"
+          echo "model-key=$(yarn workspace @zwave-js/mcp-server-dev print-semantic-model-cache-key)" >> "$GITHUB_OUTPUT"
+          echo "index-key=$(yarn workspace @zwave-js/mcp-server-dev print-semantic-index-cache-key)" >> "$GITHUB_OUTPUT"
           echo "ZWAVE_DEV_SEMANTIC_MODEL_CACHE_DIR=$HOME/.cache/zwave-js-bot/models" >> "$GITHUB_ENV"
+          echo "ZWAVE_DEV_SEMANTIC_INDEX_CACHE_DIR=$HOME/.cache/zwave-js-bot/semantic-index" >> "$GITHUB_ENV"
 
       - name: Restore semantic model
         id: semantic-model-cache
         uses: actions/cache@v6
         with:
           path: ~/.cache/zwave-js-bot/models
-          key: ${{ steps.semantic-model.outputs.key }}
+          key: ${{ steps.semantic-caches.outputs.model-key }}
           restore-keys: embedding-model-
 
       - name: Prefetch semantic model
         if: steps.semantic-model-cache.outputs.cache-hit != 'true'
         shell: bash
         run: yarn workspace @zwave-js/mcp-server-dev prefetch-semantic-model
+
+      - name: Restore semantic index
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/zwave-js-bot/semantic-index
+          key: ${{ steps.semantic-caches.outputs.index-key }}-${{ hashFiles('packages/config/config/devices/**/*.json') }}
+          restore-keys: |
+            ${{ steps.semantic-caches.outputs.index-key }}-
+
+      - name: Prepare semantic index
+        shell: bash
+        run: yarn workspace @zwave-js/mcp-server-dev prepare-semantic-index

--- a/packages/mcp-server-dev/package.json
+++ b/packages/mcp-server-dev/package.json
@@ -58,6 +58,8 @@
     "bootstrap": "yarn build",
     "clean": "del-cli build/ *.tsbuildinfo",
     "prefetch-semantic-model": "node build/semantic/prefetchModel.js",
+    "prepare-semantic-index": "node build/semantic/prepareIndex.js",
+    "print-semantic-index-cache-key": "node build/semantic/printIndexCacheKey.js",
     "print-semantic-model-cache-key": "node build/semantic/printModelCacheKey.js"
   },
   "publishConfig": {

--- a/packages/mcp-server-dev/src/semantic/env.test.ts
+++ b/packages/mcp-server-dev/src/semantic/env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	LOCAL_MODEL_CACHE_KEY,
+	SEMANTIC_INDEX_CACHE_KEY,
 	SemanticEnvError,
 	parseSemanticEnv,
 } from "./env.js";
@@ -10,6 +11,14 @@ describe("LOCAL_MODEL_CACHE_KEY", () => {
 	it("matches the cache key used by the shared bot workflows", () => {
 		expect(LOCAL_MODEL_CACHE_KEY).toBe(
 			"Xenova_all-MiniLM-L6-v2@751bff37182d3f1213fa05d7196b954e230abad9@q8",
+		);
+	});
+});
+
+describe("SEMANTIC_INDEX_CACHE_KEY", () => {
+	it("includes the model identity and embedding schema", () => {
+		expect(SEMANTIC_INDEX_CACHE_KEY).toBe(
+			"semantic-index-Xenova_all-MiniLM-L6-v2@751bff37182d3f1213fa05d7196b954e230abad9@q8@v3",
 		);
 	});
 });

--- a/packages/mcp-server-dev/src/semantic/env.test.ts
+++ b/packages/mcp-server-dev/src/semantic/env.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
 	LOCAL_MODEL_CACHE_KEY,
-	SEMANTIC_INDEX_CACHE_KEY,
 	SemanticEnvError,
 	parseSemanticEnv,
 } from "./env.js";
@@ -11,14 +10,6 @@ describe("LOCAL_MODEL_CACHE_KEY", () => {
 	it("matches the cache key used by the shared bot workflows", () => {
 		expect(LOCAL_MODEL_CACHE_KEY).toBe(
 			"Xenova_all-MiniLM-L6-v2@751bff37182d3f1213fa05d7196b954e230abad9@q8",
-		);
-	});
-});
-
-describe("SEMANTIC_INDEX_CACHE_KEY", () => {
-	it("includes the model identity and embedding schema", () => {
-		expect(SEMANTIC_INDEX_CACHE_KEY).toBe(
-			"semantic-index-Xenova_all-MiniLM-L6-v2@751bff37182d3f1213fa05d7196b954e230abad9@q8@v3",
 		);
 	});
 });

--- a/packages/mcp-server-dev/src/semantic/env.ts
+++ b/packages/mcp-server-dev/src/semantic/env.ts
@@ -24,6 +24,7 @@ export const LOCAL_MODEL_DIMENSIONS = 384;
 
 /** Bump when the embedding cache entry shape or the corpus normalization changes */
 export const EMBEDDING_SCHEMA_VERSION = 3;
+export const SEMANTIC_INDEX_CACHE_KEY = `semantic-index-${LOCAL_MODEL_CACHE_KEY}@v${EMBEDDING_SCHEMA_VERSION}`;
 
 export type LocalDownloadPolicy = "ask" | "allow" | "deny";
 

--- a/packages/mcp-server-dev/src/semantic/prepareIndex.ts
+++ b/packages/mcp-server-dev/src/semantic/prepareIndex.ts
@@ -1,0 +1,9 @@
+import { SemanticSearchService } from "./service.js";
+
+const service = new SemanticSearchService();
+const result = await service.prepareIndex();
+
+console.error(
+	`Cached ${result.parameters} parameters and ${result.templates} templates `
+		+ `with ${result.warnings} corpus warnings`,
+);

--- a/packages/mcp-server-dev/src/semantic/printIndexCacheKey.ts
+++ b/packages/mcp-server-dev/src/semantic/printIndexCacheKey.ts
@@ -1,0 +1,3 @@
+import { SEMANTIC_INDEX_CACHE_KEY } from "./env.js";
+
+console.log(SEMANTIC_INDEX_CACHE_KEY);

--- a/packages/mcp-server-dev/src/semantic/service.ts
+++ b/packages/mcp-server-dev/src/semantic/service.ts
@@ -304,6 +304,20 @@ export class SemanticSearchService {
 		}
 	}
 
+	async prepareIndex(): Promise<{
+		parameters: number;
+		templates: number;
+		warnings: number;
+	}> {
+		const corpus = await buildCorpus();
+		await this.buildIndex(corpus);
+		return {
+			parameters: corpus.parameters.length,
+			templates: corpus.templates.length,
+			warnings: corpus.warnings.length,
+		};
+	}
+
 	private matchesFilters(
 		filters: SearchFilters | undefined,
 		device: DeviceContext | undefined,


### PR DESCRIPTION
## Summary

- Precompute the semantic embedding index before Copilot starts.
- Cache the index by model, embedding schema, and device-config tree hash.
- Refresh the default-branch cache whenever device configs or semantic-search code change.

## Why

The model cache fixed download consent, but the first semantic MCP request still had to scan the full config corpus and create about 11,000 unique embeddings. GitHub's MCP client timed out before that work finished. Setup now completes the expensive work before the MCP server starts. Each PR restores the latest default-branch index and computes embeddings only for new or changed semantic hashes.

## Workflow

```mermaid
flowchart TD
    T[workflow_dispatch, push, or pull_request] --> C[Checkout repository]
    U[Untrusted pull request files] --> C
    C --> I[Install dependencies]
    I --> M[Restore pinned model cache]
    M --> R[Restore index by model, schema, and config hash]
    R --> P[Prepare missing semantic embeddings]
    P --> S[Start zwave-dev MCP server]
    S --> Q[Copilot semantic tool calls]
    G[contents: read; no secrets; checkout credentials removed] -.-> C

    classDef changed fill:#fff2cc,stroke:#d6b656,stroke-width:2px;
    class R,P changed;
```

## Validation

- MCP package build passes.
- All 84 MCP tests pass.
- ESLint, type-aware Oxlint, formatting, and workflow YAML checks pass.
- The uncached GitHub runner built the index in 1 minute 51 seconds.
- The cached GitHub runner restored the index in 2 seconds and prepared it in 6 seconds. The whole cached setup job completed in 38 seconds.