### PR TITLE
feat: expose endpoint groups from device configuration

### DIFF
--- a/.agents/instructions/config-files.md
+++ b/.agents/instructions/config-files.md
@@ -28,12 +28,13 @@ Device configuration files must follow this property order for consistency:
 6. `firmwareVersion` - Firmware version range the config applies to
 7. `preferred` - Mark as preferred over overlapping configs (only rarely needed)
 8. `endpoints` - Endpoint-specific configuration (only if needed)
-9. `associations` - Association groups (only if needed)
-10. `paramInformation` - Configuration parameters array
-11. `scenes` - Custom labels and description for Central Scenes (only if needed)
-12. `proprietary` - Proprietary CC settings (only if needed)
-13. `compat` - Compatibility flags for non-compliant devices (only if needed)
-14. `metadata` - User-facing metadata (inclusion instructions, etc.)
+9. `endpointGroups` - Physical-part grouping metadata (only if documented)
+10. `associations` - Association groups (only if needed)
+11. `paramInformation` - Configuration parameters array
+12. `scenes` - Custom labels and description for Central Scenes (only if needed)
+13. `proprietary` - Proprietary CC settings (only if needed)
+14. `compat` - Compatibility flags for non-compliant devices (only if needed)
+15. `metadata` - User-facing metadata (inclusion instructions, etc.)
 
 ## Consistency Guidelines
 
@@ -246,6 +247,28 @@ If an `endpoints` block is added to a config that already has root-level `associ
     "3": { "label": "Circuit 3" }
 }
 ```
+
+## Endpoint Groups
+
+```json
+"endpointGroups": {
+    "1": { "label": "Clamp 1", "endpoints": [1, 2] },
+    "2": { "label": "Clamp 2", "endpoints": [3, 4] }
+}
+```
+
+Use `endpointGroups` when the device documentation explicitly identifies multiple endpoints as belonging to the same physical part. Grouping is metadata and leaves endpoint behavior unchanged.
+
+- **Evidence:** Establish membership from the device manual or manufacturer's product page. Never infer membership from device classes, matching labels, or adjacent indices.
+- **Property order:** Place `endpointGroups` directly after `endpoints`, in slot 9.
+- **IDs:** Use numeric string keys starting at `"1"` without gaps in the authored file. Conditional filtering preserves the IDs.
+- **Labels:** Require a nonempty physical-part label. Follow the endpoint-label style rules.
+- **Members:** Require a nonempty array of unique integer endpoint indices from 0 to 127. Root endpoint 0 is allowed.
+- **Conditions:** Support `$if` per group. An endpoint may occur in at most one active group after evaluation. Mutually exclusive groups may share endpoint indices.
+- **Singletons:** A single configured member is allowed with a lint warning. Missing runtime endpoints may reduce a group to one member without a singleton warning.
+- **Independence:** Group membership requires no endpoint label or entry in `endpoints`. Adding only `endpointGroups` requires no root-association migration.
+
+Leave endpoints ungrouped when their physical relationship is undocumented. Whole-device totals may remain ungrouped. Applications decide how to present ungrouped endpoints.
 
 ## Central Scene Labels
 

--- a/.agents/skills/add-endpoint-labels/SKILL.md
+++ b/.agents/skills/add-endpoint-labels/SKILL.md
@@ -64,7 +64,7 @@ Files without root-level associations are safe to update directly.
 
 ## 5. Apply the Labels
 
-Insert the `endpoints` block in property order position 8 (after `firmwareVersion`/`preferred`, before `associations`). Only include endpoints that have a label. The `label` field is the only required field for a label-only endpoint entry:
+Insert the `endpoints` block in property order position 8 (after `firmwareVersion`/`preferred`, before `endpointGroups`/`associations`). Only include endpoints that have a label. The `label` field is the only required field for a label-only endpoint entry:
 
 ```json
 "endpoints": {
@@ -77,7 +77,27 @@ Insert the `endpoints` block in property order position 8 (after `firmwareVersio
 
 If an endpoint also has existing `associations` or `paramInformation`, keep them and add `label` alongside.
 
-## 6. Validate
+## 6. Record Documented Endpoint Groups
+
+When the documentation explicitly identifies several endpoints as the same physical part, add `endpointGroups` after `endpoints`. Follow the "Endpoint Groups" rules in `.agents/instructions/config-files.md`.
+
+```json
+"endpointGroups": {
+    "1": { "label": "Clamp 1", "endpoints": [1, 2] },
+    "2": { "label": "Clamp 2", "endpoints": [3, 4] }
+}
+```
+
+- **Evidence:** Use an explicit documented physical relationship. Matching device classes, labels, or adjacent indices are insufficient.
+- **IDs:** Start at `"1"` without gaps in the authored file.
+- **Members:** Include each endpoint at most once among active groups. Root endpoint 0 is allowed. Mutually exclusive `$if` groups may share indices.
+- **Labels:** Name the physical part using the endpoint-label style rules.
+- **Singletons:** A one-member group is allowed with a lint warning.
+- **Independence:** Grouped endpoints require no label or entry in `endpoints`. Adding only `endpointGroups` requires no root-association migration.
+
+Leave undocumented relationships ungrouped.
+
+## 7. Validate
 
 Run the `zwave-dev` MCP validation chain in order — do not finalize until all pass clean:
 

--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -112,6 +112,24 @@ readonly endpointLabel: string | undefined;
 
 If the device config file contains a label for this endpoint, it is exposed here.
 
+### `group`
+
+```ts
+readonly group: EndpointGroup | undefined;
+```
+
+Returns the shared group instance containing this endpoint. The group comes from [`node.endpointGroups`](api/node.md#endpointgroups). Returns `undefined` before endpoint discovery or when the endpoint is ungrouped.
+
+```ts
+const group = node.getEndpoint(1)?.group;
+if (group) {
+	console.log(group === node.endpointGroups?.get(group.id)); // true
+	console.log(group.endpoints.map((endpoint) => endpoint.index));
+}
+```
+
+The root endpoint can also belong to a group. Grouping leaves endpoint addressing, values, and command-class APIs unchanged.
+
 ### `installerIcon`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1233,6 +1233,40 @@ Contains additional information about this node, loaded from a [config file](/de
 
 This information may change after an update of the config files. To check whether a change occurred that requires a re-interview, use the [`hasDeviceConfigChanged`](#hasdeviceconfigchanged) method.
 
+### `endpointGroups`
+
+```ts
+readonly endpointGroups: ReadonlyMap<number, EndpointGroup> | undefined;
+```
+
+```ts
+const clamp = node.endpointGroups?.get(1);
+if (clamp) {
+	console.log(clamp.label);
+	for (const endpoint of clamp.endpoints) {
+		console.log(endpoint.index, endpoint.group === clamp);
+	}
+}
+```
+
+Exposes the physical-part groups defined in the [device config](config-files/file-format.md#endpointgroups). Each group contains the node's existing endpoint instances:
+
+```ts
+interface EndpointGroup {
+	readonly id: number;
+	readonly label: string;
+	readonly endpoints: readonly Endpoint[];
+}
+```
+
+Returns `undefined` until endpoint discovery completes. After discovery, an empty map means no groups with existing members apply. Missing endpoints are omitted from their groups and logged. Empty groups are omitted. The root endpoint may be a member.
+
+Group IDs are local to the node. Conditional filtering and missing members can leave gaps in the runtime IDs.
+
+Group instances are reused during normal operation. Reacquire them after a re-interview, a device-config reload, or a change to the discovered endpoints.
+
+Grouping is metadata. Applications retain control over presentation and the treatment of ungrouped endpoints. To serialize a group, convert its members to endpoint indices. Endpoint instances reference their group.
+
 ### `deviceDatabaseUrl`
 
 ```ts

--- a/docs/config-files/conditional-settings.md
+++ b/docs/config-files/conditional-settings.md
@@ -21,6 +21,7 @@ You can use `"$if"` in the following locations:
 
 - In the top-level `manufacturer`, `label` or `description` properties
 - Inside endpoint definitions
+- Inside endpoint group definitions
 - Inside association groups
 - Inside config parameters
 - Inside config parameter options

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -12,6 +12,7 @@ The following properties are defined and should always be present in the same or
 | `firmwareVersion`  | The firmware version range this config file is valid for, [see below](#firmwareVersion) for details.                                                                                                                             |
 | `preferred`        | Mark this config file as preferred over others with the same IDs, but overlapping firmware versions. Can be used to have a default white-labeled configuration with re-branded versions, without having to split files too much. |
 | `endpoints`        | Endpoint-specific configuration, [see below](#endpoints) for details. If this is present, `associations` must be specified on endpoint `"0"` instead of on the root level.                                                       |
+| `endpointGroups`   | Metadata identifying endpoints belonging to the same physical part, [see below](#endpointGroups) for details.                                                                                                                    |
 | `associations`     | The association groups the device supports, [see below](#associations) for details. Only needs to be present if the device does not support Z-Wave+ or requires changes to the default association config.                       |
 | `paramInformation` | An array of the configuration parameters the device supports. [See below](#paramInformation) for details.                                                                                                                        |
 | `scenes`           | Custom labels and descriptions for Central Scenes, [see below](#scenes) for details.                                                                                                                                             |
@@ -97,6 +98,31 @@ Optional endpoint-specific configuration. This includes associations, paramInfor
 	// etc.
 }
 ```
+
+## `endpointGroups`
+
+```json
+"endpointGroups": {
+	"1": { "label": "Clamp 1", "endpoints": [1, 2] },
+	"2": { "label": "Clamp 2", "endpoints": [3, 4] }
+}
+```
+
+This optional property identifies endpoints belonging to the same physical part of a device. Grouping is metadata. All endpoints retain their addresses and capabilities. Applications decide how to present the groups.
+
+- **IDs:** Use numeric string keys starting at `"1"` without gaps. IDs are local to the device config.
+- **Labels:** Each group requires a nonempty `label`. Use a short, documentation-derived physical-part name in Title Case.
+- **Members:** Each group requires a nonempty `endpoints` array of unique integers from 0 to 127. Endpoint 0 represents the root device.
+- **Conditions:** A group may have a [`$if` condition](config-files/conditional-settings.md). An endpoint may belong to at most one active group. Mutually exclusive groups may reference the same endpoint. Filtering preserves the configured group IDs.
+- **Singletons:** Groups with one configured member are allowed with a lint warning.
+
+Group membership and endpoint labels are independent. Grouped indices may be absent from the `endpoints` object. Adding only `endpointGroups` permits root-level `associations` to remain in place.
+
+Use the device manual or manufacturer's product page to establish membership. Device classes, matching labels, and endpoint numbering alone do not establish a physical relationship. Leave endpoints ungrouped when that relationship is undocumented.
+
+At runtime, [`node.endpointGroups`](api/node.md#endpointgroups) resolves member indices to existing endpoint instances after endpoint discovery. Missing members produce a warning. Groups without existing members are omitted. A group reduced to one runtime member is valid.
+
+Changes to grouping metadata do not require a re-interview. The metadata is refreshed when the device config is loaded.
 
 ## `associations`
 

--- a/packages/config/config.api.md
+++ b/packages/config/config.api.md
@@ -297,6 +297,8 @@ export class ConditionalDeviceConfig {
         productId: number;
     }[];
     // (undocumented)
+    readonly endpointGroups?: ReadonlyMap<number, ConditionalEndpointGroupConfig>;
+    // (undocumented)
     readonly endpoints?: ReadonlyMap<number, ConditionalEndpointConfig>;
     // (undocumented)
     evaluate(deviceId?: DeviceID): DeviceConfig;
@@ -362,6 +364,23 @@ export class ConditionalEndpointConfig implements ConditionalItem<EndpointConfig
     readonly label?: string;
     // (undocumented)
     readonly paramInformation?: ConditionalParamInfoMap;
+}
+
+// Warning: (ae-missing-release-tag) "ConditionalEndpointGroupConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class ConditionalEndpointGroupConfig implements ConditionalItem<EndpointGroupConfig> {
+    constructor(filename: string, id: number, definition: unknown);
+    // (undocumented)
+    readonly condition?: string;
+    // (undocumented)
+    readonly endpoints: readonly number[];
+    // (undocumented)
+    evaluateCondition(deviceId?: DeviceID): EndpointGroupConfig | undefined;
+    // (undocumented)
+    readonly id: number;
+    // (undocumented)
+    readonly label: string;
 }
 
 // Warning: (ae-missing-release-tag) "ConditionalParamInfoMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -539,7 +558,7 @@ export class DeviceConfig {
     constructor(filename: string, isEmbedded: boolean, manufacturer: string, manufacturerId: number, label: string, description: string, devices: readonly {
         productType: number;
         productId: number;
-    }[], firmwareVersion: FirmwareVersionRange, preferred: boolean, endpoints?: ReadonlyMap<number, EndpointConfig>, associations?: ReadonlyMap<number, AssociationConfig>, scenes?: ReadonlyMap<number, SceneConfig>, paramInformation?: ParamInfoMap, proprietary?: Record<string, unknown>, compat?: CompatConfig, metadata?: DeviceMetadata);
+    }[], firmwareVersion: FirmwareVersionRange, preferred: boolean, endpoints?: ReadonlyMap<number, EndpointConfig>, associations?: ReadonlyMap<number, AssociationConfig>, scenes?: ReadonlyMap<number, SceneConfig>, paramInformation?: ParamInfoMap, proprietary?: Record<string, unknown>, compat?: CompatConfig, metadata?: DeviceMetadata, endpointGroups?: ReadonlyMap<number, EndpointGroupConfig>);
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     static areHashesEqual(currentHash: BytesView, cachedHash: BytesView): boolean;
@@ -553,6 +572,8 @@ export class DeviceConfig {
         productType: number;
         productId: number;
     }[];
+    // (undocumented)
+    readonly endpointGroups?: ReadonlyMap<number, EndpointGroupConfig>;
     // (undocumented)
     readonly endpoints?: ReadonlyMap<number, EndpointConfig>;
     // (undocumented)
@@ -662,6 +683,11 @@ export type EndpointConfig = Omit<ConditionalEndpointConfig, "condition" | "eval
     associations?: Map<number, AssociationConfig> | undefined;
     paramInformation?: ParamInfoMap;
 };
+
+// Warning: (ae-missing-release-tag) "EndpointGroupConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type EndpointGroupConfig = Omit<ConditionalEndpointGroupConfig, "condition" | "evaluateCondition">;
 
 // Warning: (ae-missing-release-tag) "FirmwareVersionRange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/config/config/devices/0x027a/zen74.json
+++ b/packages/config/config/devices/0x027a/zen74.json
@@ -143,7 +143,7 @@
 		},
 		{
 			"#": "26",
-			"$if": "firmwareVersion >= 1.03",
+			"$if": "firmwareVersion >= 1.3",
 			"$import": "templates/zooz_template.json#local_programming",
 			"defaultValue": 0
 		},

--- a/packages/config/config/devices/0x0460/qnsw-001P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001P16.json
@@ -37,7 +37,7 @@
 		},
 		{
 			"#": "7",
-			"$if": "firmwareVersion >= 13.00",
+			"$if": "firmwareVersion >= 13.0",
 			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O Output"
 		},
@@ -78,31 +78,31 @@
 		},
 		{
 			"#": "91",
-			"$if": "firmwareVersion < 13.00",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Water"
 		},
 		{
 			"#": "92",
-			"$if": "firmwareVersion < 13.00",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Smoke"
 		},
 		{
 			"#": "93",
-			"$if": "firmwareVersion < 13.00",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: CO"
 		},
 		{
 			"#": "94",
-			"$if": "firmwareVersion < 13.00",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Heat"
 		},
 		{
 			"#": "117",
-			"$if": "firmwareVersion >= 13.00",
+			"$if": "firmwareVersion >= 13.0",
 			"$import": "templates/wave_template.json#remote_reboot"
 		},
 		{

--- a/packages/config/config/devices/0x0460/qnsw-001X16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001X16.json
@@ -37,7 +37,7 @@
 		},
 		{
 			"#": "7",
-			"$if": "firmwareVersion >= 13.00",
+			"$if": "firmwareVersion >= 13.0",
 			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O Output"
 		},
@@ -68,25 +68,25 @@
 		},
 		{
 			"#": "91",
-			"$if": "firmwareVersion < 13.00",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Water"
 		},
 		{
 			"#": "92",
-			"$if": "firmwareVersion < 13.00",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Smoke"
 		},
 		{
 			"#": "93",
-			"$if": "firmwareVersion < 13.00",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: CO"
 		},
 		{
 			"#": "94",
-			"$if": "firmwareVersion < 13.00",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Heat"
 		},

--- a/packages/config/config/devices/0x0460/wave_2pm.json
+++ b/packages/config/config/devices/0x0460/wave_2pm.json
@@ -76,13 +76,13 @@
 		},
 		{
 			"#": "7",
-			"$if": "firmwareVersion >= 16.00",
+			"$if": "firmwareVersion >= 16.0",
 			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O1 Output"
 		},
 		{
 			"#": "8",
-			"$if": "firmwareVersion >= 16.00",
+			"$if": "firmwareVersion >= 16.0",
 			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O2 Output"
 		},
@@ -166,31 +166,31 @@
 		},
 		{
 			"#": "91",
-			"$if": "firmwareVersion < 15.00",
+			"$if": "firmwareVersion < 15.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Water"
 		},
 		{
 			"#": "92",
-			"$if": "firmwareVersion < 15.00",
+			"$if": "firmwareVersion < 15.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Smoke"
 		},
 		{
 			"#": "93",
-			"$if": "firmwareVersion < 15.00",
+			"$if": "firmwareVersion < 15.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: CO"
 		},
 		{
 			"#": "94",
-			"$if": "firmwareVersion < 15.00",
+			"$if": "firmwareVersion < 15.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Heat"
 		},
 		{
 			"#": "117",
-			"$if": "firmwareVersion >= 16.00",
+			"$if": "firmwareVersion >= 16.0",
 			"$import": "templates/wave_template.json#remote_reboot"
 		},
 		{

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -371,6 +371,8 @@ function normalizeConfig(config: Record<string, any>): Record<string, any> {
 		"description",
 		"devices",
 		"firmwareVersion",
+		"endpoints",
+		"endpointGroups",
 		"associations",
 		"paramInformation",
 		"compat",

--- a/packages/config/maintenance/lintConfigFiles.test.ts
+++ b/packages/config/maintenance/lintConfigFiles.test.ts
@@ -233,7 +233,7 @@ test("only checks supported firmware for configs without endpoint groups", async
 });
 
 test.each([false, true])(
-	"handles leading zeros in firmware condition boundaries with endpoint groups: %s",
+	"rejects leading zeros in firmware condition boundaries with endpoint groups: %s",
 	async (withGroups) => {
 		definition.label = [
 			{ $if: "firmwareVersion >= 1.03", value: "Test Device" },
@@ -244,6 +244,47 @@ test.each([false, true])(
 				1: { label: "Output", endpoints: [0, 1] },
 			};
 		}
+
+		await expect(lintConfigFiles()).rejects.toThrow("lint exited");
+
+		expect(reportProblem).toHaveBeenCalledExactlyOnceWith({
+			severity: "error",
+			filename: "packages/config/config/devices/test.json",
+			message:
+				'Invalid firmware version "1.03" in a condition. Use x.y or x.y.z with integer components between 0 and 255 and no leading zeros.',
+		});
+	},
+);
+
+test.each(["01.3", "1.3.00", "256.0", "1.256", "1.0.256"])(
+	"rejects invalid firmware version %s in a condition",
+	async (version) => {
+		definition.label = [
+			{ $if: `firmwareVersion >= ${version}`, value: "Test Device" },
+			"Test Device",
+		];
+
+		await expect(lintConfigFiles()).rejects.toThrow("lint exited");
+
+		expect(reportProblem).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({
+				severity: "error",
+				filename: "packages/config/config/devices/test.json",
+				message: expect.stringContaining(
+					`Invalid firmware version "${version}"`,
+				),
+			}),
+		);
+	},
+);
+
+test.each(["0.0", "1.3", "1.3.0", "255.255.255"])(
+	"accepts valid firmware version %s in a condition",
+	async (version) => {
+		definition.label = [
+			{ $if: `firmwareVersion >= ${version}`, value: "Test Device" },
+			"Test Device",
+		];
 
 		await lintConfigFiles();
 

--- a/packages/config/maintenance/lintConfigFiles.test.ts
+++ b/packages/config/maintenance/lintConfigFiles.test.ts
@@ -232,6 +232,26 @@ test("only checks supported firmware for configs without endpoint groups", async
 	expect(reportProblem).not.toHaveBeenCalled();
 });
 
+test.each([false, true])(
+	"handles leading zeros in firmware condition boundaries with endpoint groups: %s",
+	async (withGroups) => {
+		definition.label = [
+			{ $if: "firmwareVersion >= 1.03", value: "Test Device" },
+			"Test Device",
+		];
+		if (withGroups) {
+			definition.endpointGroups = {
+				1: { label: "Output", endpoints: [0, 1] },
+			};
+		}
+
+		await lintConfigFiles();
+
+		expect(reportProblem).not.toHaveBeenCalled();
+		expect(process.exit).not.toHaveBeenCalled();
+	},
+);
+
 test("does not sample invalid firmware components between adjacent versions", async () => {
 	definition.endpointGroups = {
 		1: {

--- a/packages/config/maintenance/lintConfigFiles.test.ts
+++ b/packages/config/maintenance/lintConfigFiles.test.ts
@@ -1,0 +1,296 @@
+import { reportProblem } from "@zwave-js/maintenance";
+import type { JSONObject } from "@zwave-js/shared";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { ConfigManager } from "../src/ConfigManager.js";
+import { ConditionalDeviceConfig } from "../src/devices/DeviceConfig.js";
+
+import { lintConfigFiles } from "./lintConfigFiles.js";
+
+vi.mock("@zwave-js/maintenance", () => ({
+	reportProblem: vi.fn(),
+}));
+
+vi.mock("@zwave-js/shared", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@zwave-js/shared")>()),
+	enumFilesRecursive: vi.fn(async () => []),
+}));
+
+vi.mock("alcalzone-shared/async", async (importOriginal) => ({
+	...(await importOriginal<typeof import("alcalzone-shared/async")>()),
+	wait: vi.fn(async () => {}),
+}));
+
+let definition: JSONObject;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.spyOn(console, "log").mockImplementation(() => {});
+	vi.spyOn(console, "warn").mockImplementation(() => {});
+	vi.spyOn(process, "exit").mockImplementation(() => {
+		throw new Error("lint exited");
+	});
+	vi.spyOn(ConfigManager.prototype, "loadManufacturers").mockResolvedValue();
+	vi.spyOn(ConfigManager.prototype, "loadDeviceIndex").mockResolvedValue();
+	vi.spyOn(ConfigManager.prototype, "getIndex").mockReturnValue([
+		{
+			manufacturerId: "0xffff",
+			productType: "0x0001",
+			productId: "0x0001",
+			firmwareVersion: { min: "0.0", max: "255.255" },
+			filename: "test.json",
+		},
+	]);
+	vi.spyOn(ConditionalDeviceConfig, "from").mockImplementation(
+		async () => new ConditionalDeviceConfig("test.json", true, definition),
+	);
+	definition = {
+		manufacturer: "Test Manufacturer",
+		manufacturerId: "0xffff",
+		label: "Test Device",
+		description: "Endpoint group test device",
+		devices: [{ productType: "0x0001", productId: "0x0001" }],
+		firmwareVersion: { min: "0.0", max: "255.255" },
+	};
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+test("warns about an authored single-member group", async () => {
+	definition.endpointGroups = {
+		1: { label: "Output", endpoints: [0] },
+	};
+
+	await lintConfigFiles();
+
+	expect(reportProblem).toHaveBeenCalledExactlyOnceWith({
+		severity: "warn",
+		filename: "packages/config/config/devices/test.json",
+		message:
+			"Endpoint group 1 contains only one endpoint. Consider using an endpoint label.",
+		annotation: false,
+	});
+	expect(process.exit).not.toHaveBeenCalled();
+});
+
+test("warns about authored single-member groups even when inactive", async () => {
+	definition.endpointGroups = {
+		1: {
+			$if: "firmwareVersion > 255.255",
+			label: "Output",
+			endpoints: [1],
+		},
+	};
+
+	await lintConfigFiles();
+
+	expect(reportProblem).toHaveBeenCalledExactlyOnceWith(
+		expect.objectContaining({
+			severity: "warn",
+			message: expect.stringContaining("contains only one endpoint"),
+		}),
+	);
+	expect(process.exit).not.toHaveBeenCalled();
+});
+
+test("allows groups without endpoint configs alongside root associations", async () => {
+	definition.endpointGroups = {
+		1: { label: "Output", endpoints: [0, 1] },
+	};
+	definition.associations = {
+		1: { label: "Lifeline", maxNodes: 1, isLifeline: true },
+	};
+
+	await lintConfigFiles();
+
+	expect(reportProblem).not.toHaveBeenCalled();
+	expect(process.exit).not.toHaveBeenCalled();
+});
+
+test("reports unconditional overlapping membership", async () => {
+	definition.endpointGroups = {
+		1: { label: "Output", endpoints: [0, 1] },
+		2: { label: "Other Output", endpoints: [0, 2] },
+	};
+
+	await expect(lintConfigFiles()).rejects.toThrow("lint exited");
+
+	expect(reportProblem).toHaveBeenCalledWith(
+		expect.objectContaining({
+			severity: "error",
+			message: expect.stringContaining(
+				"Endpoint 0 belongs to multiple active endpoint groups: 1 and 2",
+			),
+		}),
+	);
+});
+
+test("checks firmware boundaries from endpoint group conditions", async () => {
+	definition.endpointGroups = {
+		1: {
+			$if: "firmwareVersion <= 2.0",
+			label: "Output",
+			endpoints: [0, 1],
+		},
+		2: {
+			$if: "firmwareVersion >= 2.0",
+			label: "Other Output",
+			endpoints: [0, 2],
+		},
+	};
+
+	await expect(lintConfigFiles()).rejects.toThrow("lint exited");
+
+	expect(reportProblem).toHaveBeenCalledExactlyOnceWith(
+		expect.objectContaining({
+			severity: "error",
+			filename: expect.stringContaining(":2.0)"),
+			message: expect.stringContaining(
+				"Endpoint 0 belongs to multiple active endpoint groups: 1 and 2",
+			),
+		}),
+	);
+});
+
+test("allows mutually exclusive overlapping membership", async () => {
+	definition.endpointGroups = {
+		1: {
+			$if: "firmwareVersion < 2.0",
+			label: "Output",
+			endpoints: [0, 1],
+		},
+		2: {
+			$if: "firmwareVersion >= 2.0",
+			label: "Other Output",
+			endpoints: [0, 2],
+		},
+	};
+
+	await lintConfigFiles();
+
+	expect(reportProblem).not.toHaveBeenCalled();
+	expect(process.exit).not.toHaveBeenCalled();
+});
+
+test("reports overlap between strict firmware boundaries", async () => {
+	definition.endpointGroups = {
+		1: {
+			$if: "firmwareVersion > 1.0",
+			label: "Output",
+			endpoints: [0, 1],
+		},
+		2: {
+			$if: "firmwareVersion < 2.0",
+			label: "Other Output",
+			endpoints: [0, 2],
+		},
+	};
+
+	await expect(lintConfigFiles()).rejects.toThrow("lint exited");
+
+	expect(reportProblem).toHaveBeenCalledWith(
+		expect.objectContaining({
+			severity: "error",
+			filename: expect.stringContaining(":1.0.1)"),
+			message: expect.stringContaining(
+				"Endpoint 0 belongs to multiple active endpoint groups: 1 and 2",
+			),
+		}),
+	);
+});
+
+test("does not report overlap outside the configured firmware range", async () => {
+	definition.firmwareVersion = { min: "1.0", max: "1.5" };
+	definition.endpointGroups = {
+		1: {
+			$if: "firmwareVersion > 1.5",
+			label: "Output",
+			endpoints: [0, 1],
+		},
+		2: {
+			$if: "firmwareVersion < 2.0",
+			label: "Other Output",
+			endpoints: [0, 2],
+		},
+	};
+
+	await lintConfigFiles();
+
+	expect(reportProblem).not.toHaveBeenCalled();
+});
+
+test("only checks supported firmware for configs without endpoint groups", async () => {
+	definition.firmwareVersion = { min: "1.1", max: "1.5" };
+	definition.label = [
+		{ $if: "firmwareVersion !== 1.0", value: "Test Device" },
+	];
+
+	await lintConfigFiles();
+
+	expect(reportProblem).not.toHaveBeenCalled();
+});
+
+test("does not sample invalid firmware components between adjacent versions", async () => {
+	definition.endpointGroups = {
+		1: {
+			$if: "firmwareVersion > 1.0.255",
+			label: "Output",
+			endpoints: [0, 1],
+		},
+		2: {
+			$if: "firmwareVersion < 1.1",
+			label: "Other Output",
+			endpoints: [0, 2],
+		},
+	};
+
+	await lintConfigFiles();
+
+	expect(reportProblem).not.toHaveBeenCalled();
+});
+
+test("reports overlap for SDK version conditions", async () => {
+	definition.endpointGroups = {
+		1: {
+			$if: "sdkVersion > 7.0",
+			label: "Output",
+			endpoints: [0, 1],
+		},
+		2: {
+			$if: "sdkVersion < 7.1",
+			label: "Other Output",
+			endpoints: [0, 2],
+		},
+	};
+
+	await expect(lintConfigFiles()).rejects.toThrow("lint exited");
+
+	expect(reportProblem).toHaveBeenCalledWith(
+		expect.objectContaining({
+			severity: "error",
+			filename: expect.stringContaining("SDK 7.0.1"),
+			message: expect.stringContaining(
+				"Endpoint 0 belongs to multiple active endpoint groups: 1 and 2",
+			),
+		}),
+	);
+});
+
+test("reports invalid member indices through config parsing", async () => {
+	definition.endpointGroups = {
+		1: { label: "Output", endpoints: [1, 128] },
+	};
+
+	await expect(lintConfigFiles()).rejects.toThrow("lint exited");
+
+	expect(reportProblem).toHaveBeenCalledExactlyOnceWith(
+		expect.objectContaining({
+			severity: "error",
+			message: expect.stringContaining(
+				"integer endpoint indices between 0 and 127",
+			),
+		}),
+	);
+});

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -69,11 +69,13 @@ function getAllConditions(
 				"ver <=",
 				"ver <",
 				"ver ===",
+				"ver !==",
 				">=",
 				">",
 				"<=",
 				"<",
 				"===",
+				"!==",
 			] as const) {
 				if (operator in logic) {
 					const [lhs, rhs] = (logic as any)[operator] as [
@@ -116,6 +118,15 @@ function getAllConditions(
 		for (const assoc of config.associations.values()) {
 			if (assoc.condition) {
 				const logic = parseLogic(assoc.condition);
+				walkLogic(logic);
+			}
+		}
+	}
+
+	if (config.endpointGroups) {
+		for (const group of config.endpointGroups.values()) {
+			if (group.condition) {
+				const logic = parseLogic(group.condition);
 				walkLogic(logic);
 			}
 		}
@@ -179,6 +190,25 @@ function getAllConditions(
 	}
 
 	return ret;
+}
+
+function addNextVersions(
+	versions: Set<string>,
+	maxComponent: number = Infinity,
+): void {
+	const boundaries = [...versions];
+	for (const version of boundaries) {
+		const parts = version.split(".").map(Number);
+		while (parts.length < 3) parts.push(0);
+		for (let i = 2; i >= 0; i--) {
+			if (parts[i] < maxComponent) {
+				parts[i]++;
+				versions.add(parts.join("."));
+				break;
+			}
+			parts[i] = 0;
+		}
+	}
 }
 
 function paramNoToString(parameter: number, valueBitMask?: number): string {
@@ -544,7 +574,9 @@ async function lintDevices(): Promise<void> {
 				variant.manufacturerId,
 			)}:${formatId(variant.productType)}:${formatId(
 				variant.productId,
-			)}:${variant.firmwareVersion})`;
+			)}:${variant.firmwareVersion}${
+				variant.sdkVersion ? `, SDK ${variant.sdkVersion}` : ""
+			})`;
 		}
 		if (!errors.has(filename)) errors.set(filename, []);
 
@@ -564,7 +596,9 @@ async function lintDevices(): Promise<void> {
 				variant.manufacturerId,
 			)}:${formatId(variant.productType)}:${formatId(
 				variant.productId,
-			)}:${variant.firmwareVersion})`;
+			)}:${variant.firmwareVersion}${
+				variant.sdkVersion ? `, SDK ${variant.sdkVersion}` : ""
+			})`;
 		}
 		if (!warnings.has(filename)) warnings.set(filename, []);
 
@@ -633,7 +667,7 @@ async function lintDevices(): Promise<void> {
 		// Check which variants of the device config we need to lint
 		const variants: (DeviceID | undefined)[] = [];
 		const conditions = getAllConditions(conditionalConfig);
-		if (conditions.size > 0) {
+		if (conditions.size > 0 || conditionalConfig.endpointGroups?.size) {
 			// If there is at least one condition, check the firmware limits too. Otherwise the minimum is enough
 			const fwVersions: Set<string> =
 				conditions.get("firmwareVersion") ?? new Set();
@@ -644,14 +678,44 @@ async function lintDevices(): Promise<void> {
 				fwVersions.add(conditionalConfig.firmwareVersion.min);
 			}
 
+			const sdkVersions = new Set<string | undefined>([undefined]);
+			if (conditionalConfig.endpointGroups?.size) {
+				// Strict comparisons can overlap between their firmware boundaries
+				addNextVersions(fwVersions, 255);
+
+				const sdkConditions = conditions.get("sdkVersion");
+				if (sdkConditions?.size) {
+					sdkConditions.add("0.0");
+					addNextVersions(sdkConditions);
+					for (const version of sdkConditions) {
+						sdkVersions.add(version);
+					}
+				}
+			}
+
+			for (const version of fwVersions) {
+				if (
+					!versionInRange(
+						version,
+						conditionalConfig.firmwareVersion.min,
+						conditionalConfig.firmwareVersion.max,
+					)
+				) {
+					fwVersions.delete(version);
+				}
+			}
+
 			// Combine each firmware version with every device ID defined in the file
 			for (const deviceId of conditionalConfig.devices) {
 				for (const firmwareVersion of fwVersions) {
-					variants.push({
-						manufacturerId: conditionalConfig.manufacturerId,
-						...deviceId,
-						firmwareVersion,
-					});
+					for (const sdkVersion of sdkVersions) {
+						variants.push({
+							manufacturerId: conditionalConfig.manufacturerId,
+							...deviceId,
+							firmwareVersion,
+							...(sdkVersion !== undefined ? { sdkVersion } : {}),
+						});
+					}
 				}
 			}
 		} else {
@@ -777,6 +841,17 @@ async function lintDevices(): Promise<void> {
 					addError(
 						file,
 						`The maximum firmware version ${config.firmwareVersion.max} is invalid. Leading zeroes are not permitted.`,
+					);
+				}
+			}
+		}
+
+		if (conditionalConfig.endpointGroups) {
+			for (const [id, group] of conditionalConfig.endpointGroups) {
+				if (group.endpoints.length === 1) {
+					addWarning(
+						file,
+						`Endpoint group ${id} contains only one endpoint. Consider using an endpoint label.`,
 					);
 				}
 			}

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -13,6 +13,7 @@ import {
 	formatId,
 	getErrorMessage,
 	num2hex,
+	padVersion,
 } from "@zwave-js/shared";
 import { distinct } from "alcalzone-shared/arrays";
 import { wait } from "alcalzone-shared/async";
@@ -21,6 +22,7 @@ import c from "ansi-colors";
 import esMain from "es-main";
 import levenshtein from "js-levenshtein";
 import type { RulesLogic } from "json-logic-js";
+import semverValid from "semver/functions/valid.js";
 
 import { configDir } from "#config_dir";
 
@@ -667,6 +669,21 @@ async function lintDevices(): Promise<void> {
 		// Check which variants of the device config we need to lint
 		const variants: (DeviceID | undefined)[] = [];
 		const conditions = getAllConditions(conditionalConfig);
+		let hasInvalidFirmwareVersion = false;
+		for (const version of conditions.get("firmwareVersion") ?? []) {
+			if (
+				!semverValid(padVersion(version))
+				|| version.split(".").some((part) => Number(part) > 255)
+			) {
+				addError(
+					file,
+					`Invalid firmware version "${version}" in a condition. Use x.y or x.y.z with integer components between 0 and 255 and no leading zeros.`,
+				);
+				hasInvalidFirmwareVersion = true;
+			}
+		}
+		if (hasInvalidFirmwareVersion) continue;
+
 		if (conditions.size > 0 || conditionalConfig.endpointGroups?.size) {
 			// If there is at least one condition, check the firmware limits too. Otherwise the minimum is enough
 			const fwVersions: Set<string> =
@@ -694,14 +711,9 @@ async function lintDevices(): Promise<void> {
 			}
 
 			for (const version of fwVersions) {
-				// Condition literals may contain leading zeros
-				const normalizedVersion = version
-					.split(".")
-					.map(Number)
-					.join(".");
 				if (
 					!versionInRange(
-						normalizedVersion,
+						version,
 						conditionalConfig.firmwareVersion.min,
 						conditionalConfig.firmwareVersion.max,
 					)

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -694,9 +694,14 @@ async function lintDevices(): Promise<void> {
 			}
 
 			for (const version of fwVersions) {
+				// Condition literals may contain leading zeros
+				const normalizedVersion = version
+					.split(".")
+					.map(Number)
+					.join(".");
 				if (
 					!versionInRange(
-						version,
+						normalizedVersion,
 						conditionalConfig.firmwareVersion.min,
 						conditionalConfig.firmwareVersion.max,
 					)

--- a/packages/config/src/devices/DeviceConfig.ts
+++ b/packages/config/src/devices/DeviceConfig.ts
@@ -56,6 +56,10 @@ import {
 	type EndpointConfig,
 } from "./EndpointConfig.js";
 import {
+	ConditionalEndpointGroupConfig,
+	type EndpointGroupConfig,
+} from "./EndpointGroupConfig.js";
+import {
 	type ConditionalParamInfoMap,
 	type ParamInfoMap,
 	type ParamInformation,
@@ -575,6 +579,48 @@ found non-numeric endpoint index "${key}" in endpoints`,
 			this.endpoints = endpoints;
 		}
 
+		if (definition.endpointGroups !== undefined) {
+			if (!isObject(definition.endpointGroups)) {
+				throwInvalidConfig(
+					"device",
+					`packages/config/config/devices/${filename}:
+endpointGroups is not an object`,
+				);
+			}
+			const endpointGroups = new Map<
+				number,
+				ConditionalEndpointGroupConfig
+			>();
+			for (const [key, group] of Object.entries(
+				definition.endpointGroups,
+			)) {
+				const id = Number(key);
+				if (!/^[1-9][0-9]*$/.test(key) || !Number.isSafeInteger(id)) {
+					throwInvalidConfig(
+						"device",
+						`packages/config/config/devices/${filename}:
+invalid endpoint group id "${key}" in endpointGroups - must be a positive safe integer without leading zeros`,
+					);
+				}
+				endpointGroups.set(
+					id,
+					new ConditionalEndpointGroupConfig(filename, id, group),
+				);
+			}
+			if (
+				![...endpointGroups.keys()]
+					.toSorted((a, b) => a - b)
+					.every((id, index) => id === index + 1)
+			) {
+				throwInvalidConfig(
+					"device",
+					`packages/config/config/devices/${filename}:
+endpointGroups IDs must start at 1 without gaps`,
+				);
+			}
+			this.endpointGroups = endpointGroups;
+		}
+
 		if (definition.associations != undefined) {
 			const associations = new Map<
 				number,
@@ -730,6 +776,10 @@ scene number ${keyNum} must be between 1 and 255`,
 	/** Mark this configuration as preferred over other config files with an overlapping firmware range */
 	public readonly preferred: boolean;
 	public readonly endpoints?: ReadonlyMap<number, ConditionalEndpointConfig>;
+	public readonly endpointGroups?: ReadonlyMap<
+		number,
+		ConditionalEndpointGroupConfig
+	>;
 	public readonly associations?: ReadonlyMap<
 		number,
 		ConditionalAssociationConfig
@@ -752,6 +802,25 @@ scene number ${keyNum} must be between 1 and 255`,
 	public readonly isEmbedded: boolean;
 
 	public evaluate(deviceId?: DeviceID): DeviceConfig {
+		const endpointGroups = evaluateDeep(this.endpointGroups, deviceId);
+		// Conditional groups may overlap before a device ID selects the active groups
+		if (deviceId && endpointGroups) {
+			const membership = new Map<number, number>();
+			for (const [id, group] of endpointGroups) {
+				for (const endpoint of group.endpoints) {
+					const existingGroup = membership.get(endpoint);
+					if (existingGroup !== undefined) {
+						throwInvalidConfig(
+							"device",
+							`packages/config/config/devices/${this.filename}:
+Endpoint ${endpoint} belongs to multiple active endpoint groups: ${existingGroup} and ${id}`,
+						);
+					}
+					membership.set(endpoint, id);
+				}
+			}
+		}
+
 		return new DeviceConfig(
 			this.filename,
 			this.isEmbedded,
@@ -769,6 +838,7 @@ scene number ${keyNum} must be between 1 and 255`,
 			this.proprietary,
 			evaluateDeep(this.compat, deviceId),
 			evaluateDeep(this.metadata, deviceId),
+			endpointGroups,
 		);
 	}
 }
@@ -816,6 +886,7 @@ export class DeviceConfig {
 		proprietary?: Record<string, unknown>,
 		compat?: CompatConfig,
 		metadata?: DeviceMetadata,
+		endpointGroups?: ReadonlyMap<number, EndpointGroupConfig>,
 	) {
 		this.filename = filename;
 		this.isEmbedded = isEmbedded;
@@ -833,6 +904,7 @@ export class DeviceConfig {
 		this.proprietary = proprietary;
 		this.compat = compat;
 		this.metadata = metadata;
+		this.endpointGroups = endpointGroups;
 	}
 
 	public readonly filename: string;
@@ -850,6 +922,7 @@ export class DeviceConfig {
 	/** Mark this configuration as preferred over other config files with an overlapping firmware range */
 	public readonly preferred: boolean;
 	public readonly endpoints?: ReadonlyMap<number, EndpointConfig>;
+	public readonly endpointGroups?: ReadonlyMap<number, EndpointGroupConfig>;
 	public readonly associations?: ReadonlyMap<number, AssociationConfig>;
 	public readonly scenes?: ReadonlyMap<number, SceneConfig>;
 	public readonly paramInformation?: ParamInfoMap;

--- a/packages/config/src/devices/EndpointGroupConfig.test.ts
+++ b/packages/config/src/devices/EndpointGroupConfig.test.ts
@@ -1,0 +1,305 @@
+import { ZWaveErrorCodes } from "@zwave-js/core";
+import { expect, expectTypeOf, test } from "vitest";
+
+import type { DeviceConfig, EndpointGroupConfig } from "../index.js";
+
+import {
+	ConditionalDeviceConfig,
+	type DeviceConfigHashVersion,
+} from "./DeviceConfig.js";
+import { ConditionalEndpointGroupConfig } from "./EndpointGroupConfig.js";
+
+const definition = {
+	manufacturer: "Test Manufacturer",
+	manufacturerId: "0xffff",
+	label: "Test Device",
+	description: "Endpoint group test device",
+	devices: [{ productType: "0x0001", productId: "0x0001" }],
+	firmwareVersion: { min: "0.0", max: "255.255" },
+};
+
+const deviceId = {
+	manufacturerId: 0xffff,
+	productType: 0x0001,
+	productId: 0x0001,
+	firmwareVersion: "1.0",
+};
+
+function parse(endpointGroups?: unknown): ConditionalDeviceConfig {
+	return new ConditionalDeviceConfig("test.json", true, {
+		...definition,
+		endpointGroups,
+	});
+}
+
+test("exposes endpoint groups as readonly metadata", () => {
+	expectTypeOf<DeviceConfig["endpointGroups"]>().toEqualTypeOf<
+		ReadonlyMap<number, EndpointGroupConfig> | undefined
+	>();
+	expectTypeOf<EndpointGroupConfig["endpoints"]>().toEqualTypeOf<
+		readonly number[]
+	>();
+
+	const config = parse({
+		1: { label: "Living Room", endpoints: [3, 1] },
+		2: { label: "Kitchen", endpoints: [2, 127] },
+	});
+	expect(config.endpointGroups?.get(1)).toBeInstanceOf(
+		ConditionalEndpointGroupConfig,
+	);
+	expect(config.evaluate(deviceId).endpointGroups).toEqual(
+		new Map([
+			[1, { id: 1, label: "Living Room", endpoints: [3, 1] }],
+			[2, { id: 2, label: "Kitchen", endpoints: [2, 127] }],
+		]),
+	);
+	expect(config.evaluate(deviceId).endpoints).toBeUndefined();
+});
+
+test("allows root membership alongside root associations", () => {
+	const config = new ConditionalDeviceConfig("test.json", true, {
+		...definition,
+		endpointGroups: {
+			1: { label: "Main Output", endpoints: [0, 1] },
+		},
+		associations: {
+			1: { label: "Lifeline", maxNodes: 1, isLifeline: true },
+		},
+	}).evaluate(deviceId);
+
+	expect(config.endpointGroups?.get(1)?.endpoints).toEqual([0, 1]);
+	expect(config.getAssociationConfigForEndpoint(0, 1)?.isLifeline).toBe(true);
+	expect(config.endpoints).toBeUndefined();
+});
+
+test("endpoint groups are optional", () => {
+	expect(parse().endpointGroups).toBeUndefined();
+	expect(parse().evaluate(deviceId).endpointGroups).toBeUndefined();
+	expect(parse({}).evaluate(deviceId).endpointGroups).toBeUndefined();
+});
+
+test.each([null, false, 1, "groups", []].map((value) => ({ value })))(
+	"rejects a non-object group map: %j",
+	({ value: endpointGroups }) => {
+		expect(() => parse(endpointGroups)).toThrow(
+			"endpointGroups is not an object",
+		);
+	},
+);
+
+test.each([
+	"0",
+	"-1",
+	"01",
+	"1.0",
+	"1.5",
+	"+1",
+	" 1",
+	"1 ",
+	"1e0",
+	"0x1",
+	"Infinity",
+	"NaN",
+	"abc",
+	"9007199254740992",
+	"999999999999999999999999",
+])("rejects invalid group ID %s", (id) => {
+	expect(() =>
+		parse({ [id]: { label: "Output", endpoints: [1, 2] } }),
+	).toThrow(`invalid endpoint group id "${id}"`);
+});
+
+test.each([[2], [1, 3], [1, 9007199254740991]])(
+	"rejects nonsequential group IDs %j",
+	(...ids) => {
+		expect(() =>
+			parse(
+				Object.fromEntries(
+					ids.map((id) => [
+						id,
+						{ label: "Output", endpoints: [1, 2] },
+					]),
+				),
+			),
+		).toThrow("endpointGroups IDs must start at 1 without gaps");
+	},
+);
+
+test.each([null, false, 1, "group", []].map((value) => ({ value })))(
+	"rejects a non-object group definition: %j",
+	({ value: group }) => {
+		expect(() => parse({ 1: group })).toThrow(
+			"Endpoint group 1 is not an object",
+		);
+	},
+);
+
+test.each(
+	[undefined, null, false, 1, "", " \t\n", [], {}].map((value) => ({
+		value,
+	})),
+)("rejects an invalid or missing label: %j", ({ value: label }) => {
+	expect(() => parse({ 1: { label, endpoints: [1, 2] } })).toThrow(
+		"label must be a nonblank string",
+	);
+});
+
+test.each(
+	[undefined, null, false, 1, "1,2", {}, []].map((value) => ({ value })),
+)(
+	"rejects an invalid or missing endpoints array: %j",
+	({ value: endpoints }) => {
+		expect(() => parse({ 1: { label: "Output", endpoints } })).toThrow(
+			"endpoints must be a nonempty array",
+		);
+	},
+);
+
+test.each(
+	[
+		-1,
+		128,
+		1.5,
+		NaN,
+		Infinity,
+		Number.MAX_SAFE_INTEGER + 1,
+		"1",
+		true,
+		null,
+		{},
+		[],
+	].map((value) => ({ value })),
+)("rejects invalid endpoint index %j", ({ value: index }) => {
+	expect(() =>
+		parse({ 1: { label: "Output", endpoints: [0, index] } }),
+	).toThrow("integer endpoint indices between 0 and 127");
+});
+
+test.each([
+	[0, 0],
+	[1, 2, 1],
+])("rejects duplicate member indices %j", (...endpoints) => {
+	expect(() => parse({ 1: { label: "Output", endpoints } })).toThrow(
+		"endpoints must not contain duplicate indices",
+	);
+});
+
+test("allows authored single-member groups", () => {
+	expect(
+		parse({ 1: { label: "Output", endpoints: [0] } })
+			.evaluate(deviceId)
+			.endpointGroups?.get(1),
+	).toEqual({ id: 1, label: "Output", endpoints: [0] });
+});
+
+test.each([false, 1, [], {}].map((value) => ({ value })))(
+	"rejects invalid $if %j",
+	({ value: $if }) => {
+		expect(() =>
+			parse({ 1: { $if, label: "Output", endpoints: [1, 2] } }),
+		).toThrow("Endpoint group 1 contains an invalid $if condition");
+	},
+);
+
+test("rejects invalid condition syntax when evaluating", () => {
+	const config = parse({
+		1: {
+			$if: "firmwareVersion >",
+			label: "Output",
+			endpoints: [1, 2],
+		},
+	});
+	expect(() => config.evaluate(deviceId)).toThrow("Invalid condition");
+});
+
+test("preserves authored IDs after excluding inactive groups", () => {
+	const config = parse({
+		1: {
+			$if: "firmwareVersion >= 2.0",
+			label: "New Output",
+			endpoints: [3, 4],
+		},
+		2: { label: "Output", endpoints: [1, 2] },
+	});
+	expect(config.evaluate(deviceId).endpointGroups).toEqual(
+		new Map([[2, { id: 2, label: "Output", endpoints: [1, 2] }]]),
+	);
+});
+
+test("omits endpoint groups when no condition applies", () => {
+	const config = parse({
+		1: {
+			$if: "firmwareVersion >= 2.0",
+			label: "Output",
+			endpoints: [1, 2],
+		},
+	});
+	expect(config.evaluate(deviceId).endpointGroups).toBeUndefined();
+});
+
+test("allows mutually exclusive groups to share members", () => {
+	const config = parse({
+		1: {
+			$if: "firmwareVersion < 2.0",
+			label: "Output",
+			endpoints: [0, 1],
+		},
+		2: {
+			$if: "firmwareVersion >= 2.0",
+			label: "New Output",
+			endpoints: [0, 1, 2],
+		},
+	});
+
+	expect([...config.evaluate(deviceId).endpointGroups!.keys()]).toEqual([1]);
+	expect([
+		...config
+			.evaluate({ ...deviceId, firmwareVersion: "2.0" })
+			.endpointGroups!.keys(),
+	]).toEqual([2]);
+	expect([...config.evaluate().endpointGroups!.keys()]).toEqual([1, 2]);
+});
+
+test.each([undefined, "firmwareVersion >= 1.0"])(
+	"rejects active overlapping membership with condition %j",
+	($if) => {
+		const config = parse({
+			1: { label: "Output", endpoints: [0, 1] },
+			2: { $if, label: "Other Output", endpoints: [0, 2] },
+		});
+		expect(() => config.evaluate(deviceId)).toThrow(
+			"Endpoint 0 belongs to multiple active endpoint groups: 1 and 2",
+		);
+		expect(() => config.evaluate(deviceId)).toThrow(
+			expect.objectContaining({ code: ZWaveErrorCodes.Config_Invalid }),
+		);
+	},
+);
+
+const hashVersions = [0, 1, 2, 3, 4] satisfies DeviceConfigHashVersion[];
+
+test.each(hashVersions)(
+	"endpoint groups do not affect hash version %i",
+	async (version) => {
+		const withoutGroups = parse().evaluate(deviceId);
+		const withGroups = parse({
+			1: { label: "Output", endpoints: [0, 1] },
+		}).evaluate(deviceId);
+		const changedGroups = parse({
+			1: {
+				$if: "firmwareVersion >= 2.0",
+				label: "Output",
+				endpoints: [0, 1],
+			},
+			2: {
+				$if: "firmwareVersion < 2.0",
+				label: "Other Output",
+				endpoints: [0, 2, 127],
+			},
+		}).evaluate(deviceId);
+
+		const expected = await withoutGroups.getHash(version);
+		expect(await withGroups.getHash(version)).toEqual(expected);
+		expect(await changedGroups.getHash(version)).toEqual(expected);
+	},
+);

--- a/packages/config/src/devices/EndpointGroupConfig.ts
+++ b/packages/config/src/devices/EndpointGroupConfig.ts
@@ -1,0 +1,91 @@
+import { isObject } from "alcalzone-shared/typeguards";
+
+import { throwInvalidConfig } from "../utils_safe.js";
+
+import {
+	type ConditionalItem,
+	conditionApplies,
+	validateCondition,
+} from "./ConditionalItem.js";
+import type { DeviceID } from "./shared.js";
+
+export class ConditionalEndpointGroupConfig implements ConditionalItem<EndpointGroupConfig> {
+	public constructor(filename: string, id: number, definition: unknown) {
+		this.id = id;
+
+		if (!isObject(definition)) {
+			throwInvalidConfig(
+				"device",
+				`packages/config/config/devices/${filename}:
+Endpoint group ${id} is not an object`,
+			);
+		}
+
+		validateCondition(
+			filename,
+			definition,
+			`Endpoint group ${id} contains an`,
+		);
+		if (typeof definition.$if === "string") {
+			this.condition = definition.$if;
+		}
+
+		if (typeof definition.label !== "string" || !definition.label.trim()) {
+			throwInvalidConfig(
+				"device",
+				`packages/config/config/devices/${filename}:
+Endpoint group ${id}: label must be a nonblank string`,
+			);
+		}
+		this.label = definition.label;
+
+		if (
+			!Array.isArray(definition.endpoints)
+			|| definition.endpoints.length === 0
+			|| !definition.endpoints.every(
+				(endpoint: unknown): endpoint is number =>
+					typeof endpoint === "number"
+					&& Number.isInteger(endpoint)
+					&& endpoint >= 0
+					&& endpoint <= 127,
+			)
+		) {
+			throwInvalidConfig(
+				"device",
+				`packages/config/config/devices/${filename}:
+Endpoint group ${id}: endpoints must be a nonempty array of integer endpoint indices between 0 and 127`,
+			);
+		}
+		if (
+			new Set(definition.endpoints).size !== definition.endpoints.length
+		) {
+			throwInvalidConfig(
+				"device",
+				`packages/config/config/devices/${filename}:
+Endpoint group ${id}: endpoints must not contain duplicate indices`,
+			);
+		}
+		this.endpoints = [...definition.endpoints];
+	}
+
+	public readonly id: number;
+	public readonly label: string;
+	public readonly endpoints: readonly number[];
+	public readonly condition?: string;
+
+	public evaluateCondition(
+		deviceId?: DeviceID,
+	): EndpointGroupConfig | undefined {
+		if (!conditionApplies(this, deviceId)) return;
+		return {
+			id: this.id,
+			label: this.label,
+			endpoints: this.endpoints,
+		};
+	}
+}
+
+export type EndpointGroupConfig = Omit<
+	ConditionalEndpointGroupConfig,
+	"condition" | "evaluateCondition"
+>;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -13,6 +13,7 @@ export * from "./devices/CompatConfig.js";
 export * from "./devices/DeviceConfig.js";
 export * from "./devices/DeviceMetadata.js";
 export * from "./devices/EndpointConfig.js";
+export * from "./devices/EndpointGroupConfig.js";
 export * from "./devices/ParamInformation.js";
 export * from "./devices/SceneConfig.js";
 export type * from "./devices/shared.js";

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -8,8 +8,9 @@ export {
 } from "@zwave-js/core";
 export type { DataRate, FLiRS } from "@zwave-js/core";
 export { DeviceClass } from "./lib/node/DeviceClass.js";
-export type { NodeDump } from "./lib/node/Dump.js";
+export type { EndpointGroupDump, NodeDump } from "./lib/node/Dump.js";
 export { Endpoint } from "./lib/node/Endpoint.js";
+export type { EndpointGroup } from "./lib/node/EndpointGroup.js";
 export { ZWaveNode } from "./lib/node/Node.js";
 export type {
 	NodeStatistics,

--- a/packages/zwave-js/src/Node_safe.ts
+++ b/packages/zwave-js/src/Node_safe.ts
@@ -8,6 +8,7 @@ export {
 } from "@zwave-js/core";
 export type { DataRate, FLiRS } from "@zwave-js/core";
 export { DeviceClass } from "./lib/node/DeviceClass.js";
+export type { EndpointGroup } from "./lib/node/EndpointGroup.js";
 export type {
 	NodeStatistics,
 	RouteStatistics,

--- a/packages/zwave-js/src/lib/node/Dump.ts
+++ b/packages/zwave-js/src/lib/node/Dump.ts
@@ -31,8 +31,16 @@ export interface ValueDump {
 	internal?: boolean;
 }
 
+export interface EndpointGroupDump {
+	id: number;
+	label: string;
+	endpoints: number[];
+}
+
 export interface EndpointDump {
 	index: number;
+	endpointLabel?: string;
+	group?: EndpointGroupDump;
 	deviceClass: DeviceClassesDump | "unknown";
 	maySupportBasicCC: boolean;
 	commandClasses: Record<string, CommandClassDump>;
@@ -40,6 +48,8 @@ export interface EndpointDump {
 
 export interface NodeDump {
 	id: number;
+	endpointLabel?: string;
+	group?: EndpointGroupDump;
 	manufacturer?: string;
 	label?: string;
 	description?: string;

--- a/packages/zwave-js/src/lib/node/Endpoint.test.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.test.ts
@@ -2,13 +2,15 @@ import "@zwave-js/cc";
 
 import { BatteryCCAPI } from "@zwave-js/cc/BatteryCC";
 import { VersionCCAPI } from "@zwave-js/cc/VersionCC";
+import { ConditionalDeviceConfig } from "@zwave-js/config";
 import {
 	CommandClasses,
+	InterviewStage,
 	ZWaveErrorCodes,
 	assertZWaveError,
 } from "@zwave-js/core";
 import { MockController } from "@zwave-js/testing";
-import { afterEach, test as baseTest } from "vitest";
+import { afterEach, test as baseTest, vi } from "vitest";
 
 import { createDefaultMockControllerBehaviors } from "../../Testing.js";
 import type { Driver } from "../driver/Driver.js";
@@ -16,11 +18,16 @@ import { createAndStartTestingDriver } from "../driver/DriverMock.js";
 
 import { Endpoint } from "./Endpoint.js";
 import { ZWaveNode } from "./Node.js";
+import {
+	setEndpointIndizes,
+	setMultiChannelInterviewComplete,
+} from "./utils.js";
 
 interface LocalTestContext {
 	context: {
 		driver: Driver;
 		controller: MockController;
+		node?: ZWaveNode;
 	};
 }
 
@@ -59,6 +66,11 @@ const test = baseTest.extend<LocalTestContext>({
 
 afterEach<LocalTestContext>(({ context, expect }) => {
 	const { driver } = context;
+	if (context.node) {
+		context.node.destroy();
+		driver.controller["_nodes"].delete(context.node.id);
+	}
+	vi.restoreAllMocks();
 	driver.networkCache.clear();
 	driver.valueDB?.clear();
 });
@@ -212,4 +224,192 @@ test.sequential("createCCInstance() returns undefined if the node supports the C
 	endpoint.addCC(cc, { isSupported: true });
 	const instance = endpoint.createCCInstance(cc);
 	expect(instance).toBeUndefined();
+});
+
+function groupConfig(
+	endpointGroups: Record<string, { label: string; endpoints: number[] }> = {
+		"1": { label: "Clamp 1", endpoints: [1, 2] },
+		"2": { label: "Clamp 2", endpoints: [0, 3] },
+	},
+) {
+	return new ConditionalDeviceConfig("test.json", true, {
+		manufacturer: "Test",
+		manufacturerId: "0x0001",
+		label: "Test",
+		description: "Test",
+		devices: [{ productType: "0x0001", productId: "0x0001" }],
+		firmwareVersion: { min: "0.0", max: "255.255" },
+		endpoints: { "1": { label: "Consumption" } },
+		endpointGroups,
+	}).evaluate({
+		manufacturerId: 1,
+		productType: 1,
+		productId: 1,
+		firmwareVersion: "1.0",
+	});
+}
+
+function nodeWithGroups(context: LocalTestContext["context"]): ZWaveNode {
+	const node = new ZWaveNode(2, context.driver, undefined, [
+		CommandClasses["Multi Channel"],
+	]);
+	context.node = node;
+	context.driver.controller["_nodes"].set(node.id, node);
+	node["deviceConfig"] = groupConfig();
+	setEndpointIndizes(context.driver, node.id, [1, 2, 3, 4]);
+	return node;
+}
+
+test.sequential("endpoint groups are unavailable before endpoint discovery", ({
+	context,
+	expect,
+}) => {
+	const node = nodeWithGroups(context);
+	const log = vi.spyOn(context.driver.controllerLog, "logNode");
+	expect(node.endpointGroups).toBeUndefined();
+	expect(node.group).toBeUndefined();
+	expect(log).not.toHaveBeenCalled();
+});
+
+test.sequential("endpoint groups share existing endpoint instances, including the root", ({
+	context,
+	expect,
+}) => {
+	const node = nodeWithGroups(context);
+	setMultiChannelInterviewComplete(context.driver, node.id, true);
+	const groups = node.endpointGroups!;
+	expect([...groups.keys()]).toEqual([1, 2]);
+	expect(groups.get(1)).toEqual({
+		id: 1,
+		label: "Clamp 1",
+		endpoints: [node.getEndpoint(1), node.getEndpoint(2)],
+	});
+	expect(groups.get(2)?.endpoints).toEqual([node, node.getEndpoint(3)]);
+	expect(node.getEndpoint(1)?.group).toBe(groups.get(1));
+	expect(node.getEndpoint(2)?.group).toBe(groups.get(1));
+	expect(node.group).toBe(groups.get(2));
+	expect(node.getEndpoint(4)?.group).toBeUndefined();
+	expect(node.endpointGroups).toBe(groups);
+	expect(node.getAllEndpoints().map((endpoint) => endpoint.index)).toEqual([
+		0, 1, 2, 3, 4,
+	]);
+});
+
+test.sequential("missing group members are logged once and empty groups are omitted", ({
+	context,
+	expect,
+}) => {
+	const node = nodeWithGroups(context);
+	node["deviceConfig"] = groupConfig({
+		"1": { label: "Clamp 1", endpoints: [1, 9] },
+		"2": { label: "Clamp 2", endpoints: [8] },
+	});
+	const log = vi
+		.spyOn(context.driver.controllerLog, "logNode")
+		.mockImplementation(() => {});
+	expect(node.endpointGroups).toBeUndefined();
+	expect(log).not.toHaveBeenCalled();
+
+	setMultiChannelInterviewComplete(context.driver, node.id, true);
+	log.mockClear();
+	const groups = node.endpointGroups!;
+	expect([...groups.keys()]).toEqual([1]);
+	expect(groups.get(1)?.endpoints).toEqual([node.getEndpoint(1)]);
+	expect(node.endpointGroups).toBe(groups);
+	expect(node.getEndpoint(1)?.group).toBe(groups.get(1));
+	expect(log.mock.calls).toEqual([
+		[node.id, "Endpoint group 1 references missing endpoint 9", "warn"],
+		[node.id, "Endpoint group 2 references missing endpoint 8", "warn"],
+	]);
+});
+
+test.sequential("endpoint groups refresh when device config is replaced or removed", ({
+	context,
+	expect,
+}) => {
+	const node = nodeWithGroups(context);
+	setMultiChannelInterviewComplete(context.driver, node.id, true);
+	const original = node.endpointGroups!;
+	const endpoint = node.getEndpoint(1)!;
+
+	node["deviceConfig"] = groupConfig({
+		"1": { label: "First Clamp", endpoints: [1, 3] },
+		"2": { label: "Second Clamp", endpoints: [0, 2] },
+	});
+	const updated = node.endpointGroups!;
+	expect(updated).not.toBe(original);
+	expect(updated.get(1)?.label).toBe("First Clamp");
+	expect(updated.get(1)?.endpoints).toEqual([endpoint, node.getEndpoint(3)]);
+	expect(endpoint.group).toBe(updated.get(1));
+	expect(node.getEndpoint(2)?.group).toBe(updated.get(2));
+
+	node["deviceConfig"] = undefined;
+	expect(node.endpointGroups?.size).toBe(0);
+	expect(endpoint.group).toBeUndefined();
+});
+
+test.sequential("endpoint groups refresh when endpoint instances or discovery change", ({
+	context,
+	expect,
+}) => {
+	const node = nodeWithGroups(context);
+	setMultiChannelInterviewComplete(context.driver, node.id, true);
+	const original = node.endpointGroups!;
+	const endpoint = node.getEndpoint(1)!;
+
+	node["_endpointInstances"].clear();
+	expect(node.endpointGroups).not.toBe(original);
+	expect(node.getEndpoint(1)).not.toBe(endpoint);
+	expect(endpoint.group).toBeUndefined();
+	expect(node.getEndpoint(1)?.group).toBe(node.endpointGroups?.get(1));
+
+	setEndpointIndizes(context.driver, node.id, [1]);
+	expect(node.endpointGroups?.get(1)?.endpoints).toEqual([
+		node.getEndpoint(1),
+	]);
+	expect(node.endpointGroups?.get(2)?.endpoints).toEqual([node]);
+	setMultiChannelInterviewComplete(context.driver, node.id, false);
+	expect(node.endpointGroups).toBeUndefined();
+	expect(node.group).toBeUndefined();
+});
+
+test.sequential("endpoint dumps serialize labels and group membership without cycles", ({
+	context,
+	expect,
+}) => {
+	const node = nodeWithGroups(context);
+	setMultiChannelInterviewComplete(context.driver, node.id, true);
+	const dump = node.getEndpoint(1)!.createEndpointDump();
+	expect(dump.endpointLabel).toBe("Consumption");
+	expect(dump.group).toEqual({
+		id: 1,
+		label: "Clamp 1",
+		endpoints: [1, 2],
+	});
+	expect(JSON.parse(JSON.stringify(dump))).toEqual(dump);
+	const rootDump = node.createDump();
+	expect(rootDump.group).toEqual({
+		id: 2,
+		label: "Clamp 2",
+		endpoints: [0, 3],
+	});
+	expect(() => JSON.stringify(rootDump)).not.toThrow();
+});
+
+test.sequential("nodes without Multi Channel expose groups after their command-class interview", ({
+	context,
+	expect,
+}) => {
+	const node = nodeWithGroups(context);
+	node.removeCC(CommandClasses["Multi Channel"]);
+	setEndpointIndizes(context.driver, node.id, []);
+	node["deviceConfig"] = undefined;
+	expect(node.endpointGroups).toBeUndefined();
+	node["setInterviewStage"](InterviewStage.CommandClasses);
+	expect(node.endpointGroups?.size).toBe(0);
+	node["deviceConfig"] = groupConfig({
+		"1": { label: "Relay", endpoints: [0] },
+	});
+	expect(node.endpointGroups?.get(1)?.endpoints).toEqual([node]);
+	expect(node.group).toBe(node.endpointGroups?.get(1));
 });

--- a/packages/zwave-js/src/lib/node/EndpointGroup.ts
+++ b/packages/zwave-js/src/lib/node/EndpointGroup.ts
@@ -1,0 +1,8 @@
+import type { Endpoint } from "./Endpoint.js";
+
+/** An endpoint group identifies endpoints belonging to the same physical part of a node */
+export interface EndpointGroup {
+	readonly id: number;
+	readonly label: string;
+	readonly endpoints: readonly Endpoint[];
+}

--- a/packages/zwave-js/src/lib/node/endpoint-mixins/00_Base.ts
+++ b/packages/zwave-js/src/lib/node/endpoint-mixins/00_Base.ts
@@ -35,6 +35,7 @@ import type { Driver } from "../../driver/Driver.js";
 import { cacheKeys } from "../../driver/NetworkCache.js";
 import type { DeviceClass } from "../DeviceClass.js";
 import type { EndpointDump } from "../Dump.js";
+import type { EndpointGroup } from "../EndpointGroup.js";
 import type { ZWaveNode } from "../Node.js";
 
 /**
@@ -129,6 +130,22 @@ export class EndpointBase
 	public get endpointLabel(): string | undefined {
 		return this.tryGetNode()?.deviceConfig?.endpoints?.get(this.index)
 			?.label;
+	}
+
+	/** Returns the shared group containing this endpoint after endpoint discovery */
+	public get group(): EndpointGroup | undefined {
+		const groups = this.tryGetNode()?.endpointGroups;
+		if (!groups) return undefined;
+		for (const group of groups.values()) {
+			if (
+				group.endpoints.some(
+					(endpoint: EndpointBase) => endpoint === this,
+				)
+			) {
+				return group;
+			}
+		}
+		return undefined;
 	}
 
 	/** Resets all stored information of this endpoint */
@@ -497,8 +514,19 @@ export class EndpointBase
 	 * Returns a dump of this endpoint's information for debugging purposes
 	 */
 	public createEndpointDump(): EndpointDump {
+		const group = this.group;
 		const ret: EndpointDump = {
 			index: this.index,
+			endpointLabel: this.endpointLabel,
+			group: group
+				? {
+						id: group.id,
+						label: group.label,
+						endpoints: group.endpoints.map(
+							(endpoint) => endpoint.index,
+						),
+					}
+				: undefined,
 			deviceClass: "unknown",
 			commandClasses: {},
 			maySupportBasicCC: this.maySupportBasicCC(),

--- a/packages/zwave-js/src/lib/node/mixins/50_Endpoints.ts
+++ b/packages/zwave-js/src/lib/node/mixins/50_Endpoints.ts
@@ -119,7 +119,7 @@ export abstract class EndpointsMixin
 	}
 
 	/** Whether the Multi Channel CC has been interviewed and all endpoint information is known */
-	private get isMultiChannelInterviewComplete(): boolean {
+	protected get isMultiChannelInterviewComplete(): boolean {
 		return nodeUtils.isMultiChannelInterviewComplete(this.driver, this.id);
 	}
 

--- a/packages/zwave-js/src/lib/node/mixins/80_DeviceConfig.ts
+++ b/packages/zwave-js/src/lib/node/mixins/80_DeviceConfig.ts
@@ -1,9 +1,16 @@
 import { refreshConfigParamMetadataFromConfigFile } from "@zwave-js/cc/ConfigurationCC";
 import { DeviceConfig, parseDeviceConfigHash } from "@zwave-js/config";
-import { InterviewStage, type MaybeNotKnown, NOT_KNOWN } from "@zwave-js/core";
+import {
+	CommandClasses,
+	InterviewStage,
+	type MaybeNotKnown,
+	NOT_KNOWN,
+} from "@zwave-js/core";
 import { Bytes, type BytesView, formatId } from "@zwave-js/shared";
 
 import { cacheKeys } from "../../driver/NetworkCache.js";
+import type { Endpoint } from "../Endpoint.js";
+import type { EndpointGroup } from "../EndpointGroup.js";
 
 import { FirmwareUpdateMixin } from "./70_FirmwareUpdate.js";
 
@@ -12,6 +19,9 @@ export interface NodeDeviceConfig {
 	 * Contains additional information about this node, loaded from a config file
 	 */
 	get deviceConfig(): MaybeNotKnown<DeviceConfig>;
+
+	/** Returns groups with existing members. Returns undefined before endpoint discovery. */
+	readonly endpointGroups: ReadonlyMap<number, EndpointGroup> | undefined;
 
 	/**
 	 * Returns the manufacturer/brand name defined in the device configuration,
@@ -59,6 +69,67 @@ export abstract class DeviceConfigMixin
 	}
 	protected set deviceConfig(value: MaybeNotKnown<DeviceConfig>) {
 		this._deviceConfig = value;
+		this._endpointGroups = undefined;
+		this._endpointGroupEndpoints = undefined;
+	}
+
+	private _endpointGroups: ReadonlyMap<number, EndpointGroup> | undefined;
+	private _endpointGroupEndpoints: readonly Endpoint[] | undefined;
+
+	/** Returns groups with existing members. Returns undefined before endpoint discovery. */
+	public get endpointGroups():
+		| ReadonlyMap<number, EndpointGroup>
+		| undefined {
+		if (
+			!this.isMultiChannelInterviewComplete
+			&& (this.supportsCC(CommandClasses["Multi Channel"])
+				|| this.interviewStage < InterviewStage.CommandClasses)
+		) {
+			return undefined;
+		}
+
+		const endpoints = this.getAllEndpoints();
+		if (
+			this._endpointGroups
+			&& this._endpointGroupEndpoints?.length === endpoints.length
+			&& endpoints.every(
+				(endpoint, i) => endpoint === this._endpointGroupEndpoints?.[i],
+			)
+		) {
+			return this._endpointGroups;
+		}
+
+		const groups = new Map<number, EndpointGroup>();
+		const endpointsByIndex = new Map(
+			endpoints.map((endpoint) => [endpoint.index, endpoint]),
+		);
+		for (const config of this.deviceConfig?.endpointGroups?.values()
+			?? []) {
+			const members: Endpoint[] = [];
+			for (const index of config.endpoints) {
+				const endpoint = endpointsByIndex.get(index);
+				if (endpoint) {
+					members.push(endpoint);
+				} else {
+					this.driver.controllerLog.logNode(
+						this.id,
+						`Endpoint group ${config.id} references missing endpoint ${index}`,
+						"warn",
+					);
+				}
+			}
+			if (members.length) {
+				groups.set(config.id, {
+					id: config.id,
+					label: config.label,
+					endpoints: members,
+				});
+			}
+		}
+
+		this._endpointGroups = groups;
+		this._endpointGroupEndpoints = endpoints;
+		return groups;
 	}
 
 	/**

--- a/packages/zwave-js/zwave-js.api.md
+++ b/packages/zwave-js/zwave-js.api.md
@@ -958,6 +958,30 @@ export type EditableZWaveOptions = Expand<Pick<PartialZWaveOptions, "attempts" |
 export class Endpoint extends EndpointMixins {
 }
 
+// Warning: (ae-missing-release-tag) "EndpointGroup" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface EndpointGroup {
+    // (undocumented)
+    readonly endpoints: readonly Endpoint[];
+    // (undocumented)
+    readonly id: number;
+    // (undocumented)
+    readonly label: string;
+}
+
+// Warning: (ae-missing-release-tag) "EndpointGroupDump" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface EndpointGroupDump {
+    // (undocumented)
+    endpoints: number[];
+    // (undocumented)
+    id: number;
+    // (undocumented)
+    label: string;
+}
+
 export { EntryControlDataTypes }
 
 export { EntryControlEventTypes }
@@ -1633,6 +1657,8 @@ export interface NodeDump {
     deviceClass: DeviceClassesDump | "unknown";
     // (undocumented)
     dsk?: string;
+    // (undocumented)
+    endpointLabel?: string;
     // Warning: (ae-forgotten-export) The symbol "EndpointDump" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -1647,6 +1673,8 @@ export interface NodeDump {
         firmwareVersion: string;
         hardwareVersion?: number;
     };
+    // (undocumented)
+    group?: EndpointGroupDump;
     // (undocumented)
     id: number;
     // (undocumented)


### PR DESCRIPTION
Adds optional `endpointGroups` metadata to describe endpoints belonging to the same physical part of a device. All existing endpoints, addresses, values, and command-class APIs remain unchanged.

```json
"endpointGroups": {
  "1": { "label": "Clamp 1", "endpoints": [1, 2] },
  "2": { "label": "Clamp 2", "endpoints": [3, 4] }
}
```

```ts
const group = node.endpointGroups?.get(1);
const endpoint = node.getEndpoint(1);

// Both accessors return the same group instance
endpoint?.group === group;

// Members are the existing Endpoint instances
group?.endpoints;
```

- **Runtime API:** `node.endpointGroups` returns `ReadonlyMap<number, EndpointGroup> | undefined`. Groups become available after endpoint discovery. Missing members are logged and omitted. Empty groups are omitted. Group objects are reused until the config or discovered endpoints change.
- **Membership:** Root endpoint 0 is allowed. Authored IDs start at 1 without gaps. `$if` filtering preserves IDs. Membership must be unique among active groups. Mutually exclusive definitions may share endpoints.
- **Config behavior:** Grouping is independent of endpoint labels and root-level associations. Authored single-member groups produce a lint warning. Runtime-only single-member groups remain valid. Grouping changes leave the device-config hash unchanged.
- **Diagnostics and documentation:** Dumps include endpoint labels and group metadata with numeric member indices. Config-format docs, API docs, authoring guidance, and public API reports describe the new contract.

Device-specific mappings and downstream presentation changes are outside this PR.