### PR TITLE
fix: learn thermostat setpoint float encodings from reports

### DIFF
--- a/docs/api/CCs/ThermostatSetpoint.md
+++ b/docs/api/CCs/ThermostatSetpoint.md
@@ -28,6 +28,7 @@ Explicit `compat.overrideFloatEncoding` settings take precedence.
 The command fails when no observed encoding for the requested scale can hold the value.
 Automatic encoding is used when no encodings are known for that scale or the command is multicast.
 New reports update the observed encodings without a reinterview.
+Each command keeps its chosen encoding while queued and during retries.
 Optimistic updates and verification polls use the transmitted value.
 
 ### `getCapabilities`

--- a/docs/api/CCs/ThermostatSetpoint.md
+++ b/docs/api/CCs/ThermostatSetpoint.md
@@ -22,6 +22,14 @@ async set(
 ): Promise<SupervisionResult | undefined>;
 ```
 
+Sets a temperature using float encodings observed anywhere on the device.
+Values are rounded to the closest representable value for the requested scale.
+Explicit `compat.overrideFloatEncoding` settings take precedence.
+The command fails when no observed encoding for the requested scale can hold the value.
+Automatic encoding is used when no encodings are known for that scale or the command is multicast.
+New reports update the observed encodings without a reinterview.
+Optimistic updates and verification polls use the transmitted value.
+
 ### `getCapabilities`
 
 ```ts

--- a/packages/cc/src/cc/ThermostatSetpointCC.test.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.test.ts
@@ -1,0 +1,298 @@
+import {
+	CommandClasses,
+	type MulticastDestination,
+	ValueDB,
+	encodeFloatWithScale,
+} from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { describe, expect, test } from "vitest";
+
+import { CCRaw, type PersistValuesContext } from "../lib/CommandClass.js";
+import {
+	ThermostatSetpointCommand,
+	ThermostatSetpointType,
+} from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	ThermostatSetpointCCCapabilitiesReport,
+	ThermostatSetpointCCReport,
+	ThermostatSetpointCCSet,
+	ThermostatSetpointCCValues,
+} from "./ThermostatSetpointCC.js";
+
+const ccId = CommandClasses["Thermostat Setpoint"];
+const observedId = ThermostatSetpointCCValues.observedFloatEncodings.id;
+
+function setup() {
+	const valueDB = new ValueDB(2, new Map() as any, new Map() as any);
+	const otherValueDB = new ValueDB(3, new Map() as any, new Map() as any);
+	const ctx = {
+		sourceNodeId: 2,
+		getValueDB: (nodeId: number) => (nodeId === 2 ? valueDB : otherValueDB),
+		tryGetValueDB: (nodeId: number) =>
+			nodeId === 2 ? valueDB : otherValueDB,
+		getSupportedCCVersion: () => 3,
+	} as unknown as CCEncodingContext & CCParsingContext & PersistValuesContext;
+
+	function report(
+		precision: number,
+		size: number,
+		scale = 0,
+		type = ThermostatSetpointType.Heating,
+		endpoint = 0,
+	) {
+		const cc = ThermostatSetpointCCReport.from(
+			new CCRaw(
+				ccId,
+				ThermostatSetpointCommand.Report,
+				Bytes.from([
+					type,
+					(precision << 5) | (scale << 3) | size,
+					...Array(size).fill(0),
+				]),
+			),
+			ctx,
+		);
+		cc.endpointIndex = endpoint;
+		expect(cc.persistValues(ctx)).toBe(true);
+		return cc;
+	}
+
+	async function encode(
+		value: number,
+		scale = 0,
+		nodeId: number | MulticastDestination = 2,
+	) {
+		const cc = new ThermostatSetpointCCSet({
+			nodeId,
+			endpointIndex: 3,
+			setpointType: ThermostatSetpointType.Cooling,
+			value,
+			scale,
+		});
+		return (await cc.serialize(ctx)).subarray(3);
+	}
+
+	return { ctx, valueDB, report, encode };
+}
+
+describe("Thermostat Setpoint float encodings", () => {
+	test("retains raw encodings globally across endpoints and types", async () => {
+		const { valueDB, report, encode } = setup();
+		report(1, 2, 0, ThermostatSetpointType.Heating, 1);
+		report(3, 4, 1, ThermostatSetpointType.Cooling, 2);
+		report(1, 2);
+		expect(valueDB.getValue(observedId)).toEqual([
+			{ precision: 1, size: 2, scale: 0 },
+			{ precision: 3, size: 4, scale: 1 },
+		]);
+		expect(
+			valueDB
+				.getValues(ccId)
+				.filter((value) => value.property === observedId.property),
+		).toHaveLength(1);
+		expect(
+			valueDB
+				.getValues(ccId)
+				.find((value) => value.property === observedId.property)
+				?.endpoint,
+		).toBe(0);
+		expect(await encode(21)).toEqual(Bytes.from([0x22, 0, 210]));
+		expect(await encode(21, 0, 3)).toEqual(encodeFloatWithScale(21, 0));
+	});
+
+	test("learns both capability bounds including their distinct scales", () => {
+		const { ctx, valueDB } = setup();
+		const cc = ThermostatSetpointCCCapabilitiesReport.from(
+			new CCRaw(
+				ccId,
+				ThermostatSetpointCommand.CapabilitiesReport,
+				Bytes.from([1, 0x22, 0, 50, 0x4c, 0, 0, 0x23, 0x28]),
+			),
+			ctx,
+		);
+		cc.endpointIndex = 4;
+		cc.persistValues(ctx);
+		expect(valueDB.getValue(observedId)).toEqual([
+			{ precision: 1, size: 2, scale: 0 },
+			{ precision: 2, size: 4, scale: 1 },
+		]);
+		expect(cc.minValue).toBe(5);
+		expect(cc.maxValue).toBe(90);
+	});
+
+	test("uses observations restored from the value cache", async () => {
+		const first = setup();
+		first.report(2, 2);
+		const restored = setup();
+		restored.valueDB.setValue(
+			observedId,
+			JSON.parse(JSON.stringify(first.valueDB.getValue(observedId))),
+		);
+		expect(await restored.encode(21.567)).toEqual(
+			Bytes.from([0x42, 8, 0x6d]),
+		);
+		restored.report(0, 1);
+		expect(restored.valueDB.getValue(observedId)).toEqual([
+			{ precision: 2, size: 2, scale: 0 },
+			{ precision: 0, size: 1, scale: 0 },
+		]);
+	});
+
+	test("ignores N/A responses without float payloads", () => {
+		const { ctx, valueDB } = setup();
+		ThermostatSetpointCCReport.from(
+			new CCRaw(ccId, ThermostatSetpointCommand.Report, Bytes.from([0])),
+			ctx,
+		).persistValues(ctx);
+		ThermostatSetpointCCCapabilitiesReport.from(
+			new CCRaw(
+				ccId,
+				ThermostatSetpointCommand.CapabilitiesReport,
+				Bytes.from([0]),
+			),
+			ctx,
+		).persistValues(ctx);
+		expect(valueDB.getValues(ccId)).toEqual([]);
+	});
+
+	test("ignores N/A reports and capabilities", () => {
+		const { ctx, valueDB, report } = setup();
+		report(7, 4, 0, ThermostatSetpointType["N/A"]);
+		const cc = ThermostatSetpointCCCapabilitiesReport.from(
+			new CCRaw(
+				ccId,
+				ThermostatSetpointCommand.CapabilitiesReport,
+				Bytes.from([0, 1, 0, 1, 0]),
+			),
+			ctx,
+		);
+		cc.persistValues(ctx);
+		expect(valueDB.getValue(observedId)).toBeUndefined();
+		expect(valueDB.getValues(ccId)).toEqual([]);
+	});
+
+	test.each([
+		[1, 2, 21, [0x22, 0, 210]],
+		[1, 2, 21.26, [0x22, 0, 213]],
+		[1, 2, -21.26, [0x22, 0xff, 0x2b]],
+		[2, 4, 21, [0x44, 0, 0, 8, 0x34]],
+		[0, 3, 40000, [3, 0, 0x9c, 0x40]],
+		[0, 3, -40000, [3, 0xff, 0x63, 0xc0]],
+		[7, 4, 21.12345678, [0xe4, 0x0c, 0x97, 0x2f, 0x08]],
+	])(
+		"uses precision %i and size %i for %s",
+		async (precision, size, value, bytes) => {
+			const { report, encode } = setup();
+			report(precision, size);
+			expect(await encode(value)).toEqual(Bytes.from(bytes));
+		},
+	);
+
+	test("preserves representable precision without inventing combinations", async () => {
+		const { report, encode } = setup();
+		report(0, 1);
+		report(2, 4);
+		expect(await encode(21)).toEqual(Bytes.from([1, 21]));
+		expect(await encode(21.5)).toEqual(Bytes.from([0x44, 0, 0, 8, 0x66]));
+		expect(await encode(21.567)).toEqual(Bytes.from([0x44, 0, 0, 8, 0x6d]));
+	});
+
+	test("uses a fitting observed combination when higher precision overflows", async () => {
+		const { report, encode } = setup();
+		report(2, 1);
+		report(0, 2);
+		expect(await encode(21.5)).toEqual(Bytes.from([2, 0, 22]));
+	});
+
+	test.each([128, -129, 127.5, Infinity, NaN])(
+		"rejects %s when no observed encoding fits",
+		async (value) => {
+			const { report, encode } = setup();
+			report(0, 1);
+			await expect(encode(value)).rejects.toThrow(
+				"any observed float encoding",
+			);
+		},
+	);
+
+	test("respects signed size limits", async () => {
+		const { report, encode } = setup();
+		report(0, 1);
+		expect(await encode(127)).toEqual(Bytes.from([1, 127]));
+		expect(await encode(-128)).toEqual(Bytes.from([1, 128]));
+	});
+
+	test("uses only encodings reported for the requested scale", async () => {
+		const { report, encode } = setup();
+		report(0, 1, 0);
+		report(2, 2, 1);
+		expect(await encode(21.55, 0)).toEqual(Bytes.from([1, 22]));
+		expect(await encode(21.55, 1)).toEqual(Bytes.from([0x4a, 8, 0x6b]));
+	});
+
+	test("falls back without observations, a matching scale, or a singlecast node", async () => {
+		const { ctx, report, encode } = setup();
+		const automatic = encodeFloatWithScale(21.55, 0);
+		expect(await encode(21.55)).toEqual(automatic);
+		report(0, 1, 1);
+		expect(await encode(21.55)).toEqual(automatic);
+		report(0, 1);
+		expect(await encode(21.55, 0, [2, 3])).toEqual(automatic);
+		const withoutValueDB = { ...ctx } as CCEncodingContext;
+		delete withoutValueDB.tryGetValueDB;
+		expect(
+			await new ThermostatSetpointCCSet({
+				nodeId: 2,
+				setpointType: ThermostatSetpointType.Heating,
+				value: 21.55,
+				scale: 0,
+			}).serialize(withoutValueDB),
+		).toEqual(
+			Bytes.concat([
+				[
+					ccId,
+					ThermostatSetpointCommand.Set,
+					ThermostatSetpointType.Heating,
+				],
+				automatic,
+			]),
+		);
+		ctx.tryGetValueDB = () => undefined;
+		expect(await encode(21.55)).toEqual(automatic);
+	});
+
+	test.each([{ precision: 3 }, { size: 4 }, { precision: 2, size: 2 }])(
+		"prioritizes explicit float overrides %j",
+		async (override) => {
+			const { ctx, report, encode } = setup();
+			report(0, 1);
+			ctx.getDeviceConfig = () =>
+				({
+					compat: { overrideFloatEncoding: override },
+				}) as ReturnType<CCEncodingContext["getDeviceConfig"]>;
+			expect(await encode(21.55)).toEqual(
+				encodeFloatWithScale(21.55, 0, override),
+			);
+		},
+	);
+
+	test.each([
+		[1, 0],
+		[1, 5, 0, 0, 0, 0, 0],
+		[1, 2, 0],
+	])("rejects invalid float payload %j", (...payload) => {
+		const { ctx } = setup();
+		expect(() =>
+			ThermostatSetpointCCReport.from(
+				new CCRaw(
+					ccId,
+					ThermostatSetpointCommand.Report,
+					Bytes.from(payload),
+				),
+				ctx,
+			),
+		).toThrow();
+	});
+});

--- a/packages/cc/src/cc/ThermostatSetpointCC.test.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.test.ts
@@ -78,6 +78,68 @@ function setup() {
 }
 
 describe("Thermostat Setpoint float encodings", () => {
+	test("S2 followups retain the multicast encoding after nodeId changes", async () => {
+		const { ctx, report } = setup();
+		report(0, 1);
+		ctx.getValueDB(3).setValue(observedId, [
+			{ precision: 2, scale: 0, size: 4 },
+		]);
+		const cc = new ThermostatSetpointCCSet({
+			nodeId: [2, 3],
+			setpointType: ThermostatSetpointType.Heating,
+			value: 21.55,
+			scale: 0,
+		});
+		const multicast = await cc.serialize(ctx);
+		for (const nodeId of [2, 3, 2]) {
+			cc.nodeId = nodeId;
+			cc.prepareRetransmission();
+			expect(await cc.serialize(ctx)).toEqual(multicast);
+			expect(cc.value).toBe(21.55);
+		}
+	});
+
+	test("retries retain the first encoding when observations change", async () => {
+		const { ctx, report } = setup();
+		const cc = new ThermostatSetpointCCSet({
+			nodeId: 2,
+			setpointType: ThermostatSetpointType.Heating,
+			value: 21.55,
+			scale: 0,
+		});
+		const initial = await cc.serialize(ctx);
+		report(0, 1);
+		cc.prepareRetransmission();
+		expect(await cc.serialize(ctx)).toEqual(initial);
+		expect(cc.value).toBe(21.55);
+		const next = new ThermostatSetpointCCSet({
+			nodeId: 2,
+			setpointType: ThermostatSetpointType.Heating,
+			value: 21.55,
+			scale: 0,
+		});
+		expect((await next.serialize(ctx)).subarray(3)).toEqual(
+			Bytes.from([1, 22]),
+		);
+		expect(next.value).toBe(22);
+	});
+
+	test("failed encoding does not prevent learning a usable encoding", async () => {
+		const { ctx, report } = setup();
+		report(0, 1);
+		const cc = new ThermostatSetpointCCSet({
+			nodeId: 2,
+			setpointType: ThermostatSetpointType.Heating,
+			value: 128,
+			scale: 0,
+		});
+		expect(() => cc.serialize(ctx)).toThrow();
+		report(0, 2);
+		expect((await cc.serialize(ctx)).subarray(3)).toEqual(
+			Bytes.from([2, 0, 128]),
+		);
+	});
+
 	test("retains raw encodings globally across endpoints and types", async () => {
 		const { valueDB, report, encode } = setup();
 		report(1, 2, 0, ThermostatSetpointType.Heating, 1);

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -30,8 +30,9 @@ import {
 	POLL_VALUE,
 	type PollValueImplementation,
 	SET_VALUE,
+	SET_VALUE_HOOKS,
 	type SetValueImplementation,
-	type ValueIDProperties,
+	type SetValueImplementationHooksFactory,
 	throwUnsupportedProperty,
 	throwWrongValueType,
 } from "../lib/API.js";
@@ -175,6 +176,36 @@ export const ThermostatSetpointCCValues = V.defineCCValues(
 
 @API(CommandClasses["Thermostat Setpoint"])
 export class ThermostatSetpointCCAPI extends CCAPI {
+	private getPreferredScale(setpointType: ThermostatSetpointType): number {
+		// SDS14223: The Scale field value MUST be identical to the value received in the Thermostat Setpoint Report for the
+		// actual Setpoint Type during the node interview. Fall back to the first scale if none is known
+		return (
+			this.tryGetValueDB()?.getValue<number>(
+				ThermostatSetpointCCValues.setpointScale(setpointType).endpoint(
+					this.endpoint.index,
+				),
+			) ?? 0
+		);
+	}
+
+	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = ({
+		property,
+		propertyKey,
+	}) => {
+		if (property === "setpoint" && typeof propertyKey === "number") {
+			return {
+				normalizeValue: (value) =>
+					typeof value === "number"
+						? this.createSetpointSet(
+								propertyKey,
+								value,
+								this.getPreferredScale(propertyKey),
+							).value
+						: value,
+			};
+		}
+	};
+
 	public supportsCommand(
 		cmd: ThermostatSetpointCommand,
 	): MaybeNotKnown<boolean> {
@@ -196,60 +227,42 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 			{ property, propertyKey },
 			value,
 		) {
-			return (
-				await this.setValueWithEffectiveValue(
-					{ property, propertyKey },
-					value,
-				)
-			).result;
-		};
-	}
+			if (property !== "setpoint") {
+				throwUnsupportedProperty(this.ccId, property);
+			}
+			if (typeof propertyKey !== "number") {
+				throw new ZWaveError(
+					`${
+						CommandClasses[this.ccId]
+					}: "${property}" must be further specified by a numeric property key`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			if (typeof value !== "number") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"number",
+					typeof value,
+				);
+			}
 
-	/** Sets a value and returns the value encoded by the command. */
-	@validateArgs()
-	public async setValueWithEffectiveValue(
-		valueId: ValueIDProperties,
-		value: unknown,
-	): Promise<{ result: SupervisionResult | undefined; value: number }> {
-		const { property, propertyKey } = valueId;
-		if (property !== "setpoint") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (typeof propertyKey !== "number") {
-			throw new ZWaveError(
-				`${
-					CommandClasses[this.ccId]
-				}: "${property}" must be further specified by a numeric property key`,
-				ZWaveErrorCodes.Argument_Invalid,
-			);
-		}
-		if (typeof value !== "number") {
-			throwWrongValueType(this.ccId, property, "number", typeof value);
-		}
-
-		// SDS14223: The Scale field value MUST be identical to the value received in the Thermostat Setpoint Report for the
-		// actual Setpoint Type during the node interview. Fall back to the first scale if none is known
-		const preferredScale = this.tryGetValueDB()?.getValue<number>(
-			ThermostatSetpointCCValues.setpointScale(propertyKey).endpoint(
-				this.endpoint.index,
-			),
-		);
-		const { result, value: effectiveValue } =
-			await this.setWithEffectiveValue(
+			const cc = this.createSetpointSet(
 				propertyKey,
 				value,
-				preferredScale ?? 0,
-				true,
+				this.getPreferredScale(propertyKey),
 			);
+			const result = await this.host.sendCommand(cc, this.commandOptions);
 
-		// Verify the current value after a delay, unless the command was supervised and successful
-		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-			// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
-			// aren't able to handle the GET this quickly.
-			this.schedulePoll({ property, propertyKey }, effectiveValue);
-		}
+			// Verify the current value after a delay, unless the command was supervised and successful
+			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+				// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
+				// aren't able to handle the GET this quickly.
+				this.schedulePoll({ property, propertyKey }, cc.value);
+			}
 
-		return { result, value: effectiveValue };
+			return result;
+		};
 	}
 
 	protected get [POLL_VALUE](): PollValueImplementation {
@@ -318,16 +331,15 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		value: number,
 		scale: number,
 	): Promise<SupervisionResult | undefined> {
-		return (await this.setWithEffectiveValue(setpointType, value, scale))
-			.result;
+		const cc = this.createSetpointSet(setpointType, value, scale);
+		return this.host.sendCommand(cc, this.commandOptions);
 	}
 
-	private async setWithEffectiveValue(
+	private createSetpointSet(
 		setpointType: ThermostatSetpointType,
 		value: number,
 		scale: number,
-		preventDeduplication = false,
-	): Promise<{ result: SupervisionResult | undefined; value: number }> {
+	): ThermostatSetpointCCSet {
 		this.assertSupportsCommand(
 			ThermostatSetpointCommand,
 			ThermostatSetpointCommand.Set,
@@ -340,12 +352,8 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 			value,
 			scale,
 		});
-		// Value updates need this instance's serialized value
-		const options = preventDeduplication
-			? { ...this.commandOptions, preventDeduplication: true }
-			: this.commandOptions;
-		const result = await this.host.sendCommand(cc, options);
-		return { result, value: cc.value };
+		cc.normalizeValue(this.host);
+		return cc;
 	}
 
 	@validateArgs()
@@ -721,7 +729,17 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 		return CommandRelation.Unrelated;
 	}
 
-	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+	/** Normalizes the value and fixes its encoding for this command. */
+	public normalizeValue(
+		ctx: Pick<CCEncodingContext, "getDeviceConfig" | "tryGetValueDB">,
+	): number {
+		this.getEncodedValue(ctx);
+		return this.value;
+	}
+
+	private getEncodedValue(
+		ctx: Pick<CCEncodingContext, "getDeviceConfig" | "tryGetValueDB">,
+	): Bytes {
 		// Retries and S2 singlecast followups must reuse the original float encoding
 		if (!this.encodedValue) {
 			// If a config file overwrites how the float should be encoded, use that information
@@ -750,9 +768,14 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 			this.value = parseFloatWithScale(encodedValue).value;
 			this.encodedValue = encodedValue;
 		}
+		return this.encodedValue;
+	}
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const encodedValue = this.getEncodedValue(ctx);
 		this.payload = Bytes.concat([
 			[this.setpointType & 0b1111],
-			this.encodedValue,
+			encodedValue,
 		]);
 		return super.serialize(ctx);
 	}

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -30,7 +30,9 @@ import {
 	POLL_VALUE,
 	type PollValueImplementation,
 	SET_VALUE,
+	SET_VALUE_HOOKS,
 	type SetValueImplementation,
+	type SetValueImplementationHooksFactory,
 	throwUnsupportedProperty,
 	throwWrongValueType,
 } from "../lib/API.js";
@@ -73,9 +75,74 @@ function getSetpointUnit(scale: number): string {
 	return getScale(scale).unit ?? "";
 }
 
+interface SetpointFloatEncoding {
+	precision: number;
+	scale: number;
+	size: number;
+}
+
+function parseSetpointFloat(payload: Bytes) {
+	const parsed = parseFloatWithScale(payload);
+	const encoding: SetpointFloatEncoding = {
+		precision: payload[0] >>> 5,
+		scale: parsed.scale,
+		size: parsed.bytesRead - 1,
+	};
+	return { ...parsed, encoding };
+}
+
+function encodeSetpointFloat(
+	value: number,
+	scale: number,
+	encodings: readonly SetpointFloatEncoding[],
+): Bytes {
+	const candidates = encodings.filter((encoding) => encoding.scale === scale);
+	if (!candidates.length) return encodeFloatWithScale(value, scale);
+
+	const fitting = candidates
+		.map((encoding) => {
+			const factor = 10 ** encoding.precision;
+			const integer = Math.round(value * factor);
+			const limit = 2 ** (8 * encoding.size - 1);
+			return {
+				...encoding,
+				integer,
+				error: Math.abs(value - integer / factor),
+				fits:
+					Number.isFinite(integer)
+					&& integer >= -limit
+					&& integer < limit,
+			};
+		})
+		.filter((candidate) => candidate.fits)
+		.toSorted(
+			(a, b) =>
+				a.error - b.error
+				|| a.precision - b.precision
+				|| a.size - b.size,
+		);
+	const selected = fitting[0];
+	if (!selected) {
+		throw new ZWaveError(
+			`Cannot encode setpoint ${value} with any observed float encoding for scale ${scale}`,
+			ZWaveErrorCodes.Argument_Invalid,
+		);
+	}
+
+	// The wire format permits three-byte integers
+	const ret = new Bytes(1 + selected.size);
+	ret[0] = (selected.precision << 5) | (scale << 3) | selected.size;
+	ret.writeIntBE(selected.integer, 1, selected.size);
+	return ret;
+}
+
 export const ThermostatSetpointCCValues = V.defineCCValues(
 	CommandClasses["Thermostat Setpoint"],
 	{
+		...V.staticProperty("observedFloatEncodings", undefined, {
+			internal: true,
+			supportsEndpoints: false,
+		}),
 		...V.staticProperty("supportedSetpointTypes", undefined, {
 			internal: true,
 		}),
@@ -108,6 +175,52 @@ export const ThermostatSetpointCCValues = V.defineCCValues(
 
 @API(CommandClasses["Thermostat Setpoint"])
 export class ThermostatSetpointCCAPI extends CCAPI {
+	private getPreferredScale(setpointType: ThermostatSetpointType): number {
+		// SDS14223 requires the scale reported for the actual setpoint type
+		return (
+			this.tryGetValueDB()?.getValue<number>(
+				ThermostatSetpointCCValues.setpointScale(setpointType).endpoint(
+					this.endpoint.index,
+				),
+			) ?? 0
+		);
+	}
+
+	private encodeSetpointValue(value: number, scale: number): Bytes {
+		const override = this.host.getDeviceConfig?.(
+			this.endpoint.nodeId as number,
+		)?.compat?.overrideFloatEncoding;
+		const observed =
+			this.tryGetValueDB()?.getValue<SetpointFloatEncoding[]>(
+				ThermostatSetpointCCValues.observedFloatEncodings.id,
+			) ?? [];
+		return override
+			? encodeFloatWithScale(value, scale, override)
+			: encodeSetpointFloat(value, scale, observed);
+	}
+
+	private normalizeSetpointValue(value: number, scale: number): number {
+		return parseFloatWithScale(this.encodeSetpointValue(value, scale))
+			.value;
+	}
+
+	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = ({
+		property,
+		propertyKey,
+	}) => {
+		if (property === "setpoint" && typeof propertyKey === "number") {
+			return {
+				normalizeValue: (value) =>
+					typeof value === "number"
+						? this.normalizeSetpointValue(
+								value,
+								this.getPreferredScale(propertyKey),
+							)
+						: value,
+			};
+		}
+	};
+
 	public supportsCommand(
 		cmd: ThermostatSetpointCommand,
 	): MaybeNotKnown<boolean> {
@@ -149,24 +262,22 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 				);
 			}
 
-			// SDS14223: The Scale field value MUST be identical to the value received in the Thermostat Setpoint Report for the
-			// actual Setpoint Type during the node interview. Fall back to the first scale if none is known
-			const preferredScale = this.tryGetValueDB()?.getValue<number>(
-				ThermostatSetpointCCValues.setpointScale(propertyKey).endpoint(
-					this.endpoint.index,
-				),
+			const preferredScale = this.getPreferredScale(propertyKey);
+			const effectiveValue = this.normalizeSetpointValue(
+				value,
+				preferredScale,
 			);
 			const result = await this.set(
 				propertyKey,
-				value,
-				preferredScale ?? 0,
+				effectiveValue,
+				preferredScale,
 			);
 
 			// Verify the current value after a delay, unless the command was supervised and successful
 			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
 				// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
 				// aren't able to handle the GET this quickly.
-				this.schedulePoll({ property, propertyKey }, value);
+				this.schedulePoll({ property, propertyKey }, effectiveValue);
 			}
 
 			return result;
@@ -226,6 +337,13 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		}
 	}
 
+	/**
+	 * Sets a temperature using float encodings observed anywhere on the device.
+	 * Values are rounded to the closest representable value for the requested scale.
+	 * Explicit `compat.overrideFloatEncoding` settings take precedence.
+	 * Automatic encoding is used until the device reports an encoding for that scale.
+	 * @throws When no observed encoding for the requested scale can hold the value.
+	 */
 	@validateArgs()
 	public async set(
 		setpointType: ThermostatSetpointType,
@@ -243,6 +361,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 			setpointType,
 			value,
 			scale,
+			encodedValue: this.encodeSetpointValue(value, scale),
 		});
 		return this.host.sendCommand(cc, this.commandOptions);
 	}
@@ -306,6 +425,33 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 @ccValues(ThermostatSetpointCCValues)
 export class ThermostatSetpointCC extends CommandClass {
 	declare ccCommand: ThermostatSetpointCommand;
+
+	protected persistFloatEncodings(
+		ctx: GetValueDB,
+		encodings: readonly SetpointFloatEncoding[],
+	): void {
+		if (!encodings.length) return;
+		const valueDB = this.getValueDB(ctx);
+		const valueId = ThermostatSetpointCCValues.observedFloatEncodings.id;
+		const observed =
+			valueDB.getValue<SetpointFloatEncoding[]>(valueId) ?? [];
+		const updated = [...observed];
+		for (const encoding of encodings) {
+			if (
+				!updated.some(
+					(entry) =>
+						entry.precision === encoding.precision
+						&& entry.scale === encoding.scale
+						&& entry.size === encoding.size,
+				)
+			) {
+				updated.push(encoding);
+			}
+		}
+		if (updated.length !== observed.length) {
+			valueDB.setValue(valueId, updated);
+		}
+	}
 
 	public translatePropertyKey(
 		ctx: GetValueDB,
@@ -545,6 +691,8 @@ export interface ThermostatSetpointCCSetOptions {
 	setpointType: ThermostatSetpointType;
 	value: number;
 	scale: number;
+	/** @internal */
+	encodedValue?: Bytes;
 }
 
 @CCCommand(ThermostatSetpointCommand.Set)
@@ -555,7 +703,10 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 		this.setpointType = options.setpointType;
 		this.value = options.value;
 		this.scale = options.scale;
+		this.encodedValue = options.encodedValue;
 	}
+
+	private readonly encodedValue: Bytes | undefined;
 
 	public static from(
 		raw: CCRaw,
@@ -595,9 +746,24 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 		// If a config file overwrites how the float should be encoded, use that information
 		const override = ctx.getDeviceConfig?.(this.nodeId as number)?.compat
 			?.overrideFloatEncoding;
+		const observed = this.isSinglecast()
+			? ctx
+					.tryGetValueDB?.(this.nodeId)
+					?.getValue<SetpointFloatEncoding[]>(
+						ThermostatSetpointCCValues.observedFloatEncodings.id,
+					)
+			: undefined;
 		this.payload = Bytes.concat([
 			[this.setpointType & 0b1111],
-			encodeFloatWithScale(this.value, this.scale, override),
+			// Keep the prepared value stable while the command waits in the queue
+			this.encodedValue
+				?? (override
+					? encodeFloatWithScale(this.value, this.scale, override)
+					: encodeSetpointFloat(
+							this.value,
+							this.scale,
+							observed ?? [],
+						)),
 		]);
 		return super.serialize(ctx);
 	}
@@ -626,6 +792,8 @@ export interface ThermostatSetpointCCReportOptions {
 
 @CCCommand(ThermostatSetpointCommand.Report)
 export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
+	private floatEncoding: SetpointFloatEncoding | undefined;
+
 	public constructor(
 		options: WithAddress<ThermostatSetpointCCReportOptions>,
 	) {
@@ -654,18 +822,26 @@ export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
 		}
 
 		// parseFloatWithScale does its own validation
-		const { value, scale } = parseFloatWithScale(raw.payload.subarray(1));
+		const { value, scale, encoding } = parseSetpointFloat(
+			raw.payload.subarray(1),
+		);
 
-		return new this({
+		const ret = new this({
 			nodeId: ctx.sourceNodeId,
 			type,
 			value,
 			scale,
 		});
+		ret.floatEncoding = encoding;
+		return ret;
 	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;
+		if (this.type === ThermostatSetpointType["N/A"]) return true;
+		if (this.floatEncoding) {
+			this.persistFloatEncodings(ctx, [this.floatEncoding]);
+		}
 
 		const scale = getScale(this.scale);
 
@@ -810,6 +986,8 @@ export interface ThermostatSetpointCCCapabilitiesReportOptions {
 
 @CCCommand(ThermostatSetpointCommand.CapabilitiesReport)
 export class ThermostatSetpointCCCapabilitiesReport extends ThermostatSetpointCC {
+	private floatEncodings: SetpointFloatEncoding[] = [];
+
 	public constructor(
 		options: WithAddress<ThermostatSetpointCCCapabilitiesReportOptions>,
 	) {
@@ -828,17 +1006,30 @@ export class ThermostatSetpointCCCapabilitiesReport extends ThermostatSetpointCC
 	): ThermostatSetpointCCCapabilitiesReport {
 		validatePayload(raw.payload.length >= 1);
 		const type: ThermostatSetpointType = raw.payload[0];
+		if (type === ThermostatSetpointType["N/A"]) {
+			return new this({
+				nodeId: ctx.sourceNodeId,
+				type,
+				minValue: 0,
+				minValueScale: 0,
+				maxValue: 0,
+				maxValueScale: 0,
+			});
+		}
 		// parseFloatWithScale does its own validation
 		const {
 			value: minValue,
 			scale: minValueScale,
 			bytesRead,
-		} = parseFloatWithScale(raw.payload.subarray(1));
-		const { value: maxValue, scale: maxValueScale } = parseFloatWithScale(
-			raw.payload.subarray(1 + bytesRead),
-		);
+			encoding: minEncoding,
+		} = parseSetpointFloat(raw.payload.subarray(1));
+		const {
+			value: maxValue,
+			scale: maxValueScale,
+			encoding: maxEncoding,
+		} = parseSetpointFloat(raw.payload.subarray(1 + bytesRead));
 
-		return new this({
+		const ret = new this({
 			nodeId: ctx.sourceNodeId,
 			type,
 			minValue,
@@ -846,10 +1037,14 @@ export class ThermostatSetpointCCCapabilitiesReport extends ThermostatSetpointCC
 			maxValue,
 			maxValueScale,
 		});
+		ret.floatEncodings = [minEncoding, maxEncoding];
+		return ret;
 	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;
+		if (this.type === ThermostatSetpointType["N/A"]) return true;
+		this.persistFloatEncodings(ctx, this.floatEncodings);
 
 		// Predefine the metadata
 		const setpointValue = ThermostatSetpointCCValues.setpoint(this.type);

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -30,9 +30,8 @@ import {
 	POLL_VALUE,
 	type PollValueImplementation,
 	SET_VALUE,
-	SET_VALUE_HOOKS,
 	type SetValueImplementation,
-	type SetValueImplementationHooksFactory,
+	type ValueIDProperties,
 	throwUnsupportedProperty,
 	throwWrongValueType,
 } from "../lib/API.js";
@@ -91,14 +90,15 @@ function parseSetpointFloat(payload: Bytes) {
 	return { ...parsed, encoding };
 }
 
-function encodeSetpointFloat(
+function findSetpointFloatEncoding(
 	value: number,
 	scale: number,
 	encodings: readonly SetpointFloatEncoding[],
-): Bytes {
+): SetpointFloatEncoding | undefined {
 	const candidates = encodings.filter((encoding) => encoding.scale === scale);
-	if (!candidates.length) return encodeFloatWithScale(value, scale);
+	if (!candidates.length) return;
 
+	// Reuse an observed combination with the least rounding error that fits the value
 	const fitting = candidates
 		.map((encoding) => {
 			const factor = 10 ** encoding.precision;
@@ -129,11 +129,11 @@ function encodeSetpointFloat(
 		);
 	}
 
-	// The wire format permits three-byte integers
-	const ret = new Bytes(1 + selected.size);
-	ret[0] = (selected.precision << 5) | (scale << 3) | selected.size;
-	ret.writeIntBE(selected.integer, 1, selected.size);
-	return ret;
+	return {
+		precision: selected.precision,
+		scale: selected.scale,
+		size: selected.size,
+	};
 }
 
 export const ThermostatSetpointCCValues = V.defineCCValues(
@@ -175,52 +175,6 @@ export const ThermostatSetpointCCValues = V.defineCCValues(
 
 @API(CommandClasses["Thermostat Setpoint"])
 export class ThermostatSetpointCCAPI extends CCAPI {
-	private getPreferredScale(setpointType: ThermostatSetpointType): number {
-		// SDS14223 requires the scale reported for the actual setpoint type
-		return (
-			this.tryGetValueDB()?.getValue<number>(
-				ThermostatSetpointCCValues.setpointScale(setpointType).endpoint(
-					this.endpoint.index,
-				),
-			) ?? 0
-		);
-	}
-
-	private encodeSetpointValue(value: number, scale: number): Bytes {
-		const override = this.host.getDeviceConfig?.(
-			this.endpoint.nodeId as number,
-		)?.compat?.overrideFloatEncoding;
-		const observed =
-			this.tryGetValueDB()?.getValue<SetpointFloatEncoding[]>(
-				ThermostatSetpointCCValues.observedFloatEncodings.id,
-			) ?? [];
-		return override
-			? encodeFloatWithScale(value, scale, override)
-			: encodeSetpointFloat(value, scale, observed);
-	}
-
-	private normalizeSetpointValue(value: number, scale: number): number {
-		return parseFloatWithScale(this.encodeSetpointValue(value, scale))
-			.value;
-	}
-
-	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = ({
-		property,
-		propertyKey,
-	}) => {
-		if (property === "setpoint" && typeof propertyKey === "number") {
-			return {
-				normalizeValue: (value) =>
-					typeof value === "number"
-						? this.normalizeSetpointValue(
-								value,
-								this.getPreferredScale(propertyKey),
-							)
-						: value,
-			};
-		}
-	};
-
 	public supportsCommand(
 		cmd: ThermostatSetpointCommand,
 	): MaybeNotKnown<boolean> {
@@ -242,46 +196,60 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 			{ property, propertyKey },
 			value,
 		) {
-			if (property !== "setpoint") {
-				throwUnsupportedProperty(this.ccId, property);
-			}
-			if (typeof propertyKey !== "number") {
-				throw new ZWaveError(
-					`${
-						CommandClasses[this.ccId]
-					}: "${property}" must be further specified by a numeric property key`,
-					ZWaveErrorCodes.Argument_Invalid,
-				);
-			}
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
-				);
-			}
-
-			const preferredScale = this.getPreferredScale(propertyKey);
-			const effectiveValue = this.normalizeSetpointValue(
-				value,
-				preferredScale,
-			);
-			const result = await this.set(
-				propertyKey,
-				effectiveValue,
-				preferredScale,
-			);
-
-			// Verify the current value after a delay, unless the command was supervised and successful
-			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-				// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
-				// aren't able to handle the GET this quickly.
-				this.schedulePoll({ property, propertyKey }, effectiveValue);
-			}
-
-			return result;
+			return (
+				await this.setValueWithEffectiveValue(
+					{ property, propertyKey },
+					value,
+				)
+			).result;
 		};
+	}
+
+	/** Sets a value and returns the value encoded by the command. */
+	@validateArgs()
+	public async setValueWithEffectiveValue(
+		valueId: ValueIDProperties,
+		value: unknown,
+	): Promise<{ result: SupervisionResult | undefined; value: number }> {
+		const { property, propertyKey } = valueId;
+		if (property !== "setpoint") {
+			throwUnsupportedProperty(this.ccId, property);
+		}
+		if (typeof propertyKey !== "number") {
+			throw new ZWaveError(
+				`${
+					CommandClasses[this.ccId]
+				}: "${property}" must be further specified by a numeric property key`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		if (typeof value !== "number") {
+			throwWrongValueType(this.ccId, property, "number", typeof value);
+		}
+
+		// SDS14223: The Scale field value MUST be identical to the value received in the Thermostat Setpoint Report for the
+		// actual Setpoint Type during the node interview. Fall back to the first scale if none is known
+		const preferredScale = this.tryGetValueDB()?.getValue<number>(
+			ThermostatSetpointCCValues.setpointScale(propertyKey).endpoint(
+				this.endpoint.index,
+			),
+		);
+		const { result, value: effectiveValue } =
+			await this.setWithEffectiveValue(
+				propertyKey,
+				value,
+				preferredScale ?? 0,
+				true,
+			);
+
+		// Verify the current value after a delay, unless the command was supervised and successful
+		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+			// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
+			// aren't able to handle the GET this quickly.
+			this.schedulePoll({ property, propertyKey }, effectiveValue);
+		}
+
+		return { result, value: effectiveValue };
 	}
 
 	protected get [POLL_VALUE](): PollValueImplementation {
@@ -350,6 +318,16 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		value: number,
 		scale: number,
 	): Promise<SupervisionResult | undefined> {
+		return (await this.setWithEffectiveValue(setpointType, value, scale))
+			.result;
+	}
+
+	private async setWithEffectiveValue(
+		setpointType: ThermostatSetpointType,
+		value: number,
+		scale: number,
+		preventDeduplication = false,
+	): Promise<{ result: SupervisionResult | undefined; value: number }> {
 		this.assertSupportsCommand(
 			ThermostatSetpointCommand,
 			ThermostatSetpointCommand.Set,
@@ -361,9 +339,13 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 			setpointType,
 			value,
 			scale,
-			encodedValue: this.encodeSetpointValue(value, scale),
 		});
-		return this.host.sendCommand(cc, this.commandOptions);
+		// Value updates need this instance's serialized value
+		const options = preventDeduplication
+			? { ...this.commandOptions, preventDeduplication: true }
+			: this.commandOptions;
+		const result = await this.host.sendCommand(cc, options);
+		return { result, value: cc.value };
 	}
 
 	@validateArgs()
@@ -691,22 +673,19 @@ export interface ThermostatSetpointCCSetOptions {
 	setpointType: ThermostatSetpointType;
 	value: number;
 	scale: number;
-	/** @internal */
-	encodedValue?: Bytes;
 }
 
 @CCCommand(ThermostatSetpointCommand.Set)
 @useSupervision()
 export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
+	private encodedValue: Bytes | undefined;
+
 	public constructor(options: WithAddress<ThermostatSetpointCCSetOptions>) {
 		super(options);
 		this.setpointType = options.setpointType;
 		this.value = options.value;
 		this.scale = options.scale;
-		this.encodedValue = options.encodedValue;
 	}
-
-	private readonly encodedValue: Bytes | undefined;
 
 	public static from(
 		raw: CCRaw,
@@ -743,27 +722,37 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 	}
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
-		// If a config file overwrites how the float should be encoded, use that information
-		const override = ctx.getDeviceConfig?.(this.nodeId as number)?.compat
-			?.overrideFloatEncoding;
-		const observed = this.isSinglecast()
-			? ctx
-					.tryGetValueDB?.(this.nodeId)
-					?.getValue<SetpointFloatEncoding[]>(
-						ThermostatSetpointCCValues.observedFloatEncodings.id,
-					)
-			: undefined;
+		// Retries and S2 singlecast followups must reuse the original float encoding
+		if (!this.encodedValue) {
+			// If a config file overwrites how the float should be encoded, use that information
+			const override = ctx.getDeviceConfig?.(this.nodeId as number)
+				?.compat?.overrideFloatEncoding;
+			const observed = this.isSinglecast()
+				? ctx
+						.tryGetValueDB?.(this.nodeId)
+						?.getValue<SetpointFloatEncoding[]>(
+							ThermostatSetpointCCValues.observedFloatEncodings
+								.id,
+						)
+				: undefined;
+			const encoding =
+				override
+				?? findSetpointFloatEncoding(
+					this.value,
+					this.scale,
+					observed ?? [],
+				);
+			const encodedValue = encodeFloatWithScale(
+				this.value,
+				this.scale,
+				encoding,
+			);
+			this.value = parseFloatWithScale(encodedValue).value;
+			this.encodedValue = encodedValue;
+		}
 		this.payload = Bytes.concat([
 			[this.setpointType & 0b1111],
-			// Keep the prepared value stable while the command waits in the queue
-			this.encodedValue
-				?? (override
-					? encodeFloatWithScale(this.value, this.scale, override)
-					: encodeSetpointFloat(
-							this.value,
-							this.scale,
-							observed ?? [],
-						)),
+			this.encodedValue,
 		]);
 		return super.serialize(ctx);
 	}

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -9010,6 +9010,36 @@ export const ThermostatOperatingStateCCValues = Object.freeze({
 });
 
 export const ThermostatSetpointCCValues = Object.freeze({
+	observedFloatEncodings: {
+		id: {
+			commandClass: CommandClasses["Thermostat Setpoint"],
+			property: "observedFloatEncodings",
+		} as const,
+		endpoint: (_endpoint?: number) =>
+			({
+				commandClass: CommandClasses["Thermostat Setpoint"],
+				endpoint: 0, // no endpoint support!
+				property: "observedFloatEncodings",
+			}) as const,
+		is: (valueId: ValueID): boolean => {
+			return (
+				valueId.commandClass === CommandClasses["Thermostat Setpoint"]
+				&& valueId.property === "observedFloatEncodings"
+				&& valueId.propertyKey == undefined
+			);
+		},
+		get meta() {
+			return ValueMetadata.Any;
+		},
+		options: {
+			internal: true,
+			minVersion: 1,
+			secret: false,
+			stateful: true,
+			supportsEndpoints: false,
+			autoCreate: true,
+		} as const satisfies CCValueOptions,
+	},
 	supportedSetpointTypes: {
 		id: {
 			commandClass: CommandClasses["Thermostat Setpoint"],

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -81,6 +81,8 @@ export type SetValueImplementationHooks = AllOrNone<{
 	supervisionOnSuccess: () => void | Promise<void>;
 	supervisionOnFailure: () => void | Promise<void>;
 }> & {
+	/** Normalizes a requested value before sending and optimistic updates. */
+	normalizeValue?: (value: unknown) => unknown;
 	// Whether the value is a target value for a CC using split
 	// target/current values. If so, the value will be updated optimistically,
 	// even if the device class does not support optimistic updates.

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -81,8 +81,6 @@ export type SetValueImplementationHooks = AllOrNone<{
 	supervisionOnSuccess: () => void | Promise<void>;
 	supervisionOnFailure: () => void | Promise<void>;
 }> & {
-	/** Normalizes a requested value before sending and optimistic updates. */
-	normalizeValue?: (value: unknown) => unknown;
 	// Whether the value is a target value for a CC using split
 	// target/current values. If so, the value will be updated optimistically,
 	// even if the device class does not support optimistic updates.

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -81,6 +81,8 @@ export type SetValueImplementationHooks = AllOrNone<{
 	supervisionOnSuccess: () => void | Promise<void>;
 	supervisionOnFailure: () => void | Promise<void>;
 }> & {
+	/** Normalizes the value before sending and optimistic updates. */
+	normalizeValue?: (value: unknown) => unknown;
 	// Whether the value is a target value for a CC using split
 	// target/current values. If so, the value will be updated optimistically,
 	// even if the device class does not support optimistic updates.

--- a/packages/cc/src/lib/traits.ts
+++ b/packages/cc/src/lib/traits.ts
@@ -4,6 +4,7 @@ import type {
 	CommandClasses,
 	FrameType,
 	GetSupportedCCVersion,
+	GetValueDB,
 	HostIDs,
 	MaybeNotKnown,
 	SecurityClass,
@@ -160,7 +161,8 @@ export interface CCEncodingContext
 		Readonly<SecurityManagers>,
 		GetDeviceConfig,
 		HostIDs,
-		GetSupportedCCVersion {
+		GetSupportedCCVersion,
+		Partial<Pick<GetValueDB, "tryGetValueDB">> {
 	getHighestSecurityClass(nodeId: number): MaybeNotKnown<SecurityClass>;
 
 	hasSecurityClass(

--- a/packages/core/src/values/Primitive.test.ts
+++ b/packages/core/src/values/Primitive.test.ts
@@ -1,5 +1,5 @@
 import { Bytes } from "@zwave-js/shared";
-import { test } from "vitest";
+import { expect, test } from "vitest";
 
 import { ZWaveErrorCodes } from "../error/ZWaveError.js";
 import { assertZWaveError } from "../test/assertZWaveError.js";
@@ -218,6 +218,22 @@ test("encodeFloatWithScale() -> should fall back to sane options when the overri
 		);
 	}
 });
+
+test.each([
+	[40000, [3, 0, 0x9c, 0x40]],
+	[-40000, [3, 0xff, 0x63, 0xc0]],
+	[0x7fffff, [3, 0x7f, 0xff, 0xff]],
+	[-0x800000, [3, 0x80, 0, 0]],
+	[0x800000, [4, 0, 0x80, 0, 0]],
+	[-0x800001, [4, 0xff, 0x7f, 0xff, 0xff]],
+])(
+	"encodeFloatWithScale() -> uses three bytes for %i when it fits",
+	(value, expected) => {
+		expect(encodeFloatWithScale(value, 0, { size: 3 })).toEqual(
+			Bytes.from(expected),
+		);
+	},
+);
 
 test("encodeFloatWithScale() -> should throw when the value cannot be represented in 4 bytes", (t) => {
 	assertZWaveError(t.expect, () => encodeFloatWithScale(0xffffffff, 0), {

--- a/packages/core/src/values/Primitive.ts
+++ b/packages/core/src/values/Primitive.ts
@@ -232,6 +232,13 @@ export function encodeFloatWithScale(
 			`Cannot encode the value ${value} because its too large or too small to fit into 4 bytes`,
 			ZWaveErrorCodes.Arithmetic,
 		);
+	} else if (
+		override.size === 3
+		&& value >= IntegerLimits.Int24.min
+		&& value <= IntegerLimits.Int24.max
+	) {
+		// getMinIntegerSize skips three-byte integers
+		size = 3;
 	} else if (override.size != undefined && override.size > size) {
 		size = override.size;
 	}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -914,6 +914,7 @@ export class Driver
 	private getEncodingContext(): MessageEncodingContext & CCEncodingContext {
 		return {
 			...this.messageEncodingContext,
+			tryGetValueDB: (nodeId) => this.tryGetValueDB(nodeId),
 			ownNodeId: this.controller.ownNodeId!,
 			homeId: this.controller.homeId!,
 			nodeIdType: this._controller?.nodeIdType ?? NodeIDType.Short,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -76,6 +76,7 @@ import { SceneActivationCCSet } from "@zwave-js/cc/SceneActivationCC";
 import { Security2CCNonceGet } from "@zwave-js/cc/Security2CC";
 import { SecurityCCNonceGet } from "@zwave-js/cc/SecurityCC";
 import { ThermostatModeCCSet } from "@zwave-js/cc/ThermostatModeCC";
+import { ThermostatSetpointCCAPI } from "@zwave-js/cc/ThermostatSetpointCC";
 import {
 	UserCredentialCCAssociationReport,
 	UserCredentialCCCredentialLearnReport,
@@ -575,7 +576,6 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			};
 
 			const hooks = api.setValueHooks?.(valueIdProps, value, options);
-			if (hooks?.normalizeValue) value = hooks.normalizeValue(value);
 
 			if (hooks?.supervisionDelayedUpdates) {
 				api = api.withOptions({
@@ -604,12 +604,14 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			}
 
 			// And call it
-			const result = await api.setValue!.call(
-				api,
-				valueIdProps,
-				value,
-				options,
-			);
+			const setpointResult =
+				api instanceof ThermostatSetpointCCAPI
+					? await api.setValueWithEffectiveValue(valueIdProps, value)
+					: undefined;
+			const result = setpointResult
+				? setpointResult.result
+				: await api.setValue!.call(api, valueIdProps, value, options);
+			if (setpointResult) value = setpointResult.value;
 
 			if (loglevel === "silly") {
 				const header = `[setValue] result of SET_VALUE API call for ${api.constructor.name}:`;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -575,6 +575,7 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			};
 
 			const hooks = api.setValueHooks?.(valueIdProps, value, options);
+			if (hooks?.normalizeValue) value = hooks.normalizeValue(value);
 
 			if (hooks?.supervisionDelayedUpdates) {
 				api = api.withOptions({

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -76,7 +76,6 @@ import { SceneActivationCCSet } from "@zwave-js/cc/SceneActivationCC";
 import { Security2CCNonceGet } from "@zwave-js/cc/Security2CC";
 import { SecurityCCNonceGet } from "@zwave-js/cc/SecurityCC";
 import { ThermostatModeCCSet } from "@zwave-js/cc/ThermostatModeCC";
-import { ThermostatSetpointCCAPI } from "@zwave-js/cc/ThermostatSetpointCC";
 import {
 	UserCredentialCCAssociationReport,
 	UserCredentialCCCredentialLearnReport,
@@ -576,6 +575,7 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			};
 
 			const hooks = api.setValueHooks?.(valueIdProps, value, options);
+			if (hooks?.normalizeValue) value = hooks.normalizeValue(value);
 
 			if (hooks?.supervisionDelayedUpdates) {
 				api = api.withOptions({
@@ -604,14 +604,12 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			}
 
 			// And call it
-			const setpointResult =
-				api instanceof ThermostatSetpointCCAPI
-					? await api.setValueWithEffectiveValue(valueIdProps, value)
-					: undefined;
-			const result = setpointResult
-				? setpointResult.result
-				: await api.setValue!.call(api, valueIdProps, value, options);
-			if (setpointResult) value = setpointResult.value;
+			const result = await api.setValue!.call(
+				api,
+				valueIdProps,
+				value,
+				options,
+			);
 
 			if (loglevel === "silly") {
 				const header = `[setValue] result of SET_VALUE API call for ${api.constructor.name}:`;

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -7,7 +7,6 @@ import {
 	type ValueIDProperties,
 	supervisionResultToSetValueResult,
 } from "@zwave-js/cc";
-import { ThermostatSetpointCCAPI } from "@zwave-js/cc/ThermostatSetpointCC";
 import {
 	type Protocols,
 	SecurityClass,
@@ -163,6 +162,7 @@ export class VirtualNode extends VirtualEndpoint {
 			};
 
 			const hooks = api.setValueHooks?.(valueIdProps, value, options);
+			if (hooks?.normalizeValue) value = hooks.normalizeValue(value);
 
 			if (hooks?.supervisionDelayedUpdates) {
 				api = api.withOptions({
@@ -191,14 +191,12 @@ export class VirtualNode extends VirtualEndpoint {
 			}
 
 			// And call it
-			const setpointResult =
-				api instanceof ThermostatSetpointCCAPI
-					? await api.setValueWithEffectiveValue(valueIdProps, value)
-					: undefined;
-			const result = setpointResult
-				? setpointResult.result
-				: await api.setValue!.call(api, valueIdProps, value, options);
-			if (setpointResult) value = setpointResult.value;
+			const result = await api.setValue!.call(
+				api,
+				valueIdProps,
+				value,
+				options,
+			);
 
 			if (api.isSetValueOptimistic(valueId)) {
 				// If the call did not throw, assume that the call was successful and remember the new value

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -162,6 +162,7 @@ export class VirtualNode extends VirtualEndpoint {
 			};
 
 			const hooks = api.setValueHooks?.(valueIdProps, value, options);
+			if (hooks?.normalizeValue) value = hooks.normalizeValue(value);
 
 			if (hooks?.supervisionDelayedUpdates) {
 				api = api.withOptions({

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -7,6 +7,7 @@ import {
 	type ValueIDProperties,
 	supervisionResultToSetValueResult,
 } from "@zwave-js/cc";
+import { ThermostatSetpointCCAPI } from "@zwave-js/cc/ThermostatSetpointCC";
 import {
 	type Protocols,
 	SecurityClass,
@@ -162,7 +163,6 @@ export class VirtualNode extends VirtualEndpoint {
 			};
 
 			const hooks = api.setValueHooks?.(valueIdProps, value, options);
-			if (hooks?.normalizeValue) value = hooks.normalizeValue(value);
 
 			if (hooks?.supervisionDelayedUpdates) {
 				api = api.withOptions({
@@ -191,12 +191,14 @@ export class VirtualNode extends VirtualEndpoint {
 			}
 
 			// And call it
-			const result = await api.setValue!.call(
-				api,
-				valueIdProps,
-				value,
-				options,
-			);
+			const setpointResult =
+				api instanceof ThermostatSetpointCCAPI
+					? await api.setValueWithEffectiveValue(valueIdProps, value)
+					: undefined;
+			const result = setpointResult
+				? setpointResult.result
+				: await api.setValue!.call(api, valueIdProps, value, options);
+			if (setpointResult) value = setpointResult.value;
 
 			if (api.isSetValueOptimistic(valueId)) {
 				// If the call did not throw, assume that the call was successful and remember the new value

--- a/packages/zwave-js/src/lib/test/cc-specific/thermostatSetpointFloatEncoding.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/thermostatSetpointFloatEncoding.test.ts
@@ -612,7 +612,7 @@ integrationTest(
 );
 
 integrationTest(
-	"Thermostat Setpoint keeps a prepared setValue consistent when precision is learned before transmission",
+	"Thermostat Setpoint uses precision learned before transmission for the wire value and cache",
 	{
 		nodeCapabilities: {
 			commandClasses: [caps, CommandClasses.Supervision],
@@ -653,17 +653,16 @@ integrationTest(
 				});
 			t.onTestFinished(() => sendCommand.mockRestore());
 			await node.setValue(valueId, 21.55);
-			t.expect(lastSetBytes(controller).subarray(-6)).toEqual(
+			t.expect(lastSetBytes(controller).subarray(-5)).toEqual(
 				Bytes.from([
 					ccId,
 					ThermostatSetpointCommand.Set,
 					ThermostatSetpointType.Heating,
-					0x42,
-					8,
-					0x6b,
+					1,
+					22,
 				]),
 			);
-			t.expect(node.getValue(valueId)).toBe(21.55);
+			t.expect(node.getValue(valueId)).toBe(22);
 			await node.setValue(valueId, 21.55);
 			t.expect(lastSetBytes(controller).subarray(-5)).toEqual(
 				Bytes.from([
@@ -675,6 +674,50 @@ integrationTest(
 				]),
 			);
 			t.expect(node.getValue(valueId)).toBe(22);
+		},
+	},
+);
+
+integrationTest(
+	"Thermostat Setpoint concurrent identical writes retain their transmitted values",
+	{
+		nodeCapabilities: {
+			commandClasses: [caps, CommandClasses.Supervision],
+		},
+		customSetup: async (_driver, _controller, mockNode) => {
+			mockNode.defineBehavior(acceptSet);
+		},
+		testBody: async (t, _driver, node, controller) => {
+			const valueId = ThermostatSetpointCCValues.setpoint(
+				ThermostatSetpointType.Heating,
+			).id;
+			const updates: unknown[] = [];
+			node.on("value updated", (_node, args) => {
+				if (
+					args.commandClass === ccId
+					&& args.property === "setpoint"
+				) {
+					updates.push(args.newValue);
+				}
+			});
+			const results = await Promise.all([
+				node.setValue(valueId, 21.55),
+				node.setValue(valueId, 21.55),
+			]);
+			t.expect(results).toEqual([
+				t.expect.objectContaining({
+					status: SupervisionStatus.Success,
+				}),
+				t.expect.objectContaining({
+					status: SupervisionStatus.Success,
+				}),
+			]);
+			t.expect(lastSetBytes(controller).subarray(-2)).toEqual(
+				Bytes.from([1, 22]),
+			);
+			t.expect(node.getValue(valueId)).toBe(22);
+			t.expect(updates.length).toBeGreaterThan(0);
+			t.expect(updates.every((value) => value === 22)).toBe(true);
 		},
 	},
 );
@@ -770,6 +813,81 @@ for (const disableOptimisticValueUpdate of [false, true]) {
 		},
 	);
 }
+
+multiNodeTest(
+	"Thermostat Setpoint multicast and reused singlecast followups send identical float bytes",
+	{
+		controllerCapabilities: {
+			supportedFunctionTypes: getDefaultSupportedFunctionTypes().filter(
+				(type) =>
+					type !== FunctionType.SendDataBridge
+					&& type !== FunctionType.SendDataMulticastBridge,
+			),
+		},
+		nodeCapabilities: [2, 3].map((id) => ({
+			id,
+			capabilities: {
+				commandClasses: [caps],
+			},
+		})),
+		customSetup: async (_driver, _controller, mockNodes) => {
+			for (const mockNode of mockNodes) {
+				mockNode.defineBehavior({
+					handleCC: (_controller, self, cc) => {
+						if (cc instanceof ThermostatSetpointCCSet) {
+							const values = self.state.get(
+								"receivedSetpoints",
+							) as number[] | undefined;
+							self.state.set("receivedSetpoints", [
+								...(values ?? []),
+								cc.value,
+							]);
+							return { action: "ok" };
+						}
+					},
+				});
+			}
+		},
+		testBody: async (t, driver, nodes, controller, mockNodes) => {
+			nodes[0].valueDB.setValue(observedId, [
+				{ precision: 0, size: 1, scale: 0 },
+			]);
+			nodes[1].valueDB.setValue(observedId, [
+				{ precision: 2, size: 4, scale: 0 },
+			]);
+			const cc = new ThermostatSetpointCCSet({
+				nodeId: [2, 3],
+				setpointType: ThermostatSetpointType.Heating,
+				value: 21.55,
+				scale: 0,
+			});
+			await driver.sendCommand(cc);
+			const multicast = lastSetBytes(controller);
+			// S2 followups reuse the command instance with each recipient's node ID
+			for (const node of nodes) {
+				cc.nodeId = node.id;
+				await driver.sendCommand(cc);
+				t.expect(lastSetBytes(controller)).toEqual(multicast);
+				t.expect(cc.value).toBe(21.55);
+			}
+			for (const mockNode of mockNodes) {
+				await t.expect
+					.poll(() => mockNode.state.get("receivedSetpoints"))
+					.toEqual([21.55, 21.55]);
+				const values = mockNode.state.get(
+					"receivedSetpoints",
+				) as number[];
+				t.expect(values.every((value) => value === 21.55)).toBe(true);
+				mockNode.assertReceivedControllerFrame(
+					(frame) =>
+						frame.type === MockZWaveFrameType.Request
+						&& frame.payload instanceof ThermostatSetpointCCSet
+						&& frame.payload.value === 21.55,
+				);
+			}
+		},
+	},
+);
 
 multiNodeTest(
 	"Thermostat Setpoint multicast keeps automatic encoding with learned bounds",

--- a/packages/zwave-js/src/lib/test/cc-specific/thermostatSetpointFloatEncoding.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/thermostatSetpointFloatEncoding.test.ts
@@ -612,7 +612,7 @@ integrationTest(
 );
 
 integrationTest(
-	"Thermostat Setpoint uses precision learned before transmission for the wire value and cache",
+	"Thermostat Setpoint keeps queued commands consistent and applies newly learned precision to later sends",
 	{
 		nodeCapabilities: {
 			commandClasses: [caps, CommandClasses.Supervision],
@@ -653,16 +653,17 @@ integrationTest(
 				});
 			t.onTestFinished(() => sendCommand.mockRestore());
 			await node.setValue(valueId, 21.55);
-			t.expect(lastSetBytes(controller).subarray(-5)).toEqual(
+			t.expect(lastSetBytes(controller).subarray(-6)).toEqual(
 				Bytes.from([
 					ccId,
 					ThermostatSetpointCommand.Set,
 					ThermostatSetpointType.Heating,
-					1,
-					22,
+					0x42,
+					8,
+					0x6b,
 				]),
 			);
-			t.expect(node.getValue(valueId)).toBe(22);
+			t.expect(node.getValue(valueId)).toBe(21.55);
 			await node.setValue(valueId, 21.55);
 			t.expect(lastSetBytes(controller).subarray(-5)).toEqual(
 				Bytes.from([

--- a/packages/zwave-js/src/lib/test/cc-specific/thermostatSetpointFloatEncoding.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/thermostatSetpointFloatEncoding.test.ts
@@ -1,0 +1,839 @@
+import {
+	CommandClass,
+	ThermostatSetpointCommand,
+	ThermostatSetpointType,
+} from "@zwave-js/cc";
+import { MultiChannelCCCommandEncapsulation } from "@zwave-js/cc/MultiChannelCC";
+import {
+	ThermostatSetpointCCCapabilitiesGet,
+	ThermostatSetpointCCSet,
+	ThermostatSetpointCCSupportedGet,
+	ThermostatSetpointCCValues,
+} from "@zwave-js/cc/ThermostatSetpointCC";
+import {
+	CommandClasses,
+	SupervisionStatus,
+	encodeFloatWithScale,
+	parseFloatWithScale,
+} from "@zwave-js/core";
+import { FunctionType } from "@zwave-js/serial";
+import {
+	SendDataBridgeRequest,
+	SendDataMulticastBridgeRequest,
+	SendDataMulticastRequest,
+	SendDataRequest,
+} from "@zwave-js/serial/serialapi";
+import { Bytes } from "@zwave-js/shared";
+import {
+	type MockController,
+	type MockNode,
+	type MockNodeBehavior,
+	MockZWaveFrameType,
+	ccCaps,
+	createMockZWaveRequestFrame,
+	getDefaultSupportedFunctionTypes,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { expect, vi } from "vitest";
+
+import { integrationTest } from "../integrationTestSuite.js";
+import { integrationTest as multiNodeTest } from "../integrationTestSuiteMulti.js";
+
+const ccId = CommandClasses["Thermostat Setpoint"];
+const observedId = ThermostatSetpointCCValues.observedFloatEncodings.id;
+const caps = ccCaps({
+	ccId,
+	isSupported: true,
+	version: 3,
+	setpoints: {
+		[ThermostatSetpointType.Heating]: {
+			minValue: 0,
+			maxValue: 100,
+			scale: "°C",
+		},
+	},
+});
+const acceptSet: MockNodeBehavior = {
+	handleCC: (_controller, _node, cc) => {
+		if (cc instanceof ThermostatSetpointCCSet) return { action: "ok" };
+	},
+};
+
+interface Encoding {
+	precision: number;
+	size: number;
+	scale: number;
+}
+
+function float(encoding: Encoding, integer = 0): Bytes {
+	const ret = new Bytes(encoding.size + 1);
+	ret[0] = (encoding.precision << 5) | (encoding.scale << 3) | encoding.size;
+	ret.writeIntBE(integer, 1, encoding.size);
+	return ret;
+}
+
+async function sendReport(
+	mockNode: MockNode,
+	mockController: MockController,
+	command: ThermostatSetpointCommand,
+	payload: Bytes,
+	endpoint = 0,
+) {
+	let cc = new CommandClass({
+		nodeId: mockController.ownNodeId,
+		ccId,
+		ccCommand: command,
+		payload,
+	});
+	if (endpoint) {
+		cc = new MultiChannelCCCommandEncapsulation({
+			nodeId: mockController.ownNodeId,
+			endpointIndex: endpoint,
+			destination: 0,
+			encapsulated: cc,
+		});
+	}
+	await mockNode.sendToController(createMockZWaveRequestFrame(cc));
+}
+
+function lastSetBytes(controller: MockController): Bytes {
+	const request = controller.receivedHostMessages.findLast(
+		(message) =>
+			message instanceof SendDataRequest
+			|| message instanceof SendDataBridgeRequest
+			|| message instanceof SendDataMulticastRequest
+			|| message instanceof SendDataMulticastBridgeRequest,
+	);
+	expect(request).toBeDefined();
+	return Bytes.view((request as SendDataRequest).serializedCC!);
+}
+
+const encodingCases: {
+	name: string;
+	observed: Encoding[];
+	value: number;
+	scale?: number;
+	expected: number[];
+}[] = [
+	{
+		name: "unknown bounds use automatic encoding",
+		observed: [],
+		value: 21.55,
+		expected: [0x42, 8, 0x6b],
+	},
+	{
+		name: "minimum precision pads whole numbers",
+		observed: [{ precision: 1, size: 2, scale: 0 }],
+		value: 21,
+		expected: [0x22, 0, 210],
+	},
+	{
+		name: "maximum precision rounds positive values",
+		observed: [{ precision: 1, size: 2, scale: 0 }],
+		value: 21.26,
+		expected: [0x22, 0, 213],
+	},
+	{
+		name: "maximum precision rounds negative values",
+		observed: [{ precision: 1, size: 2, scale: 0 }],
+		value: -21.26,
+		expected: [0x22, 0xff, 0x2b],
+	},
+	{
+		name: "four-byte padding is preserved",
+		observed: [{ precision: 2, size: 4, scale: 0 }],
+		value: 21,
+		expected: [0x44, 0, 0, 8, 0x34],
+	},
+	{
+		name: "three-byte sizes are preserved",
+		observed: [{ precision: 0, size: 3, scale: 0 }],
+		value: 40000,
+		expected: [3, 0, 0x9c, 0x40],
+	},
+	{
+		name: "precision gaps reuse a reported combination",
+		observed: [
+			{ precision: 0, size: 1, scale: 0 },
+			{ precision: 2, size: 4, scale: 0 },
+		],
+		value: 21.5,
+		expected: [0x44, 0, 0, 8, 0x66],
+	},
+	{
+		name: "a fitting lower precision handles overflow",
+		observed: [
+			{ precision: 2, size: 1, scale: 0 },
+			{ precision: 0, size: 2, scale: 0 },
+		],
+		value: 21.5,
+		expected: [2, 0, 22],
+	},
+	{
+		name: "only matching scale combinations are used",
+		observed: [
+			{ precision: 0, size: 1, scale: 0 },
+			{ precision: 2, size: 2, scale: 1 },
+		],
+		value: 21.55,
+		scale: 1,
+		expected: [0x4a, 8, 0x6b],
+	},
+	{
+		name: "an unknown scale uses automatic encoding",
+		observed: [{ precision: 0, size: 1, scale: 1 }],
+		value: 21.55,
+		expected: [0x42, 8, 0x6b],
+	},
+	{
+		name: "seven-digit precision rounds within four bytes",
+		observed: [{ precision: 7, size: 4, scale: 0 }],
+		value: 21.12345678,
+		expected: [0xe4, 0x0c, 0x97, 0x2f, 8],
+	},
+	{
+		name: "the smallest exact observed combination is selected",
+		observed: [
+			{ precision: 0, size: 1, scale: 0 },
+			{ precision: 2, size: 4, scale: 0 },
+		],
+		value: 21,
+		expected: [1, 21],
+	},
+	{
+		name: "the signed minimum is representable",
+		observed: [{ precision: 0, size: 1, scale: 0 }],
+		value: -128,
+		expected: [1, 128],
+	},
+	{
+		name: "the signed maximum is representable",
+		observed: [{ precision: 0, size: 1, scale: 0 }],
+		value: 127,
+		expected: [1, 127],
+	},
+];
+
+for (const { name, observed, value, scale = 0, expected } of encodingCases) {
+	integrationTest(`Thermostat Setpoint: ${name}`, {
+		nodeCapabilities: { commandClasses: [caps] },
+		customSetup: async (_driver, _controller, mockNode) => {
+			mockNode.defineBehavior(acceptSet);
+		},
+		testBody: async (t, _driver, node, controller, mockNode) => {
+			node.valueDB.removeValue(observedId);
+			t.expect(node.getValue(observedId)).toBeUndefined();
+			for (const encoding of observed) {
+				await sendReport(
+					mockNode,
+					controller,
+					ThermostatSetpointCommand.Report,
+					Bytes.concat([
+						[ThermostatSetpointType.Heating],
+						float(encoding),
+					]),
+				);
+			}
+			if (observed.length) {
+				await t.expect
+					.poll(() => node.getValue(observedId))
+					.toEqual(observed);
+			}
+			await node.commandClasses["Thermostat Setpoint"].set(
+				ThermostatSetpointType.Cooling,
+				value,
+				scale,
+			);
+			t.expect(lastSetBytes(controller)).toEqual(
+				Bytes.from([
+					ccId,
+					ThermostatSetpointCommand.Set,
+					ThermostatSetpointType.Cooling,
+					...expected,
+				]),
+			);
+		},
+	});
+}
+
+integrationTest(
+	"Thermostat Setpoint learns new precision without reinterview and retains it in the disk cache",
+	{
+		nodeCapabilities: { commandClasses: [caps] },
+		customSetup: async (_driver, _controller, mockNode) => {
+			mockNode.defineBehavior(acceptSet);
+		},
+		testBody: async (t, driver, node, controller, mockNode) => {
+			node.valueDB.removeValue(observedId);
+			const api = node.commandClasses["Thermostat Setpoint"];
+			await api.set(ThermostatSetpointType.Heating, 21.55, 0);
+			t.expect(lastSetBytes(controller).subarray(3)).toEqual(
+				encodeFloatWithScale(21.55, 0),
+			);
+
+			const integer = { precision: 0, size: 1, scale: 0 };
+			await sendReport(
+				mockNode,
+				controller,
+				ThermostatSetpointCommand.Report,
+				Bytes.concat([
+					[ThermostatSetpointType.Heating],
+					float(integer),
+				]),
+			);
+			await t.expect
+				.poll(() => node.getValue(observedId))
+				.toEqual([integer]);
+			await api.set(ThermostatSetpointType.Cooling, 21.55, 0);
+			t.expect(lastSetBytes(controller).subarray(3)).toEqual(
+				Bytes.from([1, 22]),
+			);
+
+			const precise = { precision: 2, size: 2, scale: 0 };
+			await sendReport(
+				mockNode,
+				controller,
+				ThermostatSetpointCommand.CapabilitiesReport,
+				Bytes.concat([
+					[ThermostatSetpointType.Cooling],
+					float(integer),
+					float(precise, 3000),
+				]),
+			);
+			await t.expect
+				.poll(() => node.getValue(observedId))
+				.toEqual([integer, precise]);
+			await api.set(ThermostatSetpointType.Heating, 21.55, 0);
+			t.expect(lastSetBytes(controller).subarray(3)).toEqual(
+				Bytes.from([0x42, 8, 0x6b]),
+			);
+
+			await driver.valueDB!.close();
+			await driver.valueDB!.open();
+			t.expect(node.getValue(observedId)).toEqual([integer, precise]);
+			await api.set(ThermostatSetpointType.Cooling, 21.55, 0);
+			t.expect(lastSetBytes(controller).subarray(3)).toEqual(
+				Bytes.from([0x42, 8, 0x6b]),
+			);
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& (frame.payload
+						instanceof ThermostatSetpointCCSupportedGet
+						|| frame.payload
+							instanceof ThermostatSetpointCCCapabilitiesGet),
+				{ noMatch: true },
+			);
+		},
+	},
+);
+
+integrationTest(
+	"Thermostat Setpoint shares capability encodings across endpoints and ignores N/A reports",
+	{
+		nodeCapabilities: {
+			commandClasses: [CommandClasses["Multi Channel"], caps],
+			endpoints: [{ commandClasses: [caps] }, { commandClasses: [caps] }],
+		},
+		customSetup: async (_driver, _controller, mockNode) => {
+			mockNode.defineBehavior(acceptSet);
+		},
+		testBody: async (t, _driver, node, controller, mockNode) => {
+			node.valueDB.removeValue(observedId);
+			for (const command of [
+				ThermostatSetpointCommand.Report,
+				ThermostatSetpointCommand.CapabilitiesReport,
+			]) {
+				await sendReport(
+					mockNode,
+					controller,
+					command,
+					Bytes.from([0]),
+					1,
+				);
+			}
+			await wait(100);
+			t.expect(node.getValue(observedId)).toBeUndefined();
+			const min = { precision: 1, size: 2, scale: 0 };
+			const max = { precision: 2, size: 4, scale: 1 };
+			await sendReport(
+				mockNode,
+				controller,
+				ThermostatSetpointCommand.Report,
+				Bytes.concat([
+					[ThermostatSetpointType.Heating],
+					float(min, 210),
+				]),
+				1,
+			);
+			await t.expect.poll(() => node.getValue(observedId)).toEqual([min]);
+			await node
+				.getEndpointOrThrow(2)
+				.commandClasses["Thermostat Setpoint"].set(
+					ThermostatSetpointType.Cooling,
+					21.55,
+					0,
+				);
+			t.expect(lastSetBytes(controller).subarray(-6)).toEqual(
+				Bytes.from([
+					ccId,
+					ThermostatSetpointCommand.Set,
+					ThermostatSetpointType.Cooling,
+					0x22,
+					0,
+					216,
+				]),
+			);
+			await sendReport(
+				mockNode,
+				controller,
+				ThermostatSetpointCommand.CapabilitiesReport,
+				Bytes.concat([
+					[ThermostatSetpointType.Heating],
+					float(min, 50),
+					float(max, 9000),
+				]),
+				1,
+			);
+			await t.expect
+				.poll(() => node.getValue(observedId))
+				.toEqual([min, max]);
+			await node
+				.getEndpointOrThrow(2)
+				.commandClasses["Thermostat Setpoint"].set(
+					ThermostatSetpointType.Cooling,
+					21.55,
+					1,
+				);
+			t.expect(lastSetBytes(controller).subarray(-8)).toEqual(
+				Bytes.from([
+					ccId,
+					ThermostatSetpointCommand.Set,
+					ThermostatSetpointType.Cooling,
+					0x4c,
+					0,
+					0,
+					8,
+					0x6b,
+				]),
+			);
+			t.expect(
+				node.valueDB
+					.getValues(ccId)
+					.filter((value) => value.property === observedId.property)
+					.map((value) => value.endpoint),
+			).toEqual([0]);
+			for (const command of [
+				ThermostatSetpointCommand.Report,
+				ThermostatSetpointCommand.CapabilitiesReport,
+			]) {
+				await sendReport(
+					mockNode,
+					controller,
+					command,
+					Bytes.from([0]),
+					2,
+				);
+			}
+			await wait(100);
+			t.expect(node.getValue(observedId)).toEqual([min, max]);
+		},
+	},
+);
+
+for (const override of [
+	{ precision: 0 },
+	{ precision: 3 },
+	{ size: 4 },
+	{ precision: 2, size: 2 },
+]) {
+	integrationTest(
+		`Thermostat Setpoint override ${JSON.stringify(override)} wins before and after learning`,
+		{
+			nodeCapabilities: { commandClasses: [caps] },
+			customSetup: async (_driver, _controller, mockNode) => {
+				mockNode.defineBehavior(acceptSet);
+			},
+			testBody: async (t, _driver, node, controller, mockNode) => {
+				node.valueDB.removeValue(observedId);
+				const config = vi
+					.spyOn(node, "deviceConfig", "get")
+					.mockReturnValue({
+						compat: { overrideFloatEncoding: override },
+					} as NonNullable<typeof node.deviceConfig>);
+				t.onTestFinished(() => config.mockRestore());
+				for (const learned of [false, true]) {
+					if (learned) {
+						const encoding = { precision: 0, size: 1, scale: 0 };
+						await sendReport(
+							mockNode,
+							controller,
+							ThermostatSetpointCommand.Report,
+							Bytes.concat([
+								[ThermostatSetpointType.Heating],
+								float(encoding),
+							]),
+						);
+						await t.expect
+							.poll(() => node.getValue(observedId))
+							.toEqual([encoding]);
+					}
+					const valueId = ThermostatSetpointCCValues.setpoint(
+						ThermostatSetpointType.Heating,
+					).id;
+					await node.setValue(valueId, 21.55);
+					t.expect(lastSetBytes(controller).subarray(3)).toEqual(
+						encodeFloatWithScale(21.55, 0, override),
+					);
+					t.expect(node.getValue(valueId)).toBe(
+						parseFloatWithScale(
+							encodeFloatWithScale(21.55, 0, override),
+						).value,
+					);
+				}
+			},
+		},
+	);
+}
+
+integrationTest(
+	"Thermostat Setpoint rejects overflow and recovers after learning a wider size",
+	{
+		nodeCapabilities: { commandClasses: [caps] },
+		customSetup: async (_driver, _controller, mockNode) => {
+			mockNode.defineBehavior(acceptSet);
+		},
+		testBody: async (t, _driver, node, controller, mockNode) => {
+			const small = { precision: 0, size: 1, scale: 0 };
+			t.expect(node.getValue(observedId)).toEqual([small]);
+			const api = node.commandClasses["Thermostat Setpoint"];
+			for (const value of [128, -129, 127.5]) {
+				await t
+					.expect(api.set(ThermostatSetpointType.Heating, value, 0))
+					.rejects.toThrow("any observed float encoding");
+			}
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof ThermostatSetpointCCSet,
+				{ noMatch: true },
+			);
+			const large = { precision: 0, size: 2, scale: 0 };
+			await sendReport(
+				mockNode,
+				controller,
+				ThermostatSetpointCommand.Report,
+				Bytes.concat([
+					[ThermostatSetpointType.Heating],
+					float(large, 128),
+				]),
+			);
+			await t.expect
+				.poll(() => node.getValue(observedId))
+				.toEqual([small, large]);
+			await api.set(ThermostatSetpointType.Heating, 128, 0);
+			t.expect(lastSetBytes(controller).subarray(3)).toEqual(
+				Bytes.from([2, 0, 128]),
+			);
+		},
+	},
+);
+
+integrationTest(
+	"Thermostat Setpoint supervised setValue caches the transmitted rounded value",
+	{
+		nodeCapabilities: {
+			commandClasses: [caps, CommandClasses.Supervision],
+		},
+		additionalDriverOptions: { disableOptimisticValueUpdate: true },
+		customSetup: async (_driver, _controller, mockNode) => {
+			mockNode.defineBehavior(acceptSet);
+		},
+		testBody: async (t, _driver, node, controller, mockNode) => {
+			const valueId = ThermostatSetpointCCValues.setpoint(
+				ThermostatSetpointType.Heating,
+			).id;
+			const updates: unknown[] = [];
+			node.on("value updated", (_node, args) => {
+				if (
+					args.commandClass === ccId
+					&& args.property === "setpoint"
+				) {
+					updates.push(args.newValue);
+				}
+			});
+			const result = await node.setValue(valueId, 21.55);
+			t.expect(result).toMatchObject({
+				status: SupervisionStatus.Success,
+			});
+			t.expect(lastSetBytes(controller).subarray(-5)).toEqual(
+				Bytes.from([
+					ccId,
+					ThermostatSetpointCommand.Set,
+					ThermostatSetpointType.Heating,
+					1,
+					22,
+				]),
+			);
+			t.expect(node.getValue(valueId)).toBe(22);
+			t.expect(updates).toEqual([22]);
+			t.expect(node.hasScheduledPolls()).toBe(false);
+
+			const precise = { precision: 2, size: 2, scale: 0 };
+			await sendReport(
+				mockNode,
+				controller,
+				ThermostatSetpointCommand.CapabilitiesReport,
+				Bytes.concat([
+					[ThermostatSetpointType.Heating],
+					float(precise),
+					float(precise, 3000),
+				]),
+			);
+			await t.expect
+				.poll(() => node.getValue<unknown[]>(observedId)?.length)
+				.toBe(2);
+			await node.setValue(valueId, 21.55);
+			t.expect(lastSetBytes(controller).subarray(-6)).toEqual(
+				Bytes.from([
+					ccId,
+					ThermostatSetpointCommand.Set,
+					ThermostatSetpointType.Heating,
+					0x42,
+					8,
+					0x6b,
+				]),
+			);
+			t.expect(node.getValue(valueId)).toBe(21.55);
+			t.expect(updates).toEqual([22, 21.55]);
+			t.expect(node.hasScheduledPolls()).toBe(false);
+		},
+	},
+);
+
+integrationTest(
+	"Thermostat Setpoint keeps a prepared setValue consistent when precision is learned before transmission",
+	{
+		nodeCapabilities: {
+			commandClasses: [caps, CommandClasses.Supervision],
+		},
+		customSetup: async (_driver, _controller, mockNode) => {
+			mockNode.defineBehavior(acceptSet);
+		},
+		testBody: async (t, driver, node, controller, mockNode) => {
+			node.valueDB.removeValue(observedId);
+			const valueId = ThermostatSetpointCCValues.setpoint(
+				ThermostatSetpointType.Heating,
+			).id;
+			const originalSendCommand = driver.sendCommand.bind(driver);
+			let reportSent = false;
+			const sendCommand = vi
+				.spyOn(driver, "sendCommand")
+				.mockImplementation(async (command, options) => {
+					if (
+						command instanceof ThermostatSetpointCCSet
+						&& !reportSent
+					) {
+						reportSent = true;
+						const integer = { precision: 0, size: 1, scale: 0 };
+						await sendReport(
+							mockNode,
+							controller,
+							ThermostatSetpointCommand.Report,
+							Bytes.concat([
+								[ThermostatSetpointType.Heating],
+								float(integer),
+							]),
+						);
+						await t.expect
+							.poll(() => node.getValue(observedId))
+							.toEqual([integer]);
+					}
+					return originalSendCommand(command, options);
+				});
+			t.onTestFinished(() => sendCommand.mockRestore());
+			await node.setValue(valueId, 21.55);
+			t.expect(lastSetBytes(controller).subarray(-6)).toEqual(
+				Bytes.from([
+					ccId,
+					ThermostatSetpointCommand.Set,
+					ThermostatSetpointType.Heating,
+					0x42,
+					8,
+					0x6b,
+				]),
+			);
+			t.expect(node.getValue(valueId)).toBe(21.55);
+			await node.setValue(valueId, 21.55);
+			t.expect(lastSetBytes(controller).subarray(-5)).toEqual(
+				Bytes.from([
+					ccId,
+					ThermostatSetpointCommand.Set,
+					ThermostatSetpointType.Heating,
+					1,
+					22,
+				]),
+			);
+			t.expect(node.getValue(valueId)).toBe(22);
+		},
+	},
+);
+
+for (const disableOptimisticValueUpdate of [false, true]) {
+	integrationTest(
+		`Thermostat Setpoint unsupervised setValue verifies the rounded value with optimistic updates ${!disableOptimisticValueUpdate}`,
+		{
+			nodeCapabilities: { commandClasses: [caps] },
+			additionalDriverOptions: {
+				disableOptimisticValueUpdate,
+				timeouts: { refreshValue: 60_000 },
+			},
+			customSetup: async (_driver, _controller, mockNode) => {
+				mockNode.defineBehavior(acceptSet);
+			},
+			testBody: async (t, driver, node, controller, mockNode) => {
+				const valueId = ThermostatSetpointCCValues.setpoint(
+					ThermostatSetpointType.Heating,
+				).id;
+				const schedulePoll = vi.spyOn(driver, "schedulePoll");
+				t.onTestFinished(() => schedulePoll.mockRestore());
+				await node.setValue(valueId, 21.55);
+				t.expect(lastSetBytes(controller).subarray(3)).toEqual(
+					Bytes.from([1, 22]),
+				);
+				t.expect(node.getValue(valueId)).toBe(
+					disableOptimisticValueUpdate ? 0 : 22,
+				);
+				t.expect(schedulePoll).toHaveBeenLastCalledWith(
+					node.id,
+					t.expect.objectContaining({
+						property: "setpoint",
+						propertyKey: ThermostatSetpointType.Heating,
+					}),
+					t.expect.objectContaining({ expectedValue: 22 }),
+				);
+				t.expect(node.hasScheduledPolls()).toBe(true);
+				const integer = { precision: 0, size: 1, scale: 0 };
+				await sendReport(
+					mockNode,
+					controller,
+					ThermostatSetpointCommand.Report,
+					Bytes.concat([
+						[ThermostatSetpointType.Heating],
+						float(integer, 21),
+					]),
+				);
+				await t.expect.poll(() => node.getValue(valueId)).toBe(21);
+				t.expect(node.hasScheduledPolls()).toBe(true);
+				await sendReport(
+					mockNode,
+					controller,
+					ThermostatSetpointCommand.Report,
+					Bytes.concat([
+						[ThermostatSetpointType.Heating],
+						float(integer, 22),
+					]),
+				);
+				await t.expect.poll(() => node.hasScheduledPolls()).toBe(false);
+				t.expect(node.getValue(valueId)).toBe(22);
+
+				const precise = { precision: 2, size: 2, scale: 0 };
+				await sendReport(
+					mockNode,
+					controller,
+					ThermostatSetpointCommand.CapabilitiesReport,
+					Bytes.concat([
+						[ThermostatSetpointType.Heating],
+						float(precise),
+						float(precise, 3000),
+					]),
+				);
+				await t.expect
+					.poll(() => node.getValue<unknown[]>(observedId)?.length)
+					.toBe(2);
+				await node.setValue(valueId, 21.55);
+				t.expect(lastSetBytes(controller).subarray(3)).toEqual(
+					Bytes.from([0x42, 8, 0x6b]),
+				);
+				t.expect(node.getValue(valueId)).toBe(
+					disableOptimisticValueUpdate ? 22 : 21.55,
+				);
+				t.expect(schedulePoll).toHaveBeenLastCalledWith(
+					node.id,
+					t.expect.objectContaining({
+						property: "setpoint",
+						propertyKey: ThermostatSetpointType.Heating,
+					}),
+					t.expect.objectContaining({ expectedValue: 21.55 }),
+				);
+			},
+		},
+	);
+}
+
+multiNodeTest(
+	"Thermostat Setpoint multicast keeps automatic encoding with learned bounds",
+	{
+		controllerCapabilities: {
+			supportedFunctionTypes: getDefaultSupportedFunctionTypes().filter(
+				(type) =>
+					type !== FunctionType.SendDataBridge
+					&& type !== FunctionType.SendDataMulticastBridge,
+			),
+		},
+		nodeCapabilities: [
+			{ id: 2, capabilities: { commandClasses: [caps] } },
+			{ id: 3, capabilities: { commandClasses: [caps] } },
+		],
+		customSetup: async (_driver, _controller, mockNodes) => {
+			for (const mockNode of mockNodes)
+				mockNode.defineBehavior(acceptSet);
+		},
+		testBody: async (t, driver, nodes, controller, mockNodes) => {
+			const encoding = { precision: 0, size: 1, scale: 0 };
+			for (let i = 0; i < nodes.length; i++) {
+				nodes[i].valueDB.removeValue(observedId);
+				await sendReport(
+					mockNodes[i],
+					controller,
+					ThermostatSetpointCommand.Report,
+					Bytes.concat([
+						[ThermostatSetpointType.Heating],
+						float(encoding),
+					]),
+				);
+				await t.expect
+					.poll(() => nodes[i].getValue(observedId))
+					.toEqual([encoding]);
+			}
+			await driver.controller
+				.getMulticastGroup([2, 3])
+				.setValue(
+					ThermostatSetpointCCValues.setpoint(
+						ThermostatSetpointType.Heating,
+					).id,
+					21.55,
+				);
+			t.expect(lastSetBytes(controller).subarray(3)).toEqual(
+				encodeFloatWithScale(21.55, 0),
+			);
+			for (const node of nodes) {
+				t.expect(
+					node.getValue(
+						ThermostatSetpointCCValues.setpoint(
+							ThermostatSetpointType.Heating,
+						).id,
+					),
+				).toBe(21.55);
+			}
+			for (const mockNode of mockNodes) {
+				mockNode.assertReceivedControllerFrame(
+					(frame) =>
+						frame.type === MockZWaveFrameType.Request
+						&& frame.payload instanceof ThermostatSetpointCCSet
+						&& frame.payload.value === 21.55,
+				);
+			}
+		},
+	},
+);


### PR DESCRIPTION
Learn precision, scale, and size combinations from Thermostat Setpoint Reports and both bounds in Capabilities Reports. Store observations globally per device across endpoints and setpoint types.

Set commands reuse an observed combination for the requested scale and round values when necessary. Explicit `overrideFloatEncoding` settings retain priority. Unknown encodings preserve the existing automatic encoding behavior. Later reports populate and update the cache without a re-interview.

Keep rounded values consistent in optimistic updates and verification polls. Preserve the selected encoding while commands wait for transmission.

Add unit and integration coverage for interview and unsolicited reports, empty caches, cache persistence, shared device-wide observations, scale matching, rounding, byte sizes, overflow recovery, overrides, N/A reports, multicast, supervised updates, verification polls, and queued commands.

This aligns us with behavior of several devices, as well as the specs.