### PR TITLE
feat(config): add Aeotec ZWA065 Siren 8

### DIFF
--- a/packages/config/config/devices/0x0371/zwa065.json
+++ b/packages/config/config/devices/0x0371/zwa065.json
@@ -1,0 +1,207 @@
+{
+	"manufacturer": "Aeotec Ltd.",
+	"manufacturerId": "0x0371",
+	"label": "ZWA065",
+	"description": "Siren 8",
+	"devices": [
+		{
+			// US version. Config param 13 switches the device between Binary Switch and
+			// Sound Switch device types, so both product types must be listed here or the
+			// device goes unmatched after switching to the other mode.
+			"productType": "0x0103",
+			"productId": "0x0041"
+		},
+		{
+			// US version, Sound Switch device type (see comment above)
+			"productType": "0x0104",
+			"productId": "0x0041"
+		},
+		{
+			// EU version. Confirmed via a real device interview (productType 3).
+			// There is no EU listing in the Z-Wave Alliance catalog yet.
+			"productType": "0x0003",
+			"productId": "0x0041"
+		},
+		{
+			// EU version, Sound Switch device type. Inferred from the same region/device-type
+			// byte pattern as the confirmed EU Binary Switch entry above, not device-confirmed.
+			"productType": "0x0004",
+			"productId": "0x0041"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Retransmit",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Alarm Duration",
+			"valueSize": 2,
+			"unit": "seconds",
+			"minValue": 10,
+			"maxValue": 600,
+			"defaultValue": 180
+		},
+		{
+			"#": "2",
+			"label": "Default Tone",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 5,
+			"defaultValue": 1
+		},
+		{
+			"#": "3",
+			"label": "Default Volume",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 100
+		},
+		{
+			"#": "4[0x01]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Stop Alarm on Button Click",
+			"defaultValue": 1
+		},
+		{
+			"#": "4[0x02]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Stop Indicator on Button Click",
+			"defaultValue": 1
+		},
+		{
+			"#": "5",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Power Outage: Play Alarm"
+		},
+		{
+			"#": "6",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Power Reconnect: Stop Alarm"
+		},
+		{
+			"#": "7",
+			"label": "Power Outage: Alarm Cancellation Delay",
+			"valueSize": 2,
+			"unit": "seconds",
+			"minValue": 0,
+			"maxValue": 300,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "No cancellation",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "8",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "LED Indicator: Siren Alarm",
+			"defaultValue": 1
+		},
+		{
+			"#": "9",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Siren Alarm: Sound",
+			"defaultValue": 1
+		},
+		{
+			"#": "10",
+			"label": "Light Pattern: Brightness Level",
+			"description": "Only applies in light pattern mode.",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 1
+		},
+		{
+			"#": "11",
+			"label": "Light Pattern: LED Activation",
+			"description": "Only applies in light pattern mode.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "One by one",
+					"value": 0
+				},
+				{
+					"label": "Together",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "12",
+			"label": "Light Pattern: Effect",
+			"description": "Byte 1 selects the mode (0 = multilevel, 1 = toggling, 2 = timeout); the meaning of bytes 2-4 depends on the selected mode. Refer to the manual for the full encoding.",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 4294967295,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "13",
+			"label": "Device Type",
+			"description": "Changing this requires the device to be re-included afterwards.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Binary Switch",
+					"value": 0
+				},
+				{
+					"label": "Sound Switch",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "80",
+			"label": "Association Groups: Report Type",
+			"description": "Selects whether groups 1 and 2 use Basic Set/Report, or the command class native to the current device type (Binary Switch or Sound Switch).",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Basic Command Class",
+					"value": 0
+				},
+				{
+					"label": "Native Command Class",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "252",
+			"$import": "~/0x0086/templates/aeotec_template.json#lock_configuration"
+		}
+	],
+	"metadata": {
+		"inclusion": "Quickly press the Action Button on the product twice.",
+		"exclusion": "Quickly press the Action Button on the product twice.",
+		"reset": "Press and hold the Action Button for 12 seconds and then release the button.",
+		"manual": "https://products.z-wavealliance.org/wp-content/uploads/products/80667/EngineeringSpec-ZWA065_AeotecSiren8_3.pdf"
+	}
+}

--- a/packages/config/config/devices/0x0371/zwa065.json
+++ b/packages/config/config/devices/0x0371/zwa065.json
@@ -27,6 +27,19 @@
 			// byte pattern as the confirmed EU Binary Switch entry above, not device-confirmed.
 			"productType": "0x0004",
 			"productId": "0x0041"
+		},
+		{
+			// AU/NZ version. Not in the Z-Wave Alliance catalog yet, but Aeotec's regional
+			// numbering pattern (EU/US/AU regions map to product type bytes 0x00/0x01/0x02) has
+			// proven reliable and is confirmed by Aeotec's own technical specification page:
+			// https://aeotec.freshdesk.com/support/solutions/articles/6000280231-siren-8-technical-specifications-
+			"productType": "0x0203",
+			"productId": "0x0041"
+		},
+		{
+			// AU/NZ version, Sound Switch device type (see comment above)
+			"productType": "0x0204",
+			"productId": "0x0041"
 		}
 	],
 	"firmwareVersion": {

--- a/packages/eslint-plugin/src/utils/wordsAndNames.ts
+++ b/packages/eslint-plugin/src/utils/wordsAndNames.ts
@@ -24,6 +24,7 @@ const ccAndCommandNames = combinations(
 		"Notification",
 		"Binary Sensor",
 		"Binary Switch",
+		"Sound Switch",
 		"Hail",
 		"Configuration",
 		"Barrier",


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

PR description here

- Add config for ZWA065.
- Add "Sound Switch" to the eslint-plugin's known Command Class names so the option label title-cases correctly.
- Claude generated the config from the manual and certification online sources. I proofread and tested manually with a real device.