### PR TITLE
fix(config): polish Aeotec ZWA056 config file

### DIFF
--- a/packages/config/config/devices/0x0371/zwa056.json
+++ b/packages/config/config/devices/0x0371/zwa056.json
@@ -167,8 +167,7 @@
 		},
 		{
 			"#": "6",
-			"$import": "~/templates/master_template.json#base_options_nounit",
-			"label": "Association Group 2: Trigger",
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_trigger",
 			"options": [
 				{
 					"label": "Switch after dry contact closed and open",
@@ -374,6 +373,9 @@
 			"description": "Sets the interval for battery, temperature and humidity reports."
 		},
 		{
+			// The spec declares this parameter as 1 byte, which cannot hold its documented
+			// -200..200 range. Sized as 2 bytes to match the identical parameter 26 and the
+			// equivalent parameter on other Gen8 sensors.
 			"#": "25",
 			"$purpose": "calibration.temperature",
 			"label": "Temperature Calibration",


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

PR description here

- Reuse aeotec_template.json#association_group_2_trigger for param 6 instead of duplicating its options inline via master_template.json's generic base_options_nounit.
- Add a comment documenting the param 25 valueSize correction (1 byte declared in spec, doesn't fit the documented range, sized to 2 like param 26).