### PR TITLE
fix: apply path-specific formatting during code generation

### DIFF
--- a/packages/cc/maintenance/generateCCValueDefinitions.ts
+++ b/packages/cc/maintenance/generateCCValueDefinitions.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { formatWithOxfmt } from "@zwave-js/maintenance";
 import { getErrorMessage } from "@zwave-js/shared";
 import {
@@ -37,7 +39,7 @@ const ignoredImports = new Set(["V", "ValueMetadata"]);
  */
 export async function generateCCValueDefinitionsFile(
 	sourceFiles: SourceFile[],
-	_srcDir: string,
+	srcDir: string,
 ): Promise<Map<string, string>> {
 	const ccSourceFiles = sourceFiles.filter((file) =>
 		file.getBaseNameWithoutExtension().endsWith("CC"),
@@ -301,7 +303,10 @@ export const CCValues = {
 		+ result;
 
 	try {
-		result = await formatWithOxfmt("index.ts", result);
+		result = await formatWithOxfmt(
+			path.join(srcDir, "cc/_CCValues.generated.ts"),
+			result,
+		);
 	} catch (e) {
 		console.error(`Error formatting: ${getErrorMessage(e)}`);
 		process.exit(1);

--- a/packages/maintenance/src/docs/generateCCAPIs.ts
+++ b/packages/maintenance/src/docs/generateCCAPIs.ts
@@ -507,7 +507,7 @@ ${formattedValueType}
 	}
 
 	text = text.replaceAll("\r\n", "\n");
-	text = await formatWithOxfmt(filename, text);
+	text = await formatWithOxfmt(path.join(ccDocsDir, filename), text);
 
 	await fsp.writeFile(path.join(ccDocsDir, filename), text, "utf8");
 


### PR DESCRIPTION
Some code generators passed placeholder filenames to `formatWithOxfmt`. This prevented path-specific overrides from matching and could produce output that failed the repository-wide formatting check.

Pass the complete destination paths for generated CC documentation and CC value definitions so code generation and CI resolve the same oxfmt settings.