### PR TITLE
feat(config): add Aeotec ZWA057 aërQ Temperature and Humidity Sensor 8

### DIFF
--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -4598,5 +4598,82 @@
 				"value": 2
 			}
 		]
+	},
+	// Gen8 sensor settings
+	"led_indicator_periodic_reports": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "LED Indicator: Periodic Reports",
+		"defaultValue": 1
+	},
+	"led_indicator_mold_danger": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "LED Indicator: Mold Danger",
+		"defaultValue": 1
+	},
+	"sensor_limit_enable_temperature_upper": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Temperature Reports: Send Above Upper Limit"
+	},
+	"sensor_limit_enable_temperature_lower": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Temperature Reports: Send Below Lower Limit"
+	},
+	"sensor_limit_enable_humidity_upper": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Humidity Reports: Send Above Upper Limit"
+	},
+	"sensor_limit_enable_humidity_lower": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Humidity Reports: Send Below Lower Limit"
+	},
+	"threshold_check_time": {
+		"label": "Threshold Check Time",
+		"description": "Allowable range: 30-2678400",
+		"valueSize": 4,
+		"unit": "seconds",
+		"minValue": 0,
+		"maxValue": 2678400,
+		"defaultValue": 900,
+		"unsigned": true,
+		"options": [
+			{
+				"label": "Disable",
+				"value": 0
+			}
+		]
+	},
+	"periodic_reports_interval": {
+		"label": "Periodic Reports Interval",
+		"description": "Allowable range: 30-2678400",
+		"valueSize": 4,
+		"unit": "seconds",
+		"minValue": 0,
+		"maxValue": 2678400,
+		"defaultValue": 43200,
+		"unsigned": true,
+		"options": [
+			{
+				"label": "Disable",
+				"value": 0
+			}
+		]
+	},
+	"watermark_humidity_upper": {
+		"label": "Humidity Reports: Upper Limit",
+		"valueSize": 2,
+		"unit": "0.1 %",
+		"minValue": 0,
+		"maxValue": 1000,
+		"defaultValue": 700,
+		"unsigned": true
+	},
+	"watermark_humidity_lower": {
+		"label": "Humidity Reports: Lower Limit",
+		"valueSize": 2,
+		"unit": "0.1 %",
+		"minValue": 0,
+		"maxValue": 1000,
+		"defaultValue": 300,
+		"unsigned": true
 	}
 }

--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -4628,11 +4628,12 @@
 	},
 	"threshold_check_time": {
 		"label": "Threshold Check Time",
-		"description": "Allowable range: 30-2678400",
 		"valueSize": 4,
 		"unit": "seconds",
-		"minValue": 0,
-		"maxValue": 2678400,
+		"allowed": [
+			{ "value": 0 },
+			{ "range": [30, 2678400] }
+		],
 		"defaultValue": 900,
 		"unsigned": true,
 		"options": [
@@ -4644,11 +4645,12 @@
 	},
 	"periodic_reports_interval": {
 		"label": "Periodic Reports Interval",
-		"description": "Allowable range: 30-2678400",
 		"valueSize": 4,
 		"unit": "seconds",
-		"minValue": 0,
-		"maxValue": 2678400,
+		"allowed": [
+			{ "value": 0 },
+			{ "range": [30, 2678400] }
+		],
 		"defaultValue": 43200,
 		"unsigned": true,
 		"options": [

--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -4630,10 +4630,7 @@
 		"label": "Threshold Check Time",
 		"valueSize": 4,
 		"unit": "seconds",
-		"allowed": [
-			{ "value": 0 },
-			{ "range": [30, 2678400] }
-		],
+		"allowed": [{ "value": 0 }, { "range": [30, 2678400] }],
 		"defaultValue": 900,
 		"unsigned": true,
 		"options": [
@@ -4647,10 +4644,7 @@
 		"label": "Periodic Reports Interval",
 		"valueSize": 4,
 		"unit": "seconds",
-		"allowed": [
-			{ "value": 0 },
-			{ "range": [30, 2678400] }
-		],
+		"allowed": [{ "value": 0 }, { "range": [30, 2678400] }],
 		"defaultValue": 43200,
 		"unsigned": true,
 		"options": [

--- a/packages/config/config/devices/0x0371/zwa057.json
+++ b/packages/config/config/devices/0x0371/zwa057.json
@@ -246,7 +246,12 @@
 		},
 		{
 			"#": "23",
-			"$import": "~/0x0086/templates/aeotec_template.json#reporting_threshold.low_battery",
+			"$purpose": "reporting_threshold.low_battery",
+			"label": "Low Battery Threshold",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 10,
+			"maxValue": 50,
 			"defaultValue": 20
 		},
 		{
@@ -288,8 +293,7 @@
 			"#": "64",
 			// Other regions:
 			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit_0",
-			"valueSize": 1,
-			"defaultValue": 0
+			"valueSize": 1
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zwa057.json
+++ b/packages/config/config/devices/0x0371/zwa057.json
@@ -1,0 +1,302 @@
+{
+	"manufacturer": "Aeotec Ltd.",
+	"manufacturerId": "0x0371",
+	"label": "ZWA057",
+	// eslint-disable-next-line @zwave-js/consistent-config-string-case -- "aërQ" is a stylized brand name
+	"description": "aërQ Temperature and Humidity Sensor 8",
+	"devices": [
+		{
+			// EU version
+			"productType": "0x0002",
+			"productId": "0x0039"
+		},
+		{
+			// US version
+			"productType": "0x0102",
+			"productId": "0x0039"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Temperature High Trigger",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Temperature Low Trigger",
+			"maxNodes": 5
+		},
+		"4": {
+			"label": "Humidity High Trigger",
+			"maxNodes": 5
+		},
+		"5": {
+			"label": "Humidity Low Trigger",
+			"maxNodes": 5
+		},
+		"6": {
+			"label": "Air Temperature",
+			"maxNodes": 5
+		},
+		"7": {
+			"label": "Mold Danger",
+			"maxNodes": 5
+		},
+		"8": {
+			"label": "Tamper",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"$import": "~/0x0086/templates/aeotec_template.json#threshold_check_time"
+		},
+		{
+			"#": "2",
+			// US-specific:
+			"$if": "productType === 0x0102",
+			"$purpose": "reporting_threshold.temperature",
+			"label": "Temperature Reports: Change Threshold",
+			"valueSize": 1,
+			"unit": "0.1 (°C/°F)",
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 36,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "2",
+			// Other regions:
+			"$purpose": "reporting_threshold.temperature",
+			"label": "Temperature Reports: Change Threshold",
+			"valueSize": 1,
+			"unit": "0.1 (°C/°F)",
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 20,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "3",
+			"$purpose": "reporting_threshold.humidity",
+			"label": "Humidity Reports: Change Threshold",
+			"valueSize": 1,
+			"unit": "0.1 %",
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 50,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "4[0x01]",
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_periodic_reports"
+		},
+		{
+			"#": "4[0x02]",
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_wake"
+		},
+		{
+			"#": "4[0x04]",
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_mold_danger"
+		},
+		{
+			"#": "4[0x08]",
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper",
+			"defaultValue": 1
+		},
+		{
+			// The spec marks this parameter read-only, but a bit field that enables
+			// per-sensor limit reporting cannot sensibly be read-only; treated as writable.
+			"#": "12[0x01]",
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_limit_enable_temperature_upper"
+		},
+		{
+			"#": "12[0x02]",
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_limit_enable_humidity_upper"
+		},
+		{
+			"#": "12[0x04]",
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_limit_enable_temperature_lower"
+		},
+		{
+			"#": "12[0x08]",
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_limit_enable_humidity_lower"
+		},
+		{
+			"#": "13",
+			"label": "Mold Danger: Humidity Offset",
+			"description": "Increases the humidity threshold that triggers the mold danger alarm, whose baseline is 60%.",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 40,
+			"defaultValue": 0
+		},
+		{
+			"#": "14",
+			// US-specific:
+			"$if": "productType === 0x0102",
+			"label": "Temperature Reports: Upper Limit",
+			"description": "Devices in Group 2 will receive a Basic Set command if the temperature exceeds this value.",
+			"valueSize": 2,
+			"unit": "0.1 (°C/°F)",
+			"minValue": 32,
+			"maxValue": 2120,
+			"defaultValue": 860
+		},
+		{
+			"#": "14",
+			// Other regions:
+			"label": "Temperature Reports: Upper Limit",
+			"description": "Devices in Group 2 will receive a Basic Set command if the temperature exceeds this value.",
+			"valueSize": 2,
+			"unit": "0.1 (°C/°F)",
+			"minValue": 0,
+			"maxValue": 1000,
+			"defaultValue": 300
+		},
+		{
+			"#": "15",
+			// US-specific:
+			"$if": "productType === 0x0102",
+			"label": "Temperature Reports: Lower Limit",
+			"description": "Devices in Group 3 will receive a Basic Set command if the temperature drops below this value.",
+			"valueSize": 2,
+			"unit": "0.1 (°C/°F)",
+			"minValue": -40,
+			"maxValue": 2120,
+			"defaultValue": 320
+		},
+		{
+			"#": "15",
+			// Other regions:
+			"label": "Temperature Reports: Lower Limit",
+			"description": "Devices in Group 3 will receive a Basic Set command if the temperature drops below this value.",
+			"valueSize": 2,
+			"unit": "0.1 (°C/°F)",
+			"minValue": -200,
+			"maxValue": 1000,
+			"defaultValue": 0
+		},
+		{
+			"#": "16",
+			"$import": "~/0x0086/templates/aeotec_template.json#watermark_humidity_upper",
+			"description": "Devices in Group 4 will receive a Basic Set command if the humidity exceeds this value."
+		},
+		{
+			"#": "17",
+			"$import": "~/0x0086/templates/aeotec_template.json#watermark_humidity_lower",
+			"description": "Devices in Group 5 will receive a Basic Set command if the humidity drops below this value."
+		},
+		{
+			"#": "18",
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Temperature Reports: Basic Set Value (Above Upper Limit)",
+			"defaultValue": 0
+		},
+		{
+			"#": "19",
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Temperature Reports: Basic Set Value (Below Lower Limit)",
+			"defaultValue": 255
+		},
+		{
+			"#": "20",
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Humidity Reports: Basic Set Value (Above Upper Limit)",
+			"defaultValue": 0
+		},
+		{
+			"#": "21",
+			"$import": "~/templates/master_template.json#basic_set_value",
+			"label": "Humidity Reports: Basic Set Value (Below Lower Limit)",
+			"defaultValue": 255
+		},
+		{
+			"#": "22",
+			"$import": "~/0x0086/templates/aeotec_template.json#enable_binary_report",
+			"description": "Backward-compatible Binary Sensor report for the mold danger state."
+		},
+		{
+			"#": "23",
+			"$import": "~/0x0086/templates/aeotec_template.json#reporting_threshold.low_battery",
+			"defaultValue": 20
+		},
+		{
+			"#": "24",
+			"$import": "~/0x0086/templates/aeotec_template.json#periodic_reports_interval"
+		},
+		{
+			"#": "25",
+			"$purpose": "calibration.temperature",
+			"label": "Temperature Calibration",
+			"description": "Scale is defined by parameter 64.",
+			"valueSize": 2,
+			"unit": "0.1 (°C/°F)",
+			"minValue": -200,
+			"maxValue": 200,
+			"defaultValue": 0,
+			"unsigned": false
+		},
+		{
+			"#": "26",
+			"$purpose": "calibration.humidity",
+			"label": "Humidity Calibration",
+			"valueSize": 2,
+			"unit": "0.1 %",
+			"minValue": -200,
+			"maxValue": 200,
+			"defaultValue": 0,
+			"unsigned": false
+		},
+		{
+			"#": "64",
+			// US-specific:
+			"$if": "productType === 0x0102",
+			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit_0",
+			"valueSize": 1,
+			"defaultValue": 1
+		},
+		{
+			"#": "64",
+			// Other regions:
+			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit_0",
+			"valueSize": 1,
+			"defaultValue": 0
+		}
+	],
+	"metadata": {
+		"wakeup": "Press the Action Button once.",
+		"inclusion": "Quickly press the Action Button on the product twice.",
+		"exclusion": "Quickly press the Action Button on the product twice.",
+		"reset": "Press and hold the Action Button for 12 seconds and then release the button.",
+		"manual": "https://products.z-wavealliance.org/wp-content/uploads/products/80653/EngineeringSpec-arQTemperatureHumiditySensor820251219B.pdf"
+	}
+}

--- a/packages/config/config/devices/0x0371/zwa057.json
+++ b/packages/config/config/devices/0x0371/zwa057.json
@@ -167,7 +167,9 @@
 			"description": "Devices in Group 2 will receive a Basic Set command if the temperature exceeds this value.",
 			"valueSize": 2,
 			"unit": "0.1 (°C/°F)",
-			"minValue": 32,
+			// The spec prints 0x0020 (32) here, but the max/default values only convert
+			// cleanly between °C and °F at 320 (32.0°F = 0.0°C, matching the EU/AU minimum).
+			"minValue": 320,
 			"maxValue": 2120,
 			"defaultValue": 860
 		},
@@ -267,8 +269,7 @@
 			"unit": "0.1 (°C/°F)",
 			"minValue": -200,
 			"maxValue": 200,
-			"defaultValue": 0,
-			"unsigned": false
+			"defaultValue": 0
 		},
 		{
 			"#": "26",
@@ -278,8 +279,7 @@
 			"unit": "0.1 %",
 			"minValue": -200,
 			"maxValue": 200,
-			"defaultValue": 0,
-			"unsigned": false
+			"defaultValue": 0
 		},
 		{
 			"#": "64",


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

PR description here

- Add config file for ZWA057 and the foundation for the common template needed for some of Aeotec gen 8 line of devices. I'll be adding four more config files for this line shortly, in follow up PRs.
- I've used Claude to generate the config based on the manual and certification data found online. I've checked it with the config pr skill. After that I've proofread it manually and tested it manually together with the device.