### PR TITLE
feat(cc): implement missing command parsing and serialization

### DIFF
--- a/packages/cc/src/cc/AlarmSensorCC.test.ts
+++ b/packages/cc/src/cc/AlarmSensorCC.test.ts
@@ -1,0 +1,107 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { AlarmSensorCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	AlarmSensorCCGet,
+	AlarmSensorCCReport,
+	AlarmSensorCCSupportedReport,
+} from "./AlarmSensorCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: () => {},
+};
+
+test.each([
+	{ state: false, severity: undefined, value: 0 },
+	{ state: true, severity: undefined, value: 255 },
+	{ state: true, severity: 50, value: 50 },
+])("Alarm report encodes state $value", async ({ state, severity, value }) => {
+	const cc = new AlarmSensorCCReport({
+		nodeId: 2,
+		sensorType: 1,
+		state,
+		severity,
+		duration: 300,
+	});
+	const bytes = await cc.serialize(ctx);
+	expect(bytes).toEqual(
+		Bytes.from([
+			CommandClasses["Alarm Sensor"],
+			AlarmSensorCommand.Report,
+			0,
+			1,
+			value,
+			1,
+			44,
+		]),
+	);
+	expect(AlarmSensorCCReport.from(CCRaw.parse(bytes), ctx)).toMatchObject({
+		state,
+		severity,
+		duration: 300,
+	});
+});
+
+test("Alarm capabilities round trip zero-based sensor types", async () => {
+	const cc = new AlarmSensorCCSupportedReport({
+		nodeId: 2,
+		supportedSensorTypes: [0, 3],
+	});
+	const bytes = await cc.serialize(ctx);
+	expect(bytes.subarray(2)).toEqual(Bytes.from([1, 9]));
+	expect(
+		AlarmSensorCCSupportedReport.from(CCRaw.parse(bytes), ctx)
+			.supportedSensorTypes,
+	).toEqual([0, 3]);
+});
+
+test("Alarm Get parses the any-sensor sentinel", async () => {
+	const cc = new AlarmSensorCCGet({ nodeId: 2 });
+	expect(
+		AlarmSensorCCGet.from(CCRaw.parse(await cc.serialize(ctx)), ctx)
+			.sensorType,
+	).toBe(255);
+});
+
+test("Alarm codecs reject truncated fields", () => {
+	for (const [command, parser, payload] of [
+		[AlarmSensorCommand.Get, AlarmSensorCCGet, []],
+		[AlarmSensorCommand.Report, AlarmSensorCCReport, [0, 1, 1, 0]],
+		[
+			AlarmSensorCommand.SupportedReport,
+			AlarmSensorCCSupportedReport,
+			[2, 1],
+		],
+	] as const) {
+		expect(() =>
+			parser.from(
+				new CCRaw(
+					CommandClasses["Alarm Sensor"],
+					command,
+					Bytes.from(payload),
+				),
+				ctx,
+			),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	}
+});

--- a/packages/cc/src/cc/AlarmSensorCC.ts
+++ b/packages/cc/src/cc/AlarmSensorCC.ts
@@ -8,8 +8,7 @@ import {
 	type MessageRecord,
 	ValueMetadata,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
+	encodeBitMask,
 	logDict,
 	logList,
 	logText,
@@ -377,6 +376,18 @@ export class AlarmSensorCCReport extends AlarmSensorCC {
 	public readonly severity: number | undefined;
 	public readonly duration: number | undefined;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([
+			0,
+			this.sensorType,
+			this.state ? (this.severity ?? 0xff) : 0,
+			0,
+			0,
+		]);
+		this.payload.writeUInt16BE(this.duration ?? 0, 3);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {
 			"sensor type": getEnumMemberName(AlarmSensorType, this.sensorType),
@@ -435,16 +446,12 @@ export class AlarmSensorCCGet extends AlarmSensorCC {
 		this.sensorType = options.sensorType ?? AlarmSensorType.Any;
 	}
 
-	public static from(_raw: CCRaw, _ctx: CCParsingContext): AlarmSensorCCGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new AlarmSensorCCGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+	public static from(raw: CCRaw, ctx: CCParsingContext): AlarmSensorCCGet {
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			sensorType: raw.payload[0],
+		});
 	}
 
 	public sensorType: AlarmSensorType;
@@ -506,6 +513,16 @@ export class AlarmSensorCCSupportedReport extends AlarmSensorCC {
 	}
 
 	public supportedSensorTypes: AlarmSensorType[];
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const mask = encodeBitMask(
+			this.supportedSensorTypes,
+			undefined,
+			AlarmSensorType["General Purpose"],
+		);
+		this.payload = Bytes.concat([[mask.length], mask]);
+		return super.serialize(ctx);
+	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;

--- a/packages/cc/src/cc/BarrierOperatorCC.test.ts
+++ b/packages/cc/src/cc/BarrierOperatorCC.test.ts
@@ -1,0 +1,135 @@
+import { CommandClasses, UNKNOWN_STATE, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import {
+	BarrierOperatorCommand,
+	BarrierState,
+	SubsystemState,
+	SubsystemType,
+} from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	BarrierOperatorCCSet,
+	BarrierOperatorCCReport,
+	BarrierOperatorCCSignalingCapabilitiesReport,
+	BarrierOperatorCCEventSignalingSet,
+	BarrierOperatorCCEventSignalingGet,
+	BarrierOperatorCCEventSignalingReport,
+} from "./BarrierOperatorCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: () => {},
+};
+
+test.each([0, 30, 99, 252, 253, 254, 255])(
+	"Barrier state %i round trips",
+	async (value) => {
+		const raw = new CCRaw(
+			CommandClasses["Barrier Operator"],
+			BarrierOperatorCommand.Report,
+			Bytes.from([value]),
+		);
+		const cc = BarrierOperatorCCReport.from(raw, ctx);
+		expect((await cc.serialize(ctx)).subarray(2)).toEqual(raw.payload);
+	},
+);
+
+test("Barrier unknown state remains unknown", async () => {
+	const cc = new BarrierOperatorCCReport({
+		nodeId: 2,
+		position: UNKNOWN_STATE,
+		currentState: UNKNOWN_STATE,
+	});
+	expect(
+		BarrierOperatorCCReport.from(CCRaw.parse(await cc.serialize(ctx)), ctx),
+	).toMatchObject({ position: UNKNOWN_STATE, currentState: UNKNOWN_STATE });
+});
+
+test("Barrier Set and signaling commands round trip", async () => {
+	const set = new BarrierOperatorCCSet({
+		nodeId: 2,
+		targetState: BarrierState.Open,
+	});
+	expect(
+		BarrierOperatorCCSet.from(CCRaw.parse(await set.serialize(ctx)), ctx)
+			.targetState,
+	).toBe(255);
+	for (const Class of [
+		BarrierOperatorCCEventSignalingSet,
+		BarrierOperatorCCEventSignalingReport,
+	]) {
+		const cc = new Class({
+			nodeId: 2,
+			subsystemType: SubsystemType.Audible,
+			subsystemState: SubsystemState.On,
+		});
+		const bytes = await cc.serialize(ctx);
+		expect(bytes.subarray(2)).toEqual(Bytes.from([1, 255]));
+		expect(Class.from(CCRaw.parse(bytes), ctx)).toMatchObject({
+			subsystemType: 1,
+			subsystemState: 255,
+		});
+	}
+	const get = new BarrierOperatorCCEventSignalingGet({
+		nodeId: 2,
+		subsystemType: SubsystemType.Visual,
+	});
+	expect(
+		BarrierOperatorCCEventSignalingGet.from(
+			CCRaw.parse(await get.serialize(ctx)),
+			ctx,
+		).subsystemType,
+	).toBe(2);
+	const caps = new BarrierOperatorCCSignalingCapabilitiesReport({
+		nodeId: 2,
+		supportedSubsystemTypes: [SubsystemType.Audible, SubsystemType.Visual],
+	});
+	const bytes = await caps.serialize(ctx);
+	expect(bytes.subarray(2)).toEqual(Bytes.from([3]));
+	expect(
+		BarrierOperatorCCSignalingCapabilitiesReport.from(
+			CCRaw.parse(bytes),
+			ctx,
+		).supportedSubsystemTypes,
+	).toEqual([1, 2]);
+});
+
+test("Barrier parsers reject malformed commands", () => {
+	for (const [Class, payload] of [
+		[BarrierOperatorCCSet, []],
+		[BarrierOperatorCCSet, [20]],
+		[BarrierOperatorCCEventSignalingSet, [1]],
+		[BarrierOperatorCCEventSignalingSet, [1, 20]],
+		[BarrierOperatorCCEventSignalingGet, []],
+		[BarrierOperatorCCEventSignalingGet, [99]],
+	] as const) {
+		expect(() =>
+			Class.from(
+				new CCRaw(
+					CommandClasses["Barrier Operator"],
+					0,
+					Bytes.from(payload),
+				),
+				ctx,
+			),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	}
+});

--- a/packages/cc/src/cc/BarrierOperatorCC.ts
+++ b/packages/cc/src/cc/BarrierOperatorCC.ts
@@ -12,13 +12,12 @@ import {
 	UNKNOWN_STATE,
 	ValueMetadata,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
 	enumValuesToMetadataStates,
 	logList,
 	logText,
 	maybeUnknownToString,
 	parseBitMask,
+	encodeBitMask,
 	validatePayload,
 } from "@zwave-js/core";
 import {
@@ -561,17 +560,16 @@ export class BarrierOperatorCCSet extends BarrierOperatorCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): BarrierOperatorCCSet {
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
+		validatePayload(raw.payload.length >= 1);
+		const targetState = raw.payload[0];
+		validatePayload(
+			targetState === BarrierState.Open
+				|| targetState === BarrierState.Closed,
 		);
-
-		// return new BarrierOperatorCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		return new this({ nodeId: ctx.sourceNodeId, targetState });
 	}
 
 	public targetState: BarrierState.Open | BarrierState.Closed;
@@ -652,6 +650,18 @@ export class BarrierOperatorCCReport extends BarrierOperatorCC {
 
 	public readonly position: MaybeUnknown<number>;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const value =
+			this.currentState === BarrierState.Stopped
+			&& typeof this.position === "number"
+				? this.position === 100
+					? 0xff
+					: this.position
+				: (this.currentState ?? 0x64);
+		this.payload = Bytes.from([value]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -707,6 +717,15 @@ export class BarrierOperatorCCSignalingCapabilitiesReport extends BarrierOperato
 
 	public readonly supportedSubsystemTypes: readonly SubsystemType[];
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = encodeBitMask(
+			this.supportedSubsystemTypes,
+			undefined,
+			SubsystemType.Audible,
+		);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -743,18 +762,21 @@ export class BarrierOperatorCCEventSignalingSet extends BarrierOperatorCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): BarrierOperatorCCEventSignalingSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
+		validatePayload(raw.payload.length >= 2);
+		const subsystemType = raw.payload[0];
+		const subsystemState = raw.payload[1];
+		validatePayload(
+			isEnumMember(SubsystemType, subsystemType),
+			isEnumMember(SubsystemState, subsystemState),
 		);
-
-		// return new BarrierOperatorCCEventSignalingSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			subsystemType,
+			subsystemState,
+		});
 	}
 
 	public subsystemType: SubsystemType;
@@ -835,6 +857,11 @@ export class BarrierOperatorCCEventSignalingReport extends BarrierOperatorCC {
 	public readonly subsystemType: SubsystemType;
 	public readonly subsystemState: SubsystemState;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([this.subsystemType, this.subsystemState]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -868,18 +895,13 @@ export class BarrierOperatorCCEventSignalingGet extends BarrierOperatorCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): BarrierOperatorCCEventSignalingGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new BarrierOperatorCCEventSignalingGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		const subsystemType = raw.payload[0];
+		validatePayload(isEnumMember(SubsystemType, subsystemType));
+		return new this({ nodeId: ctx.sourceNodeId, subsystemType });
 	}
 
 	public subsystemType: SubsystemType;

--- a/packages/cc/src/cc/CentralSceneCC.test.ts
+++ b/packages/cc/src/cc/CentralSceneCC.test.ts
@@ -1,0 +1,119 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { CentralSceneCommand, CentralSceneKeys } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	CentralSceneCCNotification,
+	CentralSceneCCSupportedReport,
+	CentralSceneCCConfigurationReport,
+	CentralSceneCCConfigurationSet,
+} from "./CentralSceneCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 3,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: () => {},
+};
+
+test("Central Scene notifications encode slow refresh only for held keys", async () => {
+	for (const keyAttribute of [
+		CentralSceneKeys.KeyPressed,
+		CentralSceneKeys.KeyHeldDown,
+	]) {
+		const cc = new CentralSceneCCNotification({
+			nodeId: 2,
+			sequenceNumber: 255,
+			sceneNumber: 2,
+			keyAttribute,
+			slowRefresh: true,
+		});
+		const bytes = await cc.serialize(ctx);
+		expect(bytes.subarray(2)).toEqual(
+			Bytes.from([
+				255,
+				keyAttribute === CentralSceneKeys.KeyHeldDown ? 0x82 : 0,
+				2,
+			]),
+		);
+		expect(
+			CentralSceneCCNotification.from(CCRaw.parse(bytes), ctx),
+		).toMatchObject({
+			keyAttribute,
+			sceneNumber: 2,
+			slowRefresh:
+				keyAttribute === CentralSceneKeys.KeyHeldDown
+					? true
+					: undefined,
+		});
+	}
+});
+
+test("Central Scene capabilities encode each scene mask", async () => {
+	const cc = new CentralSceneCCSupportedReport({
+		nodeId: 2,
+		sceneCount: 2,
+		supportsSlowRefresh: true,
+		supportedKeyAttributes: { 1: [0, 2], 2: [1, 6] },
+	});
+	const bytes = await cc.serialize(ctx);
+	expect(bytes.subarray(2)).toEqual(Bytes.from([2, 0x82, 5, 66]));
+	expect(
+		CentralSceneCCSupportedReport.from(CCRaw.parse(bytes), ctx)
+			.supportedKeyAttributes,
+	).toEqual(
+		new Map([
+			[1, [0, 2]],
+			[2, [1, 6]],
+		]),
+	);
+});
+
+test("Central Scene configuration round trips and ignores reserved bits", async () => {
+	const cc = new CentralSceneCCConfigurationReport({
+		nodeId: 2,
+		slowRefresh: true,
+	});
+	expect((await cc.serialize(ctx)).subarray(2)).toEqual(Bytes.from([0x80]));
+	const parsed = CentralSceneCCConfigurationSet.from(
+		new CCRaw(
+			CommandClasses["Central Scene"],
+			CentralSceneCommand.ConfigurationSet,
+			Bytes.from([0xff]),
+		),
+		ctx,
+	);
+	expect(parsed.slowRefresh).toBe(true);
+	expect((await parsed.serialize(ctx)).subarray(2)).toEqual(
+		Bytes.from([0x80]),
+	);
+});
+
+test("Central Scene configuration rejects an empty payload", () => {
+	expect(() =>
+		CentralSceneCCConfigurationSet.from(
+			new CCRaw(
+				CommandClasses["Central Scene"],
+				CentralSceneCommand.ConfigurationSet,
+				new Bytes(0),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/CentralSceneCC.ts
+++ b/packages/cc/src/cc/CentralSceneCC.ts
@@ -8,9 +8,8 @@ import {
 	type SupervisionResult,
 	ValueMetadata,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
 	enumValuesToMetadataStates,
+	encodeBitMask,
 	getCCName,
 	logDict,
 	logList,
@@ -372,6 +371,19 @@ export class CentralSceneCCNotification extends CentralSceneCC {
 	public readonly sceneNumber: number;
 	public readonly slowRefresh: boolean | undefined;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([
+			this.sequenceNumber,
+			(this.keyAttribute & 0b111)
+				| (this.keyAttribute === CentralSceneKeys.KeyHeldDown
+				&& this.slowRefresh
+					? 0x80
+					: 0),
+			this.sceneNumber,
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {
 			"sequence number": this.sequenceNumber,
@@ -503,6 +515,21 @@ export class CentralSceneCCSupportedReport extends CentralSceneCC {
 
 	public readonly sceneCount: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const masks = Array.from({ length: this.sceneCount }, (_, i) =>
+			encodeBitMask(
+				this.supportedKeyAttributes.get(i + 1) ?? [],
+				7,
+				CentralSceneKeys.KeyPressed,
+			),
+		);
+		this.payload = Bytes.concat([
+			[this.sceneCount, (this.supportsSlowRefresh ? 0x80 : 0) | 0b10],
+			...masks,
+		]);
+		return super.serialize(ctx);
+	}
+
 	// TODO: Only offer `slowRefresh` if this is true
 
 	public readonly supportsSlowRefresh: MaybeNotKnown<boolean>;
@@ -574,6 +601,11 @@ export class CentralSceneCCConfigurationReport extends CentralSceneCC {
 
 	public readonly slowRefresh: boolean;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([this.slowRefresh ? 0x80 : 0]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -602,17 +634,14 @@ export class CentralSceneCCConfigurationSet extends CentralSceneCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): CentralSceneCCConfigurationSet {
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new CentralSceneCCConfigurationSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			slowRefresh: !!(raw.payload[0] & 0x80),
+		});
 	}
 
 	public slowRefresh: boolean;

--- a/packages/cc/src/cc/ClimateControlScheduleCC.test.ts
+++ b/packages/cc/src/cc/ClimateControlScheduleCC.test.ts
@@ -1,0 +1,145 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { ClimateControlScheduleCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	ClimateControlScheduleCCChangedReport,
+	ClimateControlScheduleCCGet,
+	ClimateControlScheduleCCOverrideReport,
+	ClimateControlScheduleCCOverrideSet,
+	ClimateControlScheduleCCReport,
+	ClimateControlScheduleCCSet,
+} from "./ClimateControlScheduleCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const ccId = CommandClasses["Climate Control Schedule"];
+const raw = (
+	command: ClimateControlScheduleCommand,
+	payload: readonly number[],
+) => new CCRaw(ccId, command, Bytes.from(payload));
+
+test("Schedule Set and Report preserve nine wire slots and omit unused entries", async () => {
+	const payload = [
+		2,
+		6,
+		30,
+		0xf1,
+		...Array.from({ length: 8 }, () => [0, 0, 0x7f]).flat(),
+	];
+	const set = ClimateControlScheduleCCSet.from(
+		raw(ClimateControlScheduleCommand.Set, payload),
+		ctx,
+	);
+	expect(set.switchPoints).toEqual([{ hour: 6, minute: 30, state: -1.5 }]);
+	expect(await set.serialize(ctx)).toEqual(Bytes.from([ccId, 1, ...payload]));
+	const report = new ClimateControlScheduleCCReport({
+		nodeId: 2,
+		weekday: 2,
+		schedule: set.switchPoints,
+	});
+	expect(await report.serialize(ctx)).toEqual(
+		Bytes.from([ccId, 3, ...payload]),
+	);
+	expect(
+		ClimateControlScheduleCCReport.from(
+			raw(ClimateControlScheduleCommand.Report, payload),
+			ctx,
+		).schedule,
+	).toEqual(set.switchPoints);
+});
+
+test("Schedule Get masks reserved weekday bits", async () => {
+	const get = ClimateControlScheduleCCGet.from(
+		raw(ClimateControlScheduleCommand.Get, [0xfa]),
+		ctx,
+	);
+	expect(get.weekday).toBe(2);
+	expect(await get.serialize(ctx)).toEqual(Bytes.from([ccId, 2, 2]));
+});
+
+test.each([0, 0xf1, 0x79, 0x7a, 0x7f])(
+	"Override codecs preserve setback byte %i",
+	async (state) => {
+		const set = ClimateControlScheduleCCOverrideSet.from(
+			raw(ClimateControlScheduleCommand.OverrideSet, [0xfd, state]),
+			ctx,
+		);
+		expect(set.overrideType).toBe(1);
+		expect(await set.serialize(ctx)).toEqual(
+			Bytes.from([ccId, 6, 1, state]),
+		);
+		const report = new ClimateControlScheduleCCOverrideReport({
+			nodeId: 2,
+			overrideType: set.overrideType,
+			overrideState: set.overrideState,
+		});
+		expect(await report.serialize(ctx)).toEqual(
+			Bytes.from([ccId, 8, 1, state]),
+		);
+		expect(
+			ClimateControlScheduleCCOverrideReport.from(
+				raw(ClimateControlScheduleCommand.OverrideReport, [1, state]),
+				ctx,
+			).overrideState,
+		).toEqual(set.overrideState);
+	},
+);
+
+test("Changed Report serializes its counter", async () => {
+	const report = new ClimateControlScheduleCCChangedReport({
+		nodeId: 2,
+		changeCounter: 255,
+	});
+	expect(await report.serialize(ctx)).toEqual(Bytes.from([ccId, 5, 255]));
+	expect(
+		ClimateControlScheduleCCChangedReport.from(
+			raw(ClimateControlScheduleCommand.ChangedReport, [255]),
+			ctx,
+		).changeCounter,
+	).toBe(255);
+});
+
+test("Schedule parsers reject truncated payloads", () => {
+	for (const [parse, command, payload] of [
+		[
+			ClimateControlScheduleCCSet.from.bind(ClimateControlScheduleCCSet),
+			ClimateControlScheduleCommand.Set,
+			Array(27).fill(0),
+		],
+		[
+			ClimateControlScheduleCCGet.from.bind(ClimateControlScheduleCCGet),
+			ClimateControlScheduleCommand.Get,
+			[],
+		],
+		[
+			ClimateControlScheduleCCOverrideSet.from.bind(
+				ClimateControlScheduleCCOverrideSet,
+			),
+			ClimateControlScheduleCommand.OverrideSet,
+			[1],
+		],
+	] as const) {
+		expect(() => parse(raw(command, payload), ctx)).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	}
+});

--- a/packages/cc/src/cc/ClimateControlScheduleCC.ts
+++ b/packages/cc/src/cc/ClimateControlScheduleCC.ts
@@ -6,8 +6,6 @@ import {
 	type SupervisionResult,
 	ValueMetadata,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
 	enumValuesToMetadataStates,
 	validatePayload,
 } from "@zwave-js/core";
@@ -217,17 +215,18 @@ export class ClimateControlScheduleCCSet extends ClimateControlScheduleCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): ClimateControlScheduleCCSet {
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new ClimateControlScheduleCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 28);
+		const switchPoints = Array.from({ length: 9 }, (_, i) =>
+			decodeSwitchpoint(raw.payload.subarray(1 + 3 * i)),
+		).filter((sp) => sp.state !== "Unused");
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			weekday: raw.payload[0] & 0b111,
+			switchPoints,
+		});
 	}
 
 	public switchPoints: Switchpoint[];
@@ -319,6 +318,22 @@ export class ClimateControlScheduleCCReport extends ClimateControlScheduleCC {
 
 	public readonly schedule: readonly Switchpoint[];
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.concat([
+			[this.weekday & 0b111],
+			...Array.from({ length: 9 }, (_, i) =>
+				encodeSwitchpoint(
+					this.schedule[i] ?? {
+						hour: 0,
+						minute: 0,
+						state: "Unused",
+					},
+				),
+			),
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -353,17 +368,14 @@ export class ClimateControlScheduleCCGet extends ClimateControlScheduleCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): ClimateControlScheduleCCGet {
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new ClimateControlScheduleCCGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			weekday: raw.payload[0] & 0b111,
+		});
 	}
 
 	public weekday: Weekday;
@@ -411,6 +423,11 @@ export class ClimateControlScheduleCCChangedReport extends ClimateControlSchedul
 	}
 
 	public readonly changeCounter: number;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([this.changeCounter]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
@@ -466,6 +483,14 @@ export class ClimateControlScheduleCCOverrideReport extends ClimateControlSchedu
 
 	public readonly overrideState: SetbackState;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.concat([
+			[this.overrideType & 0b11],
+			encodeSetbackState(this.overrideState),
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -502,17 +527,16 @@ export class ClimateControlScheduleCCOverrideSet extends ClimateControlScheduleC
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): ClimateControlScheduleCCOverrideSet {
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new ClimateControlScheduleCCOverrideSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 2);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			overrideType: raw.payload[0] & 0b11,
+			overrideState:
+				decodeSetbackState(raw.payload, 1) ?? raw.payload.readInt8(1),
+		});
 	}
 
 	public overrideType: ScheduleOverrideType;

--- a/packages/cc/src/cc/ClockCC.test.ts
+++ b/packages/cc/src/cc/ClockCC.test.ts
@@ -1,0 +1,73 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { ClockCommand, Weekday } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import { ClockCCReport, ClockCCSet } from "./ClockCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+
+test("Clock Set parses weekday and time", () => {
+	const cc = ClockCCSet.from(
+		new CCRaw(
+			CommandClasses.Clock,
+			ClockCommand.Set,
+			Bytes.from([0xf7, 59]),
+		),
+		ctx,
+	);
+	expect(cc).toMatchObject({
+		nodeId: 2,
+		weekday: Weekday.Sunday,
+		hour: 23,
+		minute: 59,
+	});
+});
+
+test("Clock Report serializes weekday and time", async () => {
+	const cc = new ClockCCReport({
+		nodeId: 2,
+		weekday: Weekday.Sunday,
+		hour: 23,
+		minute: 59,
+	});
+	expect(await cc.serialize(ctx)).toEqual(
+		Bytes.from([CommandClasses.Clock, ClockCommand.Report, 0xf7, 59]),
+	);
+});
+
+test.each([[], [0], [24, 0], [0, 60]].map((payload) => ({ payload })))(
+	"Clock Set rejects invalid payload $payload",
+	({ payload }) => {
+		expect(() =>
+			ClockCCSet.from(
+				new CCRaw(
+					CommandClasses.Clock,
+					ClockCommand.Set,
+					Bytes.from(payload),
+				),
+				ctx,
+			),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	},
+);

--- a/packages/cc/src/cc/ClockCC.ts
+++ b/packages/cc/src/cc/ClockCC.ts
@@ -6,8 +6,6 @@ import {
 	MessagePriority,
 	type SupervisionResult,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
 	validatePayload,
 } from "@zwave-js/core";
 import { Bytes, getEnumMemberName, pick } from "@zwave-js/shared";
@@ -155,16 +153,19 @@ export class ClockCCSet extends ClockCC {
 		this.minute = options.minute;
 	}
 
-	public static from(_raw: CCRaw, _ctx: CCParsingContext): ClockCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
+	public static from(raw: CCRaw, ctx: CCParsingContext): ClockCCSet {
+		validatePayload(raw.payload.length >= 2);
+		const weekday: Weekday = raw.payload[0] >>> 5;
+		const hour = raw.payload[0] & 0b11111;
+		const minute = raw.payload[1];
+		validatePayload(weekday <= Weekday.Sunday, hour <= 23, minute <= 59);
 
-		// return new ClockCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			weekday,
+			hour,
+			minute,
+		});
 	}
 
 	public weekday: Weekday;
@@ -230,6 +231,14 @@ export class ClockCCReport extends ClockCC {
 	public readonly weekday: Weekday;
 	public readonly hour: number;
 	public readonly minute: number;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([
+			((this.weekday & 0b111) << 5) | (this.hour & 0b11111),
+			this.minute,
+		]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {

--- a/packages/cc/src/cc/ConfigurationCC.test.ts
+++ b/packages/cc/src/cc/ConfigurationCC.test.ts
@@ -1,0 +1,231 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { ConfigurationCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	ConfigurationCCBulkGet,
+	ConfigurationCCBulkReport,
+	ConfigurationCCBulkSet,
+} from "./ConfigurationCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 4,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+
+test.each([1, 2, 3, 4])(
+	"Bulk Set roundtrips signed values of size %s",
+	async (valueSize) => {
+		const options = {
+			nodeId: 2,
+			parameters: [65534, 65535],
+			handshake: true,
+			valueSize,
+			values: [-(2 ** (8 * valueSize - 1)), 2 ** (8 * valueSize - 1) - 1],
+		};
+		const bytes = await new ConfigurationCCBulkSet(options).serialize(ctx);
+		const cc = ConfigurationCCBulkSet.from(CCRaw.parse(bytes), ctx);
+		expect(cc).toMatchObject(options);
+		expect(await cc.serialize(ctx)).toEqual(bytes);
+	},
+);
+
+test("Bulk Set parses reset and handshake flags", async () => {
+	const options = {
+		nodeId: 2,
+		parameters: [256, 257],
+		handshake: true,
+		resetToDefault: true as const,
+	};
+	const bytes = await new ConfigurationCCBulkSet(options).serialize(ctx);
+	expect([...bytes.subarray(2)]).toEqual([1, 0, 2, 0xc1, 0, 0]);
+	expect(ConfigurationCCBulkSet.from(CCRaw.parse(bytes), ctx)).toMatchObject(
+		options,
+	);
+});
+
+test("Bulk Get roundtrips the maximum parameter number", async () => {
+	const bytes = await new ConfigurationCCBulkGet({
+		nodeId: 2,
+		parameters: [65535],
+	}).serialize(ctx);
+	expect([...bytes.subarray(2)]).toEqual([255, 255, 1]);
+	expect(
+		ConfigurationCCBulkGet.from(CCRaw.parse(bytes), ctx).parameters,
+	).toEqual([65535]);
+});
+
+test("Bulk Get parses the maximum parameter count", () => {
+	const cc = ConfigurationCCBulkGet.from(
+		new CCRaw(
+			CommandClasses.Configuration,
+			ConfigurationCommand.BulkGet,
+			Bytes.from([0, 0, 255]),
+		),
+		ctx,
+	);
+	expect(cc.parameters).toHaveLength(255);
+	expect(cc.parameters[0]).toBe(0);
+	expect(cc.parameters.at(-1)).toBe(254);
+});
+
+test.each(
+	[[], [0, 1, 1, 0], [0, 1, 1, 0, 5], [0, 1, 1, 0, 2, 0]].map((payload) => ({
+		payload,
+	})),
+)("Bulk Report rejects malformed payload $payload", ({ payload }) => {
+	expect(() =>
+		ConfigurationCCBulkReport.from(
+			new CCRaw(
+				CommandClasses.Configuration,
+				ConfigurationCommand.BulkReport,
+				Bytes.from(payload),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});
+
+test.each([
+	{
+		command: ConfigurationCommand.BulkGet,
+		parse: ConfigurationCCBulkGet.from.bind(ConfigurationCCBulkGet),
+		payloads: [[], [0], [0, 1], [0, 1, 0], [255, 255, 2]],
+	},
+	{
+		command: ConfigurationCommand.BulkSet,
+		parse: ConfigurationCCBulkSet.from.bind(ConfigurationCCBulkSet),
+		payloads: [
+			[],
+			[0, 1, 1],
+			[0, 1, 1, 0],
+			[0, 1, 1, 5],
+			[0, 1, 0, 1],
+			[0, 1, 1, 2, 0],
+			[255, 255, 2, 1, 0, 0],
+		],
+	},
+])(
+	"Configuration command $command rejects malformed payloads",
+	({ command, parse, payloads }) => {
+		for (const payload of payloads) {
+			expect(() =>
+				parse(
+					new CCRaw(
+						CommandClasses.Configuration,
+						command,
+						Bytes.from(payload),
+					),
+					ctx,
+				),
+			).toThrow(
+				expect.objectContaining({
+					code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+				}),
+			);
+		}
+	},
+);
+
+test.each([1, 2, 3, 4])(
+	"Bulk Report roundtrips signed values of size %s",
+	async (valueSize) => {
+		const values = {
+			256: -(2 ** (8 * valueSize - 1)),
+			257: 2 ** (8 * valueSize - 1) - 1,
+		};
+		const options = {
+			nodeId: 2,
+			reportsToFollow: 255,
+			defaultValues: true,
+			isHandshakeResponse: true,
+			valueSize,
+			values,
+		};
+		const bytes = await new ConfigurationCCBulkReport(options).serialize(
+			ctx,
+		);
+		expect([...bytes.subarray(2, 7)]).toEqual([
+			1,
+			0,
+			2,
+			255,
+			0xc0 | valueSize,
+		]);
+		const parsed = ConfigurationCCBulkReport.from(CCRaw.parse(bytes), ctx);
+		expect(parsed.values).toEqual(
+			new Map(
+				Object.entries(values).map(([key, value]) => [
+					Number(key),
+					value,
+				]),
+			),
+		);
+		expect(await parsed.serialize(ctx)).toEqual(bytes);
+	},
+);
+
+test("Bulk Report serializes unsigned values as their wire representation", async () => {
+	const bytes = await new ConfigurationCCBulkReport({
+		nodeId: 2,
+		reportsToFollow: 0,
+		defaultValues: false,
+		isHandshakeResponse: false,
+		valueSize: 1,
+		values: { 1: 255 },
+	}).serialize(ctx);
+	expect([...bytes.subarray(2)]).toEqual([0, 1, 1, 0, 1, 255]);
+	expect(
+		ConfigurationCCBulkReport.from(CCRaw.parse(bytes), ctx).values.get(1),
+	).toBe(-1);
+});
+
+test("Bulk Report preserves empty reports with size zero", async () => {
+	const raw = new CCRaw(
+		CommandClasses.Configuration,
+		ConfigurationCommand.BulkReport,
+		Bytes.from([0, 0, 0, 0, 0]),
+	);
+	const cc = ConfigurationCCBulkReport.from(raw, ctx);
+	expect(cc.values.size).toBe(0);
+	expect(cc.valueSize).toBe(0);
+	expect(CCRaw.parse(await cc.serialize(ctx)).payload).toEqual(raw.payload);
+});
+
+test.each([
+	{ valueSize: 1, values: { 1: 0, 3: 0 } },
+	{ valueSize: 0, values: { 1: 0 } },
+	{ valueSize: 5, values: { 1: 0 } },
+	{ valueSize: 1, values: { 1: 256 } },
+	{ valueSize: 1, values: { 1: -129 } },
+])("Bulk Report rejects unencodable values: $values", (options) => {
+	expect(() =>
+		new ConfigurationCCBulkReport({
+			nodeId: 2,
+			reportsToFollow: 0,
+			defaultValues: false,
+			isHandshakeResponse: false,
+			...options,
+		}).serialize(ctx),
+	).toThrow(
+		expect.objectContaining({ code: ZWaveErrorCodes.Argument_Invalid }),
+	);
+});

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -2281,18 +2281,39 @@ export class ConfigurationCCBulkSet extends ConfigurationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): ConfigurationCCBulkSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
+		validatePayload(raw.payload.length >= 4);
+		const firstParameter = raw.payload.readUInt16BE(0);
+		const numParams = raw.payload[2];
+		const resetToDefault = !!(raw.payload[3] & 0b1000_0000);
+		const handshake = !!(raw.payload[3] & 0b0100_0000);
+		const valueSize = raw.payload[3] & 0b111;
+		validatePayload(numParams > 0, firstParameter + numParams <= 0x10000);
+		validatePayload(valueSize >= 1, valueSize <= 4);
+		validatePayload(raw.payload.length >= 4 + numParams * valueSize);
+		const parameters = Array.from(
+			{ length: numParams },
+			(_, i) => firstParameter + i,
 		);
-
-		// return new ConfigurationCCBulkSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		if (resetToDefault) {
+			return new this({
+				nodeId: ctx.sourceNodeId,
+				parameters,
+				handshake,
+				resetToDefault,
+			});
+		}
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			parameters,
+			handshake,
+			valueSize,
+			values: parameters.map((_, i) =>
+				raw.payload.readIntBE(4 + i * valueSize, valueSize),
+			),
+		});
 	}
 
 	private _parameters: number[];
@@ -2496,6 +2517,60 @@ export class ConfigurationCCBulkReport extends ConfigurationCC {
 		return this._values;
 	}
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const parameters = [...this._values.keys()].toSorted((a, b) => a - b);
+		if (
+			parameters.length > 255
+			|| (parameters.length > 0 && !isConsecutiveArray(parameters))
+			|| parameters.some(
+				(p) => !Number.isInteger(p) || p < 0 || p > 0xffff,
+			)
+			|| !Number.isInteger(this.valueSize)
+			|| this.valueSize < (parameters.length > 0 ? 1 : 0)
+			|| this.valueSize > 4
+		) {
+			throw new ZWaveError(
+				"ConfigurationCCBulkReport requires consecutive parameters and a valid value size",
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		this.payload = new Bytes(5 + parameters.length * this.valueSize);
+		this.payload.writeUInt16BE(parameters[0] ?? 0, 0);
+		this.payload[2] = parameters.length;
+		this.payload[3] = this.reportsToFollow;
+		this.payload[4] =
+			(this.defaultValues ? 0b1000_0000 : 0)
+			| (this.isHandshakeResponse ? 0b0100_0000 : 0)
+			| this.valueSize;
+		for (let i = 0; i < parameters.length; i++) {
+			const value = this._values.get(parameters[i])!;
+			const format =
+				value < 0
+					? ConfigValueFormat.SignedInteger
+					: ConfigValueFormat.UnsignedInteger;
+			if (
+				!Number.isInteger(value)
+				|| value < -(2 ** (8 * this.valueSize - 1))
+				|| value >= 2 ** (8 * this.valueSize)
+			) {
+				throwInvalidValueError(
+					value,
+					parameters[i],
+					this.valueSize,
+					format,
+				);
+			}
+			serializeValue(
+				this.payload,
+				5 + i * this.valueSize,
+				this.valueSize,
+				format,
+				value,
+			);
+		}
+		return super.serialize(ctx);
+	}
+
 	public getPartialCCSessionId(): Record<string, any> | undefined {
 		return {};
 	}
@@ -2564,18 +2639,20 @@ export class ConfigurationCCBulkGet extends ConfigurationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): ConfigurationCCBulkGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new ConfigurationCCBulkGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 3);
+		const firstParameter = raw.payload.readUInt16BE(0);
+		const numParams = raw.payload[2];
+		validatePayload(numParams > 0, firstParameter + numParams <= 0x10000);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			parameters: Array.from(
+				{ length: numParams },
+				(_, i) => firstParameter + i,
+			),
+		});
 	}
 
 	private _parameters: number[];

--- a/packages/cc/src/cc/DoorLockLoggingCC.test.ts
+++ b/packages/cc/src/cc/DoorLockLoggingCC.test.ts
@@ -1,0 +1,113 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { DoorLockLoggingCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	DoorLockLoggingCCRecordGet,
+	DoorLockLoggingCCRecordReport,
+	DoorLockLoggingCCRecordsSupportedReport,
+} from "./DoorLockLoggingCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: () => {},
+};
+
+test("Door Lock Logging encodes empty records and supported counts", async () => {
+	const empty = new DoorLockLoggingCCRecordReport({
+		nodeId: 2,
+		recordNumber: 3,
+	});
+	const bytes = await empty.serialize(ctx);
+	expect(bytes.subarray(2)).toEqual(
+		Bytes.from([3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+	);
+	expect(
+		DoorLockLoggingCCRecordReport.from(CCRaw.parse(bytes), ctx).record,
+	).toBeUndefined();
+	const caps = new DoorLockLoggingCCRecordsSupportedReport({
+		nodeId: 2,
+		recordsCount: 30,
+	});
+	expect((await caps.serialize(ctx)).subarray(2)).toEqual(Bytes.from([30]));
+});
+
+test.each(["1234", Bytes.from([0xff, 0x80, 0])])(
+	"Door Lock Logging encodes timestamps and user codes %s",
+	async (userCode) => {
+		const record = {
+			timestamp: new Date(2025, 5, 12, 14, 30, 45).toISOString(),
+			eventType: 1,
+			label: "Locked via Access Code",
+			userId: 7,
+			userCode,
+		};
+		const cc = new DoorLockLoggingCCRecordReport({
+			nodeId: 2,
+			recordNumber: 2,
+			record,
+		});
+		const bytes = await cc.serialize(ctx);
+		expect(bytes.subarray(2, 13)).toEqual(
+			Bytes.from([2, 7, 233, 6, 12, 0x2e, 30, 45, 1, 7, userCode.length]),
+		);
+		expect(
+			DoorLockLoggingCCRecordReport.from(CCRaw.parse(bytes), ctx).record,
+		).toEqual(record);
+	},
+);
+
+test("Door Lock Logging Get round trips latest-record sentinel", async () => {
+	const cc = new DoorLockLoggingCCRecordGet({ nodeId: 2, recordNumber: 0 });
+	expect(
+		DoorLockLoggingCCRecordGet.from(
+			CCRaw.parse(await cc.serialize(ctx)),
+			ctx,
+		).recordNumber,
+	).toBe(0);
+	expect(() =>
+		DoorLockLoggingCCRecordGet.from(
+			new CCRaw(
+				CommandClasses["Door Lock Logging"],
+				DoorLockLoggingCommand.RecordGet,
+				new Bytes(0),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});
+
+test("Door Lock Logging rejects a truncated user code", () => {
+	expect(() =>
+		DoorLockLoggingCCRecordReport.from(
+			new CCRaw(
+				CommandClasses["Door Lock Logging"],
+				DoorLockLoggingCommand.RecordReport,
+				Bytes.from([2, 7, 233, 6, 12, 0x2e, 30, 45, 1, 7, 2, 49]),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/DoorLockLoggingCC.ts
+++ b/packages/cc/src/cc/DoorLockLoggingCC.ts
@@ -260,6 +260,11 @@ export class DoorLockLoggingCCRecordsSupportedReport extends DoorLockLoggingCC {
 
 	public readonly recordsCount: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([this.recordsCount]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -355,6 +360,43 @@ export class DoorLockLoggingCCRecordReport extends DoorLockLoggingCC {
 	public readonly recordNumber: number;
 	public readonly record?: DoorLockLoggingRecord;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const code =
+			typeof this.record?.userCode === "string"
+				? Bytes.from(this.record.userCode, "utf8")
+				: (this.record?.userCode ?? new Bytes(0));
+		if (code.length > 10) {
+			throw new ZWaveError(
+				"User code must not exceed 10 bytes",
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		this.payload = new Bytes(11 + code.length);
+		this.payload[0] = this.recordNumber;
+		if (this.record) {
+			const date = new Date(this.record.timestamp);
+			if (!Number.isFinite(date.getTime())) {
+				throw new ZWaveError(
+					"Invalid record timestamp",
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			this.payload.writeUInt16BE(date.getFullYear(), 1);
+			this.payload[3] = date.getMonth() + 1;
+			this.payload[4] = date.getDate();
+			this.payload[5] =
+				(DoorLockLoggingRecordStatus.HoldsLegalData << 5)
+				| date.getHours();
+			this.payload[6] = date.getMinutes();
+			this.payload[7] = date.getSeconds();
+			this.payload[8] = this.record.eventType;
+			this.payload[9] = this.record.userId ?? 0;
+			this.payload[10] = code.length;
+			this.payload.set(code, 11);
+		}
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		let message: MessageRecord;
 
@@ -413,17 +455,14 @@ export class DoorLockLoggingCCRecordGet extends DoorLockLoggingCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): DoorLockLoggingCCRecordGet {
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new DoorLockLoggingCCRecordGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			recordNumber: raw.payload[0],
+		});
 	}
 
 	public recordNumber: number;

--- a/packages/cc/src/cc/EntryControlCC.test.ts
+++ b/packages/cc/src/cc/EntryControlCC.test.ts
@@ -1,0 +1,157 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { EntryControlCommand, EntryControlDataTypes } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	EntryControlCCNotification,
+	EntryControlCCKeySupportedReport,
+	EntryControlCCEventSupportedReport,
+	EntryControlCCConfigurationReport,
+	EntryControlCCConfigurationSet,
+} from "./EntryControlCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: () => {},
+};
+
+test.each([
+	{ dataType: EntryControlDataTypes.None, eventData: undefined, length: 0 },
+	{
+		dataType: EntryControlDataTypes.Raw,
+		eventData: Bytes.from([0, 255, 1]),
+		length: 3,
+	},
+	{ dataType: EntryControlDataTypes.ASCII, eventData: "1234", length: 16 },
+	{
+		dataType: EntryControlDataTypes.ASCII,
+		eventData: "1".repeat(17),
+		length: 32,
+	},
+	{
+		dataType: EntryControlDataTypes.MD5,
+		eventData: new Bytes(16).fill(1),
+		length: 16,
+	},
+])(
+	"Entry Control notifications round trip data type $dataType and length $length",
+	async ({ dataType, eventData, length }) => {
+		const cc = new EntryControlCCNotification({
+			nodeId: 2,
+			sequenceNumber: 7,
+			eventType: 2,
+			dataType,
+			eventData,
+		});
+		const bytes = await cc.serialize(ctx);
+		expect(bytes.subarray(2, 6)).toEqual(
+			Bytes.from([7, dataType, 2, length]),
+		);
+		if (dataType === EntryControlDataTypes.ASCII) {
+			expect(bytes.at(-1)).toBe(255);
+		}
+		expect(
+			EntryControlCCNotification.from(CCRaw.parse(bytes), ctx),
+		).toMatchObject({ dataType, eventData });
+	},
+);
+
+test("Entry Control capability masks round trip", async () => {
+	const keys = new EntryControlCCKeySupportedReport({
+		nodeId: 2,
+		supportedKeys: [0, 8],
+	});
+	const keyBytes = await keys.serialize(ctx);
+	expect(keyBytes.subarray(2)).toEqual(Bytes.from([2, 1, 1]));
+	expect(
+		EntryControlCCKeySupportedReport.from(CCRaw.parse(keyBytes), ctx)
+			.supportedKeys,
+	).toEqual([0, 8]);
+	const options = {
+		nodeId: 2,
+		supportedDataTypes: [0, 2],
+		supportedEventTypes: [0, 8],
+		minKeyCacheSize: 1,
+		maxKeyCacheSize: 32,
+		minKeyCacheTimeout: 1,
+		maxKeyCacheTimeout: 255,
+	};
+	const events = new EntryControlCCEventSupportedReport(options);
+	const eventBytes = await events.serialize(ctx);
+	expect(eventBytes.subarray(2)).toEqual(
+		Bytes.from([1, 5, 2, 1, 1, 1, 32, 1, 255]),
+	);
+	expect(
+		EntryControlCCEventSupportedReport.from(CCRaw.parse(eventBytes), ctx),
+	).toMatchObject(options);
+});
+
+test("Entry Control configuration round trips", async () => {
+	for (const Class of [
+		EntryControlCCConfigurationReport,
+		EntryControlCCConfigurationSet,
+	]) {
+		const cc = new Class({
+			nodeId: 2,
+			keyCacheSize: 32,
+			keyCacheTimeout: 255,
+		});
+		const bytes = await cc.serialize(ctx);
+		expect(bytes.subarray(2)).toEqual(Bytes.from([32, 255]));
+		expect(Class.from(CCRaw.parse(bytes), ctx)).toMatchObject({
+			keyCacheSize: 32,
+			keyCacheTimeout: 255,
+		});
+	}
+});
+
+test.each([[], [1], [0, 1], [33, 1]].map((payload) => ({ payload })))(
+	"Entry Control configuration rejects $payload",
+	({ payload }) => {
+		expect(() =>
+			EntryControlCCConfigurationSet.from(
+				new CCRaw(
+					CommandClasses["Entry Control"],
+					EntryControlCommand.ConfigurationSet,
+					Bytes.from(payload),
+				),
+				ctx,
+			),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	},
+);
+
+test("Entry Control rejects truncated event data", () => {
+	expect(() =>
+		EntryControlCCNotification.from(
+			new CCRaw(
+				CommandClasses["Entry Control"],
+				EntryControlCommand.Notification,
+				Bytes.from([1, 1, 1, 2, 0]),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/EntryControlCC.ts
+++ b/packages/cc/src/cc/EntryControlCC.ts
@@ -11,6 +11,7 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 	getCCName,
+	encodeBitMask,
 	parseBitMask,
 	supervisedCommandSucceeded,
 	validatePayload,
@@ -477,6 +478,40 @@ export class EntryControlCCNotification extends EntryControlCC {
 	public readonly eventType: EntryControlEventTypes;
 	public readonly eventData?: BytesView | string;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		let data =
+			typeof this.eventData === "string"
+				? Bytes.from(this.eventData, "ascii")
+				: Bytes.from(this.eventData ?? []);
+		if (
+			data.length > 32
+			|| (this.dataType === EntryControlDataTypes.MD5
+				&& data.length !== 16)
+		) {
+			throw new ZWaveError(
+				"Invalid event data length",
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		if (this.dataType === EntryControlDataTypes.ASCII && data.length > 0) {
+			const padded = new Bytes(Math.ceil(data.length / 16) * 16).fill(
+				0xff,
+			);
+			padded.set(data);
+			data = padded;
+		}
+		this.payload = Bytes.concat([
+			[
+				this.sequenceNumber,
+				this.dataType & 0b11,
+				this.eventType,
+				data.length,
+			],
+			data,
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {
 			"sequence number": this.sequenceNumber,
@@ -541,6 +576,12 @@ export class EntryControlCCKeySupportedReport extends EntryControlCC {
 	}
 
 	public readonly supportedKeys: readonly number[];
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const mask = encodeBitMask(this.supportedKeys, undefined, 0);
+		this.payload = Bytes.concat([[mask.length], mask]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
@@ -658,6 +699,32 @@ export class EntryControlCCEventSupportedReport extends EntryControlCC {
 	public readonly minKeyCacheTimeout: number;
 	public readonly maxKeyCacheTimeout: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const dataTypes = encodeBitMask(
+			this.supportedDataTypes,
+			undefined,
+			EntryControlDataTypes.None,
+		);
+		const eventTypes = encodeBitMask(
+			this.supportedEventTypes,
+			undefined,
+			EntryControlEventTypes.Caching,
+		);
+		this.payload = Bytes.concat([
+			[dataTypes.length],
+			dataTypes,
+			[eventTypes.length],
+			eventTypes,
+			[
+				this.minKeyCacheSize,
+				this.maxKeyCacheSize,
+				this.minKeyCacheTimeout,
+				this.maxKeyCacheTimeout,
+			],
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -721,6 +788,11 @@ export class EntryControlCCConfigurationReport extends EntryControlCC {
 
 	public readonly keyCacheTimeout: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([this.keyCacheSize, this.keyCacheTimeout]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -754,18 +826,17 @@ export class EntryControlCCConfigurationSet extends EntryControlCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): EntryControlCCConfigurationSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new EntryControlCCConfigurationSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 2);
+		const keyCacheSize = raw.payload[0];
+		validatePayload(keyCacheSize >= 1 && keyCacheSize <= 32);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			keyCacheSize,
+			keyCacheTimeout: raw.payload[1],
+		});
 	}
 
 	public readonly keyCacheSize: number;

--- a/packages/cc/src/cc/FirmwareUpdateMetaDataCC.test.ts
+++ b/packages/cc/src/cc/FirmwareUpdateMetaDataCC.test.ts
@@ -1,0 +1,112 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { FirmwareUpdateMetaDataCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import { FirmwareUpdateMetaDataCCReport } from "./FirmwareUpdateMetaDataCC.js";
+
+const parsingContext: CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: () => {},
+};
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	...parsingContext,
+	getSupportedCCVersion: () => 2,
+};
+
+test("Firmware V1 fragments preserve checksum-shaped firmware bytes", async () => {
+	const v1Context = { ...ctx, getSupportedCCVersion: () => 1 };
+	const options = {
+		nodeId: 2,
+		isLast: true,
+		reportNumber: 1,
+		firmwareData: Bytes.from([0, 1, 2, 3]),
+	};
+	const cc = new FirmwareUpdateMetaDataCCReport(options);
+	const bytes = await cc.serialize(v1Context);
+	expect(bytes.subarray(2)).toEqual(Bytes.from([0x80, 1, 0, 1, 2, 3]));
+	expect(
+		FirmwareUpdateMetaDataCCReport.from(CCRaw.parse(bytes), v1Context),
+	).toMatchObject(options);
+});
+
+test("Firmware parsing defaults to checksum validation without version information", async () => {
+	const cc = new FirmwareUpdateMetaDataCCReport({
+		nodeId: 2,
+		isLast: true,
+		reportNumber: 1,
+		firmwareData: Bytes.from([7]),
+	});
+	const raw = CCRaw.parse(await cc.serialize(ctx));
+	expect(
+		FirmwareUpdateMetaDataCCReport.from(raw, parsingContext).firmwareData,
+	).toEqual(Bytes.from([7]));
+	raw.payload[2] ^= 1;
+	expect(() =>
+		FirmwareUpdateMetaDataCCReport.from(raw, parsingContext),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});
+
+test.each([false, true])(
+	"Firmware fragments round trip with last=%s",
+	async (isLast) => {
+		const options = {
+			nodeId: 2,
+			isLast,
+			reportNumber: 0x1234,
+			firmwareData: Bytes.from([0, 1, 255, 128]),
+		};
+		const cc = new FirmwareUpdateMetaDataCCReport(options);
+		const bytes = await cc.serialize(ctx);
+		expect(bytes.subarray(2, -2)).toEqual(
+			Bytes.from([isLast ? 0x92 : 0x12, 0x34, 0, 1, 255, 128]),
+		);
+		expect(
+			FirmwareUpdateMetaDataCCReport.from(CCRaw.parse(bytes), ctx),
+		).toMatchObject(options);
+		bytes[4] ^= 1;
+		expect(() =>
+			FirmwareUpdateMetaDataCCReport.from(CCRaw.parse(bytes), ctx),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	},
+);
+
+test.each(
+	[[], [0], [0, 1], [0, 1, 0], [0, 1, 0, 0]].map((payload) => ({ payload })),
+)("Firmware fragment rejects short payload $payload", ({ payload }) => {
+	expect(() =>
+		FirmwareUpdateMetaDataCCReport.from(
+			new CCRaw(
+				CommandClasses["Firmware Update Meta Data"],
+				FirmwareUpdateMetaDataCommand.Report,
+				Bytes.from(payload),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/FirmwareUpdateMetaDataCC.ts
+++ b/packages/cc/src/cc/FirmwareUpdateMetaDataCC.ts
@@ -1,14 +1,13 @@
 import {
 	CRC16_CCITT,
 	CommandClasses,
+	type GetSupportedCCVersion,
 	type GetValueDB,
 	type MaybeNotKnown,
 	type MessageOrCCLogEntry,
 	MessagePriority,
 	type MessageRecord,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
 	validatePayload,
 } from "@zwave-js/core";
 import {
@@ -870,18 +869,34 @@ export class FirmwareUpdateMetaDataCCReport extends FirmwareUpdateMetaDataCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext & Partial<GetSupportedCCVersion>,
 	): FirmwareUpdateMetaDataCCReport {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new FirmwareUpdateMetaDataCCReport({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		// V1 fragments omit the checksum. Unknown versions use the V2+ format
+		const version = ctx.getSupportedCCVersion?.(raw.ccId, ctx.sourceNodeId);
+		const hasChecksum = version !== 1;
+		validatePayload(raw.payload.length >= (hasChecksum ? 5 : 3));
+		const data = hasChecksum ? raw.payload.subarray(0, -2) : raw.payload;
+		if (hasChecksum) {
+			let crc = CRC16_CCITT(
+				Bytes.from([
+					CommandClasses["Firmware Update Meta Data"],
+					FirmwareUpdateMetaDataCommand.Report,
+				]),
+			);
+			crc = CRC16_CCITT(data, crc);
+			validatePayload(
+				crc === raw.payload.readUInt16BE(raw.payload.length - 2),
+			);
+		}
+		const reportNumber = data.readUInt16BE(0) & 0x7fff;
+		validatePayload(reportNumber > 0);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			reportNumber,
+			isLast: !!(data[0] & 0x80),
+			firmwareData: data.subarray(2),
+		});
 	}
 
 	public isLast: boolean;

--- a/packages/cc/src/cc/HumidityControlModeCC.test.ts
+++ b/packages/cc/src/cc/HumidityControlModeCC.test.ts
@@ -1,0 +1,80 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { HumidityControlModeCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	HumidityControlModeCCReport,
+	HumidityControlModeCCSet,
+	HumidityControlModeCCSupportedReport,
+} from "./HumidityControlModeCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const ccId = CommandClasses["Humidity Control Mode"];
+
+test("Humidity mode codecs mask reserved bits", async () => {
+	const set = HumidityControlModeCCSet.from(
+		new CCRaw(ccId, HumidityControlModeCommand.Set, Bytes.from([0xf2])),
+		ctx,
+	);
+	expect(set.mode).toBe(2);
+	expect(await set.serialize(ctx)).toEqual(Bytes.from([ccId, 1, 2]));
+	const report = new HumidityControlModeCCReport({
+		nodeId: 2,
+		mode: set.mode,
+	});
+	expect(await report.serialize(ctx)).toEqual(Bytes.from([ccId, 3, 2]));
+	expect(
+		HumidityControlModeCCReport.from(
+			new CCRaw(ccId, HumidityControlModeCommand.Report, Bytes.from([2])),
+			ctx,
+		).mode,
+	).toBe(2);
+});
+
+test("Humidity supported modes encode zero-based bits", async () => {
+	const report = new HumidityControlModeCCSupportedReport({
+		nodeId: 2,
+		supportedModes: [0, 2, 3],
+	});
+	expect(await report.serialize(ctx)).toEqual(Bytes.from([ccId, 5, 0x0d]));
+	expect(
+		HumidityControlModeCCSupportedReport.from(
+			new CCRaw(
+				ccId,
+				HumidityControlModeCommand.SupportedReport,
+				Bytes.from([0x0d]),
+			),
+			ctx,
+		).supportedModes,
+	).toEqual([0, 2, 3]);
+});
+
+test("Humidity mode Set rejects an empty payload", () => {
+	expect(() =>
+		HumidityControlModeCCSet.from(
+			new CCRaw(ccId, HumidityControlModeCommand.Set, Bytes.from([])),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/HumidityControlModeCC.ts
+++ b/packages/cc/src/cc/HumidityControlModeCC.ts
@@ -7,8 +7,7 @@ import {
 	type SupervisionResult,
 	ValueMetadata,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
+	encodeBitMask,
 	enumValuesToMetadataStates,
 	logList,
 	logText,
@@ -288,18 +287,14 @@ export class HumidityControlModeCCSet extends HumidityControlModeCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): HumidityControlModeCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new HumidityControlModeCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			mode: raw.payload[0] & 0b1111,
+		});
 	}
 
 	public mode: HumidityControlMode;
@@ -350,6 +345,11 @@ export class HumidityControlModeCCReport extends HumidityControlModeCC {
 	}
 
 	public readonly mode: HumidityControlMode;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([this.mode & 0b1111]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
@@ -418,6 +418,15 @@ export class HumidityControlModeCCSupportedReport extends HumidityControlModeCC 
 	}
 
 	public supportedModes: HumidityControlMode[];
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = encodeBitMask(
+			this.supportedModes,
+			undefined,
+			HumidityControlMode.Off,
+		);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {

--- a/packages/cc/src/cc/HumidityControlOperatingStateCC.test.ts
+++ b/packages/cc/src/cc/HumidityControlOperatingStateCC.test.ts
@@ -1,0 +1,55 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { HumidityControlOperatingStateCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import { HumidityControlOperatingStateCCReport } from "./HumidityControlOperatingStateCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const ccId = CommandClasses["Humidity Control Operating State"];
+
+test("Humidity operating state roundtrips with reserved bits cleared", async () => {
+	const report = HumidityControlOperatingStateCCReport.from(
+		new CCRaw(
+			ccId,
+			HumidityControlOperatingStateCommand.Report,
+			Bytes.from([0xf2]),
+		),
+		ctx,
+	);
+	expect(report.state).toBe(2);
+	expect(await report.serialize(ctx)).toEqual(Bytes.from([ccId, 2, 2]));
+});
+
+test("Humidity operating state rejects an empty payload", () => {
+	expect(() =>
+		HumidityControlOperatingStateCCReport.from(
+			new CCRaw(
+				ccId,
+				HumidityControlOperatingStateCommand.Report,
+				Bytes.from([]),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/HumidityControlOperatingStateCC.ts
+++ b/packages/cc/src/cc/HumidityControlOperatingStateCC.ts
@@ -9,7 +9,7 @@ import {
 	enumValuesToMetadataStates,
 	validatePayload,
 } from "@zwave-js/core";
-import { getEnumMemberName } from "@zwave-js/shared";
+import { Bytes, getEnumMemberName } from "@zwave-js/shared";
 
 import {
 	CCAPI,
@@ -38,7 +38,7 @@ import {
 	HumidityControlOperatingState,
 	HumidityControlOperatingStateCommand,
 } from "../lib/_Types.js";
-import type { CCParsingContext } from "../lib/traits.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
 
 export const HumidityControlOperatingStateCCValues = V.defineCCValues(
 	CommandClasses["Humidity Control Operating State"],
@@ -188,6 +188,11 @@ export class HumidityControlOperatingStateCCReport extends HumidityControlOperat
 	}
 
 	public readonly state: HumidityControlOperatingState;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([this.state & 0b1111]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {

--- a/packages/cc/src/cc/HumidityControlSetpointCC.test.ts
+++ b/packages/cc/src/cc/HumidityControlSetpointCC.test.ts
@@ -1,0 +1,176 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { HumidityControlSetpointCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	HumidityControlSetpointCCCapabilitiesGet,
+	HumidityControlSetpointCCCapabilitiesReport,
+	HumidityControlSetpointCCGet,
+	HumidityControlSetpointCCReport,
+	HumidityControlSetpointCCScaleSupportedGet,
+	HumidityControlSetpointCCScaleSupportedReport,
+	HumidityControlSetpointCCSet,
+	HumidityControlSetpointCCSupportedReport,
+} from "./HumidityControlSetpointCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 2,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const ccId = CommandClasses["Humidity Control Setpoint"];
+const raw = (
+	command: HumidityControlSetpointCommand,
+	payload: readonly number[],
+) => new CCRaw(ccId, command, Bytes.from(payload));
+
+test("Humidity setpoints preserve signed floats and scale", async () => {
+	const payload = [1, 0x29, 0xf1];
+	const set = HumidityControlSetpointCCSet.from(
+		raw(HumidityControlSetpointCommand.Set, [0xf1, ...payload.slice(1)]),
+		ctx,
+	);
+	expect(set).toMatchObject({ setpointType: 1, value: -1.5, scale: 1 });
+	expect(await set.serialize(ctx)).toEqual(Bytes.from([ccId, 1, ...payload]));
+	const report = new HumidityControlSetpointCCReport({
+		nodeId: 2,
+		type: 1,
+		value: -1.5,
+		scale: 1,
+	});
+	expect(await report.serialize(ctx)).toEqual(
+		Bytes.from([ccId, 3, ...payload]),
+	);
+	expect(
+		HumidityControlSetpointCCReport.from(
+			raw(HumidityControlSetpointCommand.Report, payload),
+			ctx,
+		),
+	).toMatchObject({ type: 1, value: -1.5, scale: 1 });
+});
+
+test("Humidity capabilities encode independent minimum and maximum scales", async () => {
+	const options = {
+		nodeId: 2,
+		type: 1,
+		minValue: -1.5,
+		minValueScale: 1,
+		maxValue: 60,
+		maxValueScale: 0,
+	};
+	const report = new HumidityControlSetpointCCCapabilitiesReport(options);
+	const payload = [1, 0x29, 0xf1, 1, 60];
+	expect(await report.serialize(ctx)).toEqual(
+		Bytes.from([
+			ccId,
+			HumidityControlSetpointCommand.CapabilitiesReport,
+			...payload,
+		]),
+	);
+	expect(
+		HumidityControlSetpointCCCapabilitiesReport.from(
+			raw(HumidityControlSetpointCommand.CapabilitiesReport, payload),
+			ctx,
+		),
+	).toMatchObject(options);
+});
+
+test("Humidity supported reports encode zero-based masks", async () => {
+	const types = new HumidityControlSetpointCCSupportedReport({
+		nodeId: 2,
+		supportedSetpointTypes: [1, 3],
+	});
+	expect(await types.serialize(ctx)).toEqual(
+		Bytes.from([ccId, HumidityControlSetpointCommand.SupportedReport, 10]),
+	);
+	expect(
+		HumidityControlSetpointCCSupportedReport.from(
+			raw(HumidityControlSetpointCommand.SupportedReport, [10]),
+			ctx,
+		).supportedSetpointTypes,
+	).toEqual([1, 3]);
+	const scales = new HumidityControlSetpointCCScaleSupportedReport({
+		nodeId: 2,
+		supportedScales: [0, 1, 3],
+	});
+	expect(await scales.serialize(ctx)).toEqual(
+		Bytes.from([
+			ccId,
+			HumidityControlSetpointCommand.ScaleSupportedReport,
+			11,
+		]),
+	);
+	expect(
+		HumidityControlSetpointCCScaleSupportedReport.from(
+			raw(HumidityControlSetpointCommand.ScaleSupportedReport, [0xfb]),
+			ctx,
+		).supportedScales,
+	).toEqual([0, 1, 3]);
+});
+
+test("Humidity Get codecs mask reserved bits and reject empty payloads", async () => {
+	for (const [ctor, command] of [
+		[HumidityControlSetpointCCGet, HumidityControlSetpointCommand.Get],
+		[
+			HumidityControlSetpointCCScaleSupportedGet,
+			HumidityControlSetpointCommand.ScaleSupportedGet,
+		],
+		[
+			HumidityControlSetpointCCCapabilitiesGet,
+			HumidityControlSetpointCommand.CapabilitiesGet,
+		],
+	] as const) {
+		const get = ctor.from(raw(command, [0xf1]), ctx);
+		expect(get.setpointType).toBe(1);
+		expect(await get.serialize(ctx)).toEqual(
+			Bytes.from([ccId, command, 1]),
+		);
+		expect(() => ctor.from(raw(command, []), ctx)).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	}
+});
+
+test.each([{ payload: [] }, { payload: [1] }, { payload: [1, 2, 0] }])(
+	"Humidity Set rejects truncated floats %j",
+	({ payload }) => {
+		expect(() =>
+			HumidityControlSetpointCCSet.from(
+				raw(HumidityControlSetpointCommand.Set, payload),
+				ctx,
+			),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	},
+);
+
+test("Humidity capabilities reject a missing maximum", () => {
+	expect(() =>
+		HumidityControlSetpointCCCapabilitiesReport.from(
+			raw(HumidityControlSetpointCommand.CapabilitiesReport, [1, 1, 0]),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/HumidityControlSetpointCC.ts
+++ b/packages/cc/src/cc/HumidityControlSetpointCC.ts
@@ -11,6 +11,7 @@ import {
 	type WithAddress,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeBitMask,
 	encodeFloatWithScale,
 	getNamedScale,
 	getUnknownScale,
@@ -529,18 +530,17 @@ export class HumidityControlSetpointCCSet extends HumidityControlSetpointCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): HumidityControlSetpointCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new HumidityControlSetpointCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		const { value, scale } = parseFloatWithScale(raw.payload.subarray(1));
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			setpointType: raw.payload[0] & 0b1111,
+			value,
+			scale,
+		});
 	}
 
 	public setpointType: HumidityControlSetpointType;
@@ -654,6 +654,14 @@ export class HumidityControlSetpointCCReport extends HumidityControlSetpointCC {
 	public scale: number;
 	public value: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.concat([
+			[this.type & 0b1111],
+			encodeFloatWithScale(this.value, this.scale),
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const scale = getScale(this.scale);
 		return {
@@ -696,18 +704,14 @@ export class HumidityControlSetpointCCGet extends HumidityControlSetpointCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): HumidityControlSetpointCCGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new HumidityControlSetpointCCGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			setpointType: raw.payload[0] & 0b1111,
+		});
 	}
 
 	public setpointType: HumidityControlSetpointType;
@@ -766,6 +770,15 @@ export class HumidityControlSetpointCCSupportedReport extends HumidityControlSet
 
 	public readonly supportedSetpointTypes: readonly HumidityControlSetpointType[];
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = encodeBitMask(
+			this.supportedSetpointTypes,
+			undefined,
+			HumidityControlSetpointType["N/A"],
+		);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -818,6 +831,11 @@ export class HumidityControlSetpointCCScaleSupportedReport extends HumidityContr
 
 	public readonly supportedScales: readonly number[];
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = encodeBitMask(this.supportedScales, 3, 0);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const supportedScales = this.supportedScales.map((scale) =>
 			getScale(scale),
@@ -851,18 +869,14 @@ export class HumidityControlSetpointCCScaleSupportedGet extends HumidityControlS
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): HumidityControlSetpointCCScaleSupportedGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new HumidityControlSetpointCCScaleSupportedGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			setpointType: raw.payload[0] & 0b1111,
+		});
 	}
 
 	public setpointType: HumidityControlSetpointType;
@@ -960,6 +974,15 @@ export class HumidityControlSetpointCCCapabilitiesReport extends HumidityControl
 	public minValueScale: number;
 	public maxValueScale: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.concat([
+			[this.type & 0b1111],
+			encodeFloatWithScale(this.minValue, this.minValueScale),
+			encodeFloatWithScale(this.maxValue, this.maxValueScale),
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const minValueScale = getScale(this.minValueScale);
 		const maxValueScale = getScale(this.maxValueScale);
@@ -993,18 +1016,14 @@ export class HumidityControlSetpointCCCapabilitiesGet extends HumidityControlSet
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): HumidityControlSetpointCCCapabilitiesGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new HumidityControlSetpointCCCapabilitiesGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			setpointType: raw.payload[0] & 0b1111,
+		});
 	}
 
 	public setpointType: HumidityControlSetpointType;

--- a/packages/cc/src/cc/IrrigationCC.test.ts
+++ b/packages/cc/src/cc/IrrigationCC.test.ts
@@ -1,0 +1,310 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw, type CommandClass } from "../lib/CommandClass.js";
+import { IrrigationCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	IrrigationCCSystemConfigReport,
+	IrrigationCCSystemConfigSet,
+	IrrigationCCSystemInfoReport,
+	IrrigationCCSystemShutoff,
+	IrrigationCCSystemStatusReport,
+	IrrigationCCValveConfigGet,
+	IrrigationCCValveConfigReport,
+	IrrigationCCValveConfigSet,
+	IrrigationCCValveInfoGet,
+	IrrigationCCValveInfoReport,
+	IrrigationCCValveRun,
+	IrrigationCCValveTableGet,
+	IrrigationCCValveTableReport,
+	IrrigationCCValveTableRun,
+	IrrigationCCValveTableSet,
+} from "./IrrigationCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+
+const systemConfig = {
+	nodeId: 2,
+	masterValveDelay: 255,
+	highPressureThreshold: 123.5,
+	lowPressureThreshold: 0,
+	rainSensorPolarity: 0,
+	moistureSensorPolarity: 1,
+};
+const valveConfig = {
+	nodeId: 2,
+	valveId: "master" as const,
+	nominalCurrentHighThreshold: 2550,
+	nominalCurrentLowThreshold: 0,
+	maximumFlow: 1000,
+	highFlowThreshold: 123.5,
+	lowFlowThreshold: 0,
+	useRainSensor: true,
+	useMoistureSensor: false,
+};
+const table = {
+	nodeId: 2,
+	tableId: 255,
+	entries: [
+		{ valveId: 1, duration: 0 },
+		{ valveId: 255, duration: 65535 },
+	],
+};
+
+const cases: {
+	cc: CommandClass;
+	parse: (raw: CCRaw, ctx: CCParsingContext) => CommandClass;
+	expected: object;
+}[] = [
+	{
+		cc: new IrrigationCCSystemConfigSet(systemConfig),
+		parse: IrrigationCCSystemConfigSet.from.bind(
+			IrrigationCCSystemConfigSet,
+		),
+		expected: systemConfig,
+	},
+	{
+		cc: new IrrigationCCSystemConfigReport(systemConfig),
+		parse: IrrigationCCSystemConfigReport.from.bind(
+			IrrigationCCSystemConfigReport,
+		),
+		expected: systemConfig,
+	},
+	{
+		cc: new IrrigationCCValveConfigSet(valveConfig),
+		parse: IrrigationCCValveConfigSet.from.bind(IrrigationCCValveConfigSet),
+		expected: valveConfig,
+	},
+	{
+		cc: new IrrigationCCValveConfigReport(valveConfig),
+		parse: IrrigationCCValveConfigReport.from.bind(
+			IrrigationCCValveConfigReport,
+		),
+		expected: valveConfig,
+	},
+	{
+		cc: new IrrigationCCValveTableSet(table),
+		parse: IrrigationCCValveTableSet.from.bind(IrrigationCCValveTableSet),
+		expected: table,
+	},
+	{
+		cc: new IrrigationCCValveTableReport(table),
+		parse: IrrigationCCValveTableReport.from.bind(
+			IrrigationCCValveTableReport,
+		),
+		expected: table,
+	},
+	{
+		cc: new IrrigationCCValveInfoGet({ nodeId: 2, valveId: "master" }),
+		parse: IrrigationCCValveInfoGet.from.bind(IrrigationCCValveInfoGet),
+		expected: { valveId: "master" },
+	},
+	{
+		cc: new IrrigationCCValveConfigGet({ nodeId: 2, valveId: 255 }),
+		parse: IrrigationCCValveConfigGet.from.bind(IrrigationCCValveConfigGet),
+		expected: { valveId: 255 },
+	},
+	{
+		cc: new IrrigationCCValveRun({
+			nodeId: 2,
+			valveId: 255,
+			duration: 65535,
+		}),
+		parse: IrrigationCCValveRun.from.bind(IrrigationCCValveRun),
+		expected: { valveId: 255, duration: 65535 },
+	},
+	{
+		cc: new IrrigationCCValveTableGet({ nodeId: 2, tableId: 255 }),
+		parse: IrrigationCCValveTableGet.from.bind(IrrigationCCValveTableGet),
+		expected: { tableId: 255 },
+	},
+	{
+		cc: new IrrigationCCValveTableRun({ nodeId: 2, tableIDs: [0, 1, 255] }),
+		parse: IrrigationCCValveTableRun.from.bind(IrrigationCCValveTableRun),
+		expected: { tableIDs: [0, 1, 255] },
+	},
+	{
+		cc: new IrrigationCCSystemShutoff({ nodeId: 2 }),
+		parse: IrrigationCCSystemShutoff.from.bind(IrrigationCCSystemShutoff),
+		expected: { duration: 255 },
+	},
+];
+
+for (const { cc, parse, expected } of cases) {
+	test(`${cc.constructor.name} roundtrips`, async () => {
+		const serialized = await cc.serialize(ctx);
+		const parsed = parse(CCRaw.parse(serialized), ctx);
+		expect(parsed).toMatchObject(expected);
+		expect(await parsed.serialize(ctx)).toEqual(serialized);
+	});
+
+	test(`${cc.constructor.name} rejects truncated payloads`, async () => {
+		const raw = CCRaw.parse(await cc.serialize(ctx));
+		const minimumLength =
+			cc instanceof IrrigationCCValveTableRun ? 1 : raw.payload.length;
+		for (let length = 0; length < minimumLength; length++) {
+			if (
+				(cc instanceof IrrigationCCValveTableSet
+					|| cc instanceof IrrigationCCValveTableReport)
+				&& length >= 1
+				&& (length - 1) % 3 === 0
+			)
+				continue;
+			expect(() =>
+				parse(
+					new CCRaw(
+						raw.ccId,
+						raw.ccCommand,
+						raw.payload.subarray(0, length),
+					),
+					ctx,
+				),
+			).toThrow(
+				expect.objectContaining({
+					code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+				}),
+			);
+		}
+	});
+}
+
+test("System Info Report serializes capability fields", async () => {
+	const options = {
+		nodeId: 2,
+		supportsMasterValve: true,
+		numValves: 255,
+		numValveTables: 255,
+		maxValveTableSize: 15,
+	};
+	const bytes = await new IrrigationCCSystemInfoReport(options).serialize(
+		ctx,
+	);
+	expect([...bytes.subarray(2)]).toEqual([1, 255, 255, 15]);
+	expect(
+		IrrigationCCSystemInfoReport.from(CCRaw.parse(bytes), ctx),
+	).toMatchObject(options);
+});
+
+test.each([true, false])(
+	"System Status Report roundtrips active sensors: %s",
+	async (active) => {
+		const options = {
+			nodeId: 2,
+			systemVoltage: 24,
+			flowSensorActive: active,
+			pressureSensorActive: active,
+			rainSensorActive: true,
+			moistureSensorActive: false,
+			flow: active ? 123.5 : undefined,
+			pressure: active ? 400 : undefined,
+			shutoffDuration: 255,
+			errorNotProgrammed: true,
+			errorEmergencyShutdown: false,
+			errorHighPressure: true,
+			errorLowPressure: false,
+			errorValve: true,
+			masterValveOpen: active,
+			firstOpenZoneId: active ? 255 : undefined,
+		};
+		const bytes = await new IrrigationCCSystemStatusReport(
+			options,
+		).serialize(ctx);
+		expect(
+			IrrigationCCSystemStatusReport.from(CCRaw.parse(bytes), ctx),
+		).toMatchObject(options);
+		expect(bytes[3]).toBe(active ? 7 : 4);
+	},
+);
+
+test.each(["master", 255] as const)(
+	"Valve Info Report roundtrips %s valve",
+	async (valveId) => {
+		const options = {
+			nodeId: 2,
+			valveId,
+			connected: true,
+			nominalCurrent: 2550,
+			errorShortCircuit: true,
+			errorHighCurrent: false,
+			errorLowCurrent: true,
+			errorMaximumFlow: valveId === "master" ? true : undefined,
+			errorHighFlow: valveId === "master" ? false : undefined,
+			errorLowFlow: valveId === "master" ? true : undefined,
+		};
+		const bytes = await new IrrigationCCValveInfoReport(options).serialize(
+			ctx,
+		);
+		expect([...bytes.subarray(2)]).toEqual(
+			valveId === "master" ? [3, 1, 255, 45] : [2, 255, 255, 5],
+		);
+		expect(
+			IrrigationCCValveInfoReport.from(CCRaw.parse(bytes), ctx),
+		).toMatchObject(options);
+	},
+);
+
+test("System Config encodes polarity values and validity", async () => {
+	for (const ctor of [
+		IrrigationCCSystemConfigSet,
+		IrrigationCCSystemConfigReport,
+	]) {
+		expect((await new ctor(systemConfig).serialize(ctx)).at(-1)).toBe(0x82);
+		const bytes = await new ctor({
+			...systemConfig,
+			rainSensorPolarity: undefined,
+			moistureSensorPolarity: undefined,
+		}).serialize(ctx);
+		expect(bytes.at(-1)).toBe(0);
+		expect(
+			IrrigationCCSystemConfigSet.from(CCRaw.parse(bytes), ctx),
+		).toMatchObject({
+			rainSensorPolarity: undefined,
+			moistureSensorPolarity: undefined,
+		});
+	}
+});
+
+test("Config commands reject unsupported float scales", async () => {
+	for (const { cc, parse } of cases.slice(0, 4)) {
+		const raw = CCRaw.parse(await cc.serialize(ctx));
+		raw.payload[
+			cc instanceof IrrigationCCSystemConfigSet
+			|| cc instanceof IrrigationCCSystemConfigReport
+				? 1
+				: 4
+		] |= 0x08;
+		expect(() => parse(raw, ctx)).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	}
+});
+
+test("Valve Table Set supports empty tables", () => {
+	const cc = IrrigationCCValveTableSet.from(
+		new CCRaw(
+			CommandClasses.Irrigation,
+			IrrigationCommand.ValveTableSet,
+			Bytes.from([1]),
+		),
+		ctx,
+	);
+	expect(cc.entries).toEqual([]);
+});

--- a/packages/cc/src/cc/IrrigationCC.ts
+++ b/packages/cc/src/cc/IrrigationCC.ts
@@ -1254,6 +1254,16 @@ export class IrrigationCCSystemInfoReport extends IrrigationCC {
 
 	public readonly maxValveTableSize: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([
+			this.supportsMasterValve ? 1 : 0,
+			this.numValves,
+			this.numValveTables,
+			this.maxValveTableSize & 0b1111,
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -1433,6 +1443,31 @@ export class IrrigationCCSystemStatusReport extends IrrigationCC {
 
 	public firstOpenZoneId?: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.concat([
+			[
+				this.systemVoltage,
+				(this.flowSensorActive ? 1 : 0)
+					| (this.pressureSensorActive ? 2 : 0)
+					| (this.rainSensorActive ? 4 : 0)
+					| (this.moistureSensorActive ? 8 : 0),
+			],
+			encodeFloatWithScale(this.flow ?? 0, 0),
+			encodeFloatWithScale(this.pressure ?? 0, 0),
+			[
+				this.shutoffDuration,
+				(this.errorNotProgrammed ? 1 : 0)
+					| (this.errorEmergencyShutdown ? 2 : 0)
+					| (this.errorHighPressure ? 4 : 0)
+					| (this.errorLowPressure ? 8 : 0)
+					| (this.errorValve ? 16 : 0),
+				this.masterValveOpen ? 1 : 0,
+				this.firstOpenZoneId ?? 0,
+			],
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {
 			"system voltage": `${this.systemVoltage} V`,
@@ -1508,18 +1543,20 @@ export class IrrigationCCSystemConfigSet extends IrrigationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): IrrigationCCSystemConfigSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new IrrigationCCSystemConfigSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		const report = IrrigationCCSystemConfigReport.from(raw, ctx);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			...pick(report, [
+				"masterValveDelay",
+				"highPressureThreshold",
+				"lowPressureThreshold",
+				"rainSensorPolarity",
+				"moistureSensorPolarity",
+			]),
+		});
 	}
 
 	public masterValveDelay: number;
@@ -1530,11 +1567,11 @@ export class IrrigationCCSystemConfigSet extends IrrigationCC {
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		let polarity = 0;
-		if (this.rainSensorPolarity != undefined) polarity |= 0b1;
-		if (this.moistureSensorPolarity != undefined) polarity |= 0b10;
+		polarity |= (this.rainSensorPolarity ?? 0) & 0b1;
+		polarity |= ((this.moistureSensorPolarity ?? 0) & 0b1) << 1;
 		if (
-			this.rainSensorPolarity == undefined
-			&& this.moistureSensorPolarity == undefined
+			this.rainSensorPolarity != undefined
+			|| this.moistureSensorPolarity != undefined
 		) {
 			// Valid bit
 			polarity |= 0b1000_0000;
@@ -1668,6 +1705,23 @@ export class IrrigationCCSystemConfigReport extends IrrigationCC {
 
 	public readonly moistureSensorPolarity?: IrrigationSensorPolarity;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const polarity =
+			(this.rainSensorPolarity ?? 0)
+			| ((this.moistureSensorPolarity ?? 0) << 1)
+			| (this.rainSensorPolarity != undefined
+			|| this.moistureSensorPolarity != undefined
+				? 0b1000_0000
+				: 0);
+		this.payload = Bytes.concat([
+			[this.masterValveDelay],
+			encodeFloatWithScale(this.highPressureThreshold, 0),
+			encodeFloatWithScale(this.lowPressureThreshold, 0),
+			[polarity],
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {
 			"master valve delay": `${this.masterValveDelay} s`,
@@ -1779,6 +1833,23 @@ export class IrrigationCCValveInfoReport extends IrrigationCC {
 	public readonly errorMaximumFlow?: boolean;
 	public readonly errorHighFlow?: boolean;
 	public readonly errorLowFlow?: boolean;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([
+			(this.valveId === "master" ? 1 : 0) | (this.connected ? 2 : 0),
+			this.valveId === "master" ? 1 : this.valveId,
+			Math.floor(this.nominalCurrent / 10),
+			(this.errorShortCircuit ? 1 : 0)
+				| (this.errorHighCurrent ? 2 : 0)
+				| (this.errorLowCurrent ? 4 : 0)
+				| (this.valveId === "master"
+					? (this.errorMaximumFlow ? 8 : 0)
+						| (this.errorHighFlow ? 16 : 0)
+						| (this.errorLowFlow ? 32 : 0)
+					: 0),
+		]);
+		return super.serialize(ctx);
+	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;
@@ -1897,18 +1968,14 @@ export class IrrigationCCValveInfoGet extends IrrigationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): IrrigationCCValveInfoGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new IrrigationCCValveInfoGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 2);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			valveId: raw.payload[0] & 1 ? "master" : raw.payload[1],
+		});
 	}
 
 	public valveId: ValveId;
@@ -1961,18 +2028,23 @@ export class IrrigationCCValveConfigSet extends IrrigationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): IrrigationCCValveConfigSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new IrrigationCCValveConfigSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		const report = IrrigationCCValveConfigReport.from(raw, ctx);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			...pick(report, [
+				"valveId",
+				"nominalCurrentHighThreshold",
+				"nominalCurrentLowThreshold",
+				"maximumFlow",
+				"highFlowThreshold",
+				"lowFlowThreshold",
+				"useRainSensor",
+				"useMoistureSensor",
+			]),
+		});
 	}
 
 	public valveId: ValveId;
@@ -2180,6 +2252,22 @@ export class IrrigationCCValveConfigReport extends IrrigationCC {
 	public useRainSensor: boolean;
 	public useMoistureSensor: boolean;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.concat([
+			[
+				this.valveId === "master" ? 1 : 0,
+				this.valveId === "master" ? 1 : this.valveId,
+				Math.floor(this.nominalCurrentHighThreshold / 10),
+				Math.floor(this.nominalCurrentLowThreshold / 10),
+			],
+			encodeFloatWithScale(this.maximumFlow, 0),
+			encodeFloatWithScale(this.highFlowThreshold, 0),
+			encodeFloatWithScale(this.lowFlowThreshold, 0),
+			[(this.useRainSensor ? 1 : 0) | (this.useMoistureSensor ? 2 : 0)],
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -2216,18 +2304,14 @@ export class IrrigationCCValveConfigGet extends IrrigationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): IrrigationCCValveConfigGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new IrrigationCCValveConfigGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 2);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			valveId: raw.payload[0] & 1 ? "master" : raw.payload[1],
+		});
 	}
 
 	public valveId: ValveId;
@@ -2266,18 +2350,15 @@ export class IrrigationCCValveRun extends IrrigationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): IrrigationCCValveRun {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new IrrigationCCValveRun({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 4);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			valveId: raw.payload[0] & 1 ? "master" : raw.payload[1],
+			duration: raw.payload.readUInt16BE(2),
+		});
 	}
 
 	public valveId: ValveId;
@@ -2326,18 +2407,15 @@ export class IrrigationCCValveTableSet extends IrrigationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): IrrigationCCValveTableSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new IrrigationCCValveTableSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		const report = IrrigationCCValveTableReport.from(raw, ctx);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			tableId: report.tableId,
+			entries: report.entries,
+		});
 	}
 
 	public tableId: number;
@@ -2417,6 +2495,17 @@ export class IrrigationCCValveTableReport extends IrrigationCC {
 	public readonly tableId: number;
 	public readonly entries: ValveTableEntry[];
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = new Bytes(1 + this.entries.length * 3);
+		this.payload[0] = this.tableId;
+		for (let i = 0; i < this.entries.length; i++) {
+			const offset = 1 + i * 3;
+			this.payload[offset] = this.entries[i].valveId;
+			this.payload.writeUInt16BE(this.entries[i].duration, offset + 1);
+		}
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {
 			"table ID": this.tableId,
@@ -2461,18 +2550,14 @@ export class IrrigationCCValveTableGet extends IrrigationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): IrrigationCCValveTableGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new IrrigationCCValveTableGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			tableId: raw.payload[0],
+		});
 	}
 
 	public tableId: number;
@@ -2512,18 +2597,14 @@ export class IrrigationCCValveTableRun extends IrrigationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): IrrigationCCValveTableRun {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new IrrigationCCValveTableRun({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			tableIDs: [...raw.payload],
+		});
 	}
 
 	public tableIDs: number[];
@@ -2563,18 +2644,14 @@ export class IrrigationCCSystemShutoff extends IrrigationCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): IrrigationCCSystemShutoff {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new IrrigationCCSystemShutoff({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			duration: raw.payload[0],
+		});
 	}
 
 	public duration?: number;

--- a/packages/cc/src/cc/LanguageCC.test.ts
+++ b/packages/cc/src/cc/LanguageCC.test.ts
@@ -1,0 +1,67 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { LanguageCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import { LanguageCCReport, LanguageCCSet } from "./LanguageCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+
+test.each([undefined, "US"])(
+	"Language codecs preserve country %s",
+	async (country) => {
+		const payload = Bytes.from("eng" + (country ?? ""), "ascii");
+		const set = LanguageCCSet.from(
+			new CCRaw(CommandClasses.Language, LanguageCommand.Set, payload),
+			ctx,
+		);
+		expect(set).toMatchObject({ language: "eng", country });
+		const report = new LanguageCCReport({
+			nodeId: 2,
+			language: "eng",
+			country,
+		});
+		expect(await report.serialize(ctx)).toEqual(
+			Bytes.concat([
+				[CommandClasses.Language, LanguageCommand.Report],
+				payload,
+			]),
+		);
+	},
+);
+
+test.each(["", "en", "ENG", "engus"])(
+	"Language Set rejects invalid code %s",
+	(payload) => {
+		expect(() =>
+			LanguageCCSet.from(
+				new CCRaw(
+					CommandClasses.Language,
+					LanguageCommand.Set,
+					Bytes.from(payload, "ascii"),
+				),
+				ctx,
+			),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	},
+);

--- a/packages/cc/src/cc/LanguageCC.ts
+++ b/packages/cc/src/cc/LanguageCC.ts
@@ -166,16 +166,21 @@ export class LanguageCCSet extends LanguageCC {
 		this._country = options.country;
 	}
 
-	public static from(_raw: CCRaw, _ctx: CCParsingContext): LanguageCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
+	public static from(raw: CCRaw, ctx: CCParsingContext): LanguageCCSet {
+		validatePayload(raw.payload.length >= 3);
+		const language = raw.payload.subarray(0, 3).toString("ascii");
+		validatePayload(language.toLowerCase() === language);
+		let country: string | undefined;
+		if (raw.payload.length >= 5) {
+			country = raw.payload.subarray(3, 5).toString("ascii");
+			validatePayload(country.toUpperCase() === country);
+		}
 
-		// return new LanguageCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			language,
+			country,
+		});
 	}
 
 	private _language: string;
@@ -276,6 +281,14 @@ export class LanguageCCReport extends LanguageCC {
 	public readonly language: string;
 
 	public readonly country: MaybeNotKnown<string>;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from(
+			this.language + (this.country ?? ""),
+			"ascii",
+		);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = { language: this.language };

--- a/packages/cc/src/cc/MultiChannelCC.test.ts
+++ b/packages/cc/src/cc/MultiChannelCC.test.ts
@@ -1,0 +1,82 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { MultiChannelCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	MultiChannelCCAggregatedMembersGet,
+	MultiChannelCCAggregatedMembersReport,
+} from "./MultiChannelCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 4,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const raw = (command: MultiChannelCommand, payload: number[]) =>
+	new CCRaw(CommandClasses["Multi Channel"], command, Bytes.from(payload));
+
+test("Aggregated Members Get ignores reserved bits and roundtrips", async () => {
+	const cc = MultiChannelCCAggregatedMembersGet.from(
+		raw(MultiChannelCommand.AggregatedMembersGet, [0x83]),
+		ctx,
+	);
+	expect(cc.requestedEndpoint).toBe(3);
+	expect(await cc.serialize(ctx)).toEqual(Bytes.from([0x60, 0x0e, 3]));
+});
+
+test.each([
+	{ members: [1, 8, 9, 127], mask: [0x81, 1, ...Array(13).fill(0), 0x40] },
+	{ members: [], mask: [0] },
+])("Aggregated Members Report encodes $members", async ({ members, mask }) => {
+	const cc = new MultiChannelCCAggregatedMembersReport({
+		nodeId: 2,
+		aggregatedEndpointIndex: 3,
+		members,
+	});
+	const payload = [3, mask.length, ...mask];
+	expect(await cc.serialize(ctx)).toEqual(
+		Bytes.from([0x60, 0x0f, ...payload]),
+	);
+	expect(
+		MultiChannelCCAggregatedMembersReport.from(
+			raw(MultiChannelCommand.AggregatedMembersReport, payload),
+			ctx,
+		),
+	).toMatchObject({ aggregatedEndpointIndex: 3, members });
+});
+
+test("Aggregated Members rejects truncated payloads", () => {
+	expect(() =>
+		MultiChannelCCAggregatedMembersGet.from(
+			raw(MultiChannelCommand.AggregatedMembersGet, []),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+	expect(() =>
+		MultiChannelCCAggregatedMembersReport.from(
+			raw(MultiChannelCommand.AggregatedMembersReport, [3, 2, 1]),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/MultiChannelCC.ts
+++ b/packages/cc/src/cc/MultiChannelCC.ts
@@ -12,8 +12,6 @@ import {
 	type SpecificDeviceClass,
 	type SupportsCC,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
 	encodeApplicationNodeInformation,
 	encodeBitMask,
 	getCCName,
@@ -1267,6 +1265,15 @@ export class MultiChannelCCAggregatedMembersReport extends MultiChannelCC {
 
 	public readonly members: readonly number[];
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const bitMask = encodeBitMask(this.members);
+		this.payload = Bytes.concat([
+			[this.aggregatedEndpointIndex & 0b0111_1111, bitMask.length],
+			bitMask,
+		]);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -1294,18 +1301,14 @@ export class MultiChannelCCAggregatedMembersGet extends MultiChannelCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): MultiChannelCCAggregatedMembersGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new MultiChannelCCAggregatedMembersGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			requestedEndpoint: raw.payload[0] & 0b0111_1111,
+		});
 	}
 
 	public requestedEndpoint: number;

--- a/packages/cc/src/cc/SceneActuatorConfigurationCC.test.ts
+++ b/packages/cc/src/cc/SceneActuatorConfigurationCC.test.ts
@@ -1,0 +1,132 @@
+import { CommandClasses, Duration, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { SceneActuatorConfigurationCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	SceneActuatorConfigurationCCGet,
+	SceneActuatorConfigurationCCReport,
+	SceneActuatorConfigurationCCSet,
+} from "./SceneActuatorConfigurationCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const ccId = CommandClasses["Scene Actuator Configuration"];
+const raw = (command: SceneActuatorConfigurationCommand, payload: number[]) =>
+	new CCRaw(ccId, command, Bytes.from(payload));
+
+test.each([false, true])(
+	"Scene actuator Set decodes override=%s and default duration",
+	async (override) => {
+		const set = SceneActuatorConfigurationCCSet.from(
+			raw(SceneActuatorConfigurationCommand.Set, [
+				2,
+				255,
+				override ? 0xff : 0x7f,
+				40,
+			]),
+			ctx,
+		);
+		expect(set.level).toBe(override ? 40 : undefined);
+		expect(set.dimmingDuration).toEqual(Duration.default());
+		expect(await set.serialize(ctx)).toEqual(
+			Bytes.from([
+				ccId,
+				1,
+				2,
+				255,
+				override ? 0x80 : 0,
+				override ? 40 : 255,
+			]),
+		);
+	},
+);
+
+test("Scene actuator Report serializes minute duration", async () => {
+	const report = new SceneActuatorConfigurationCCReport({
+		nodeId: 2,
+		sceneId: 2,
+		level: 40,
+		dimmingDuration: new Duration(2, "minutes"),
+	});
+	expect(await report.serialize(ctx)).toEqual(
+		Bytes.from([ccId, 3, 2, 40, 0x81]),
+	);
+	expect(
+		SceneActuatorConfigurationCCReport.from(
+			raw(SceneActuatorConfigurationCommand.Report, [2, 40, 0x81]),
+			ctx,
+		),
+	).toMatchObject({
+		sceneId: 2,
+		level: 40,
+		dimmingDuration: new Duration(2, "minutes"),
+	});
+});
+
+test("Scene actuator inactive Report clears ignored fields", async () => {
+	const report = new SceneActuatorConfigurationCCReport({
+		nodeId: 2,
+		sceneId: 0,
+	});
+	expect(await report.serialize(ctx)).toEqual(Bytes.from([ccId, 3, 0, 0, 0]));
+	expect(
+		SceneActuatorConfigurationCCReport.from(
+			raw(SceneActuatorConfigurationCommand.Report, [0, 0, 0]),
+			ctx,
+		),
+	).toMatchObject({
+		sceneId: 0,
+		level: undefined,
+		dimmingDuration: undefined,
+	});
+});
+
+test("Scene actuator Get preserves scene zero", async () => {
+	const get = SceneActuatorConfigurationCCGet.from(
+		raw(SceneActuatorConfigurationCommand.Get, [0]),
+		ctx,
+	);
+	expect(await get.serialize(ctx)).toEqual(Bytes.from([ccId, 2, 0]));
+	expect(() =>
+		SceneActuatorConfigurationCCGet.from(
+			raw(SceneActuatorConfigurationCommand.Get, []),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});
+
+test.each([{ payload: [1, 0, 0] }, { payload: [0, 0, 0, 0] }])(
+	"Scene actuator Set rejects invalid payload %j",
+	({ payload }) => {
+		expect(() =>
+			SceneActuatorConfigurationCCSet.from(
+				raw(SceneActuatorConfigurationCommand.Set, payload),
+				ctx,
+			),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	},
+);

--- a/packages/cc/src/cc/SceneActuatorConfigurationCC.ts
+++ b/packages/cc/src/cc/SceneActuatorConfigurationCC.ts
@@ -358,18 +358,17 @@ export class SceneActuatorConfigurationCCSet extends SceneActuatorConfigurationC
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): SceneActuatorConfigurationCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new SceneActuatorConfigurationCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 4);
+		validatePayload(raw.payload[0] >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			sceneId: raw.payload[0],
+			dimmingDuration: Duration.parseSet(raw.payload[1])!,
+			level: raw.payload[2] & 0b1000_0000 ? raw.payload[3] : undefined,
+		});
 	}
 
 	public sceneId: number;
@@ -449,6 +448,19 @@ export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurati
 	public readonly level?: number;
 	public readonly dimmingDuration?: Duration;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([
+			this.sceneId,
+			this.sceneId === 0 ? 0 : (this.level ?? 0xff),
+			this.sceneId === 0
+				? 0
+				: (
+						this.dimmingDuration ?? Duration.unknown()
+					).serializeReport(),
+		]);
+		return super.serialize(ctx);
+	}
+
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;
 
@@ -522,18 +534,14 @@ export class SceneActuatorConfigurationCCGet extends SceneActuatorConfigurationC
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): SceneActuatorConfigurationCCGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new SceneActuatorConfigurationCCGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			sceneId: raw.payload[0],
+		});
 	}
 
 	public sceneId: number;

--- a/packages/cc/src/cc/SceneControllerConfigurationCC.test.ts
+++ b/packages/cc/src/cc/SceneControllerConfigurationCC.test.ts
@@ -1,0 +1,106 @@
+import { CommandClasses, Duration, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { SceneControllerConfigurationCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	SceneControllerConfigurationCCGet,
+	SceneControllerConfigurationCCReport,
+	SceneControllerConfigurationCCSet,
+} from "./SceneControllerConfigurationCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const ccId = CommandClasses["Scene Controller Configuration"];
+const raw = (command: SceneControllerConfigurationCommand, payload: number[]) =>
+	new CCRaw(ccId, command, Bytes.from(payload));
+
+test.each([0, 5, 0x80, 0xff])(
+	"Scene controller Set roundtrips duration byte %i",
+	async (duration) => {
+		const set = SceneControllerConfigurationCCSet.from(
+			raw(SceneControllerConfigurationCommand.Set, [2, 0, duration]),
+			ctx,
+		);
+		expect(set).toMatchObject({
+			groupId: 2,
+			sceneId: 0,
+			dimmingDuration: Duration.parseSet(duration),
+		});
+		expect(await set.serialize(ctx)).toEqual(
+			Bytes.from([ccId, 1, 2, 0, duration]),
+		);
+	},
+);
+
+test.each([new Duration(2, "minutes"), Duration.unknown()])(
+	"Scene controller Report roundtrips %j",
+	async (dimmingDuration) => {
+		const report = new SceneControllerConfigurationCCReport({
+			nodeId: 2,
+			groupId: 2,
+			sceneId: 3,
+			dimmingDuration,
+		});
+		const durationByte = dimmingDuration.unit === "unknown" ? 0xfe : 0x81;
+		expect(await report.serialize(ctx)).toEqual(
+			Bytes.from([ccId, 3, 2, 3, durationByte]),
+		);
+		expect(
+			SceneControllerConfigurationCCReport.from(
+				raw(SceneControllerConfigurationCommand.Report, [
+					2,
+					3,
+					durationByte,
+				]),
+				ctx,
+			),
+		).toMatchObject({ groupId: 2, sceneId: 3, dimmingDuration });
+	},
+);
+
+test("Scene controller Get preserves group zero", async () => {
+	const get = SceneControllerConfigurationCCGet.from(
+		raw(SceneControllerConfigurationCommand.Get, [0]),
+		ctx,
+	);
+	expect(await get.serialize(ctx)).toEqual(Bytes.from([ccId, 2, 0]));
+	expect(() =>
+		SceneControllerConfigurationCCGet.from(
+			raw(SceneControllerConfigurationCommand.Get, []),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});
+
+test("Scene controller Set rejects truncated payloads", () => {
+	expect(() =>
+		SceneControllerConfigurationCCSet.from(
+			raw(SceneControllerConfigurationCommand.Set, [1, 2]),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/SceneControllerConfigurationCC.ts
+++ b/packages/cc/src/cc/SceneControllerConfigurationCC.ts
@@ -490,18 +490,16 @@ export class SceneControllerConfigurationCCSet extends SceneControllerConfigurat
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): SceneControllerConfigurationCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new SceneControllerConfigurationCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 3);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			groupId: raw.payload[0],
+			sceneId: raw.payload[1],
+			dimmingDuration: Duration.parseSet(raw.payload[2]),
+		});
 	}
 
 	public groupId: number;
@@ -571,6 +569,15 @@ export class SceneControllerConfigurationCCReport extends SceneControllerConfigu
 	public readonly sceneId: number;
 	public readonly dimmingDuration: Duration;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([
+			this.groupId,
+			this.sceneId,
+			this.dimmingDuration.serializeReport(),
+		]);
+		return super.serialize(ctx);
+	}
+
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;
 
@@ -631,18 +638,14 @@ export class SceneControllerConfigurationCCGet extends SceneControllerConfigurat
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): SceneControllerConfigurationCCGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new SceneControllerConfigurationCCGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			groupId: raw.payload[0],
+		});
 	}
 
 	public groupId: number;

--- a/packages/cc/src/cc/ThermostatFanModeCC.test.ts
+++ b/packages/cc/src/cc/ThermostatFanModeCC.test.ts
@@ -1,0 +1,101 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { ThermostatFanModeCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	ThermostatFanModeCCReport,
+	ThermostatFanModeCCSet,
+	ThermostatFanModeCCSupportedReport,
+} from "./ThermostatFanModeCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 5,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const ccId = CommandClasses["Thermostat Fan Mode"];
+
+test.each([false, true])(
+	"Fan mode codecs preserve off=%s and mask reserved bits",
+	async (off) => {
+		const value = (off ? 0x80 : 0) | 2;
+		const set = ThermostatFanModeCCSet.from(
+			new CCRaw(
+				ccId,
+				ThermostatFanModeCommand.Set,
+				Bytes.from([value | 0x70]),
+			),
+			ctx,
+		);
+		expect(set).toMatchObject({ mode: 2, off });
+		expect(await set.serialize(ctx)).toEqual(Bytes.from([ccId, 1, value]));
+		const report = new ThermostatFanModeCCReport({
+			nodeId: 2,
+			mode: set.mode,
+			off,
+		});
+		expect(await report.serialize(ctx)).toEqual(
+			Bytes.from([ccId, 3, value]),
+		);
+		expect(
+			ThermostatFanModeCCReport.from(
+				new CCRaw(
+					ccId,
+					ThermostatFanModeCommand.Report,
+					Bytes.from([value]),
+				),
+				ctx,
+			),
+		).toMatchObject({ mode: 2, off });
+	},
+);
+
+test.each([{ supportedModes: [0, 2, 10] }, { supportedModes: [] }])(
+	"Fan supported modes roundtrip %j",
+	async ({ supportedModes }) => {
+		const report = new ThermostatFanModeCCSupportedReport({
+			nodeId: 2,
+			supportedModes,
+		});
+		const payload = supportedModes.length ? [5, 4] : [0];
+		expect(await report.serialize(ctx)).toEqual(
+			Bytes.from([ccId, 5, ...payload]),
+		);
+		expect(
+			ThermostatFanModeCCSupportedReport.from(
+				new CCRaw(
+					ccId,
+					ThermostatFanModeCommand.SupportedReport,
+					Bytes.from(payload),
+				),
+				ctx,
+			).supportedModes,
+		).toEqual(supportedModes);
+	},
+);
+
+test("Fan mode Set rejects an empty payload", () => {
+	expect(() =>
+		ThermostatFanModeCCSet.from(
+			new CCRaw(ccId, ThermostatFanModeCommand.Set, Bytes.from([])),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/ThermostatFanModeCC.ts
+++ b/packages/cc/src/cc/ThermostatFanModeCC.ts
@@ -10,6 +10,7 @@ import {
 	type WithAddress,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeBitMask,
 	enumValuesToMetadataStates,
 	logList,
 	logText,
@@ -344,18 +345,15 @@ export class ThermostatFanModeCCSet extends ThermostatFanModeCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): ThermostatFanModeCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new ThermostatFanModeCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 1);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			mode: raw.payload[0] & 0b1111,
+			off: !!(raw.payload[0] & 0b1000_0000),
+		});
 	}
 
 	public mode: ThermostatFanMode;
@@ -416,6 +414,13 @@ export class ThermostatFanModeCCReport extends ThermostatFanModeCC {
 	public readonly mode: ThermostatFanMode;
 
 	public readonly off: boolean | undefined;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([
+			(this.off ? 0b1000_0000 : 0) | (this.mode & 0b1111),
+		]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {
@@ -484,6 +489,15 @@ export class ThermostatFanModeCCSupportedReport extends ThermostatFanModeCC {
 	}
 
 	public readonly supportedModes: ThermostatFanMode[];
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = encodeBitMask(
+			this.supportedModes,
+			undefined,
+			ThermostatFanMode["Auto low"],
+		);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {

--- a/packages/cc/src/cc/ThermostatFanStateCC.test.ts
+++ b/packages/cc/src/cc/ThermostatFanStateCC.test.ts
@@ -1,0 +1,47 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { ThermostatFanStateCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import { ThermostatFanStateCCReport } from "./ThermostatFanStateCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 2,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const ccId = CommandClasses["Thermostat Fan State"];
+
+test("Fan state roundtrips with reserved bits cleared", async () => {
+	const report = ThermostatFanStateCCReport.from(
+		new CCRaw(ccId, ThermostatFanStateCommand.Report, Bytes.from([0xf2])),
+		ctx,
+	);
+	expect(report.state).toBe(2);
+	expect(await report.serialize(ctx)).toEqual(Bytes.from([ccId, 3, 2]));
+});
+
+test("Fan state rejects an empty payload", () => {
+	expect(() =>
+		ThermostatFanStateCCReport.from(
+			new CCRaw(ccId, ThermostatFanStateCommand.Report, Bytes.from([])),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/ThermostatFanStateCC.ts
+++ b/packages/cc/src/cc/ThermostatFanStateCC.ts
@@ -10,7 +10,7 @@ import {
 	enumValuesToMetadataStates,
 	validatePayload,
 } from "@zwave-js/core";
-import { getEnumMemberName } from "@zwave-js/shared";
+import { Bytes, getEnumMemberName } from "@zwave-js/shared";
 
 import {
 	CCAPI,
@@ -39,7 +39,7 @@ import {
 	ThermostatFanState,
 	ThermostatFanStateCommand,
 } from "../lib/_Types.js";
-import type { CCParsingContext } from "../lib/traits.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
 
 export const ThermostatFanStateCCValues = V.defineCCValues(
 	CommandClasses["Thermostat Fan State"],
@@ -184,6 +184,11 @@ export class ThermostatFanStateCCReport extends ThermostatFanStateCC {
 	}
 
 	public readonly state: ThermostatFanState;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([this.state & 0b1111]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {

--- a/packages/cc/src/cc/TimeCC.test.ts
+++ b/packages/cc/src/cc/TimeCC.test.ts
@@ -1,0 +1,68 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { TimeCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import { TimeCCTimeOffsetSet } from "./TimeCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 2,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+
+test.each([
+	{ offsets: [0x85, 30, 60], standardOffset: -330, dstOffset: -270 },
+	{ offsets: [5, 30, 0x80 | 30], standardOffset: 330, dstOffset: 300 },
+])(
+	"Time Offset Set parses signed offsets $standardOffset/$dstOffset",
+	async ({ offsets, standardOffset, dstOffset }) => {
+		const payload = Bytes.from([...offsets, 3, 15, 2, 10, 20, 3]);
+		const cc = TimeCCTimeOffsetSet.from(
+			new CCRaw(CommandClasses.Time, TimeCommand.TimeOffsetSet, payload),
+			ctx,
+		);
+		const year = new Date().getUTCFullYear();
+		expect(cc).toMatchObject({
+			standardOffset,
+			dstOffset,
+			dstStartDate: new Date(Date.UTC(year, 2, 15, 2)),
+			dstEndDate: new Date(Date.UTC(year, 9, 20, 3)),
+		});
+		expect(await cc.serialize(ctx)).toEqual(
+			Bytes.concat([
+				[CommandClasses.Time, TimeCommand.TimeOffsetSet],
+				payload,
+			]),
+		);
+	},
+);
+
+test("Time Offset Set rejects truncated dates", () => {
+	expect(() =>
+		TimeCCTimeOffsetSet.from(
+			new CCRaw(
+				CommandClasses.Time,
+				TimeCommand.TimeOffsetSet,
+				new Bytes(8),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/TimeCC.ts
+++ b/packages/cc/src/cc/TimeCC.ts
@@ -7,8 +7,6 @@ import {
 	MessagePriority,
 	type SupervisionResult,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
 	formatDate,
 	getDSTInfo,
 	validatePayload,
@@ -375,19 +373,31 @@ export class TimeCCTimeOffsetSet extends TimeCC {
 		this.dstEndDate = options.dstEnd;
 	}
 
-	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
-	): TimeCCTimeOffsetSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new TimeCCTimeOffsetSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+	public static from(raw: CCRaw, ctx: CCParsingContext): TimeCCTimeOffsetSet {
+		validatePayload(raw.payload.length >= 9);
+		const { standardOffset, dstOffset } = parseTimezone(raw.payload);
+		const currentYear = new Date().getUTCFullYear();
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			standardOffset,
+			dstOffset,
+			dstStart: new Date(
+				Date.UTC(
+					currentYear,
+					raw.payload[3] - 1,
+					raw.payload[4],
+					raw.payload[5],
+				),
+			),
+			dstEnd: new Date(
+				Date.UTC(
+					currentYear,
+					raw.payload[6] - 1,
+					raw.payload[7],
+					raw.payload[8],
+				),
+			),
+		});
 	}
 
 	public standardOffset: number;

--- a/packages/cc/src/cc/TimeParametersCC.test.ts
+++ b/packages/cc/src/cc/TimeParametersCC.test.ts
@@ -1,0 +1,67 @@
+import { CommandClasses } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { TimeParametersCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import { TimeParametersCCReport } from "./TimeParametersCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+
+test("Time Parameters Report serializes UTC date fields by default", async () => {
+	const dateAndTime = new Date("2026-09-11T13:28:29.000Z");
+	const cc = new TimeParametersCCReport({ nodeId: 2, dateAndTime });
+	const serialized = await cc.serialize(ctx);
+	expect(serialized).toEqual(
+		Bytes.from([
+			CommandClasses["Time Parameters"],
+			TimeParametersCommand.Report,
+			0x07,
+			0xea,
+			9,
+			11,
+			13,
+			28,
+			29,
+		]),
+	);
+	expect(
+		TimeParametersCCReport.from(CCRaw.parse(serialized), ctx).dateAndTime,
+	).toEqual(dateAndTime);
+});
+
+test("Time Parameters Report can serialize local date fields", async () => {
+	const cc = new TimeParametersCCReport({
+		nodeId: 2,
+		dateAndTime: new Date(2026, 8, 11, 13, 28, 29),
+		useLocalTime: true,
+	});
+	expect(await cc.serialize(ctx)).toEqual(
+		Bytes.from([
+			CommandClasses["Time Parameters"],
+			TimeParametersCommand.Report,
+			0x07,
+			0xea,
+			9,
+			11,
+			13,
+			28,
+			29,
+		]),
+	);
+});

--- a/packages/cc/src/cc/TimeParametersCC.ts
+++ b/packages/cc/src/cc/TimeParametersCC.ts
@@ -250,6 +250,7 @@ export class TimeParametersCC extends CommandClass {
 // @publicAPI
 export interface TimeParametersCCReportOptions {
 	dateAndTime: Date;
+	useLocalTime?: boolean;
 }
 
 @CCCommand(TimeParametersCommand.Report)
@@ -258,8 +259,8 @@ export class TimeParametersCCReport extends TimeParametersCC {
 	public constructor(options: WithAddress<TimeParametersCCReportOptions>) {
 		super(options);
 
-		// TODO: Check implementation:
 		this.dateAndTime = options.dateAndTime;
+		this.useLocalTime = options.useLocalTime;
 	}
 
 	public static from(
@@ -307,6 +308,22 @@ export class TimeParametersCCReport extends TimeParametersCC {
 	}
 
 	public dateAndTime: Date;
+	private useLocalTime?: boolean;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const segments = dateToSegments(this.dateAndTime, !!this.useLocalTime);
+		this.payload = Bytes.from([
+			0,
+			0,
+			segments.month,
+			segments.day,
+			segments.hour,
+			segments.minute,
+			segments.second,
+		]);
+		this.payload.writeUInt16BE(segments.year, 0);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {

--- a/packages/cc/src/cc/UserCodeCC.test.ts
+++ b/packages/cc/src/cc/UserCodeCC.test.ts
@@ -1,0 +1,141 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { UserCodeCommand, UserIDStatus } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	UserCodeCCExtendedUserCodeGet,
+	UserCodeCCExtendedUserCodeReport,
+} from "./UserCodeCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 2,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const raw = (command: UserCodeCommand, payload: number[]) =>
+	new CCRaw(CommandClasses["User Code"], command, Bytes.from(payload));
+
+test.each([0xfe, 0xff])(
+	"Extended User Code Get masks flags %i",
+	async (flags) => {
+		const cc = UserCodeCCExtendedUserCodeGet.from(
+			raw(UserCodeCommand.ExtendedUserCodeGet, [0x12, 0x34, flags]),
+			ctx,
+		);
+		expect(cc).toMatchObject({ userId: 0x1234, reportMore: !!(flags & 1) });
+		expect(await cc.serialize(ctx)).toEqual(
+			Bytes.from([0x63, 0x0c, 0x12, 0x34, flags & 1]),
+		);
+	},
+);
+
+test("Extended User Code Report encodes records and pagination", async () => {
+	const userCodes = [
+		{
+			userId: 0x1234,
+			userIdStatus: UserIDStatus.Enabled,
+			userCode: "1234",
+		},
+		{ userId: 0x1235, userIdStatus: UserIDStatus.Available, userCode: "" },
+	];
+	const cc = new UserCodeCCExtendedUserCodeReport({
+		nodeId: 2,
+		userCodes,
+		nextUserId: 0x1236,
+	});
+	const payload = [
+		2, 0x12, 0x34, 1, 4, 49, 50, 51, 52, 0x12, 0x35, 0, 0, 0x12, 0x36,
+	];
+	expect(await cc.serialize(ctx)).toEqual(
+		Bytes.from([0x63, 0x0d, ...payload]),
+	);
+	expect(
+		UserCodeCCExtendedUserCodeReport.from(
+			raw(UserCodeCommand.ExtendedUserCodeReport, payload),
+			ctx,
+		),
+	).toMatchObject({ userCodes, nextUserId: 0x1236 });
+});
+
+test("Extended User Code Report supports an empty final page", async () => {
+	const cc = new UserCodeCCExtendedUserCodeReport({
+		nodeId: 2,
+		userCodes: [],
+		nextUserId: 0,
+	});
+	expect(await cc.serialize(ctx)).toEqual(Bytes.from([0x63, 0x0d, 0, 0, 0]));
+});
+
+test("Extended User Code Report rejects overflowing code lengths and counts", () => {
+	const code = {
+		userId: 1,
+		userIdStatus: UserIDStatus.Enabled,
+		userCode: "1".repeat(16),
+	};
+	const oversizedCode = new UserCodeCCExtendedUserCodeReport({
+		nodeId: 2,
+		userCodes: [code],
+		nextUserId: 0,
+	});
+	expect(() => oversizedCode.serialize(ctx)).toThrow(
+		expect.objectContaining({ code: ZWaveErrorCodes.Argument_Invalid }),
+	);
+	const oversizedCount = new UserCodeCCExtendedUserCodeReport({
+		nodeId: 2,
+		userCodes: Array.from({ length: 256 }, () => ({ ...code })),
+		nextUserId: 0,
+	});
+	expect(() => oversizedCount.serialize(ctx)).toThrow(
+		expect.objectContaining({ code: ZWaveErrorCodes.Argument_Invalid }),
+	);
+});
+
+test.each([[], [0], [0, 1]].map((payload) => ({ payload })))(
+	"Extended User Code Get rejects truncated payload $payload",
+	({ payload }) => {
+		expect(() =>
+			UserCodeCCExtendedUserCodeGet.from(
+				raw(UserCodeCommand.ExtendedUserCodeGet, payload),
+				ctx,
+			),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	},
+);
+
+test.each(
+	[
+		[1, 0, 1, 1, 4, 49],
+		[0, 0],
+	].map((payload) => ({ payload })),
+)(
+	"Extended User Code Report rejects truncated payload $payload",
+	({ payload }) => {
+		expect(() =>
+			UserCodeCCExtendedUserCodeReport.from(
+				raw(UserCodeCommand.ExtendedUserCodeReport, payload),
+				ctx,
+			),
+		).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	},
+);

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -2355,6 +2355,37 @@ export class UserCodeCCExtendedUserCodeReport extends UserCodeCC {
 	public readonly userCodes: readonly UserCode[];
 	public readonly nextUserId: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		if (this.userCodes.length > 255) {
+			throw new ZWaveError(
+				"An extended user code report can contain at most 255 codes",
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		const codes = this.userCodes.map((code) => {
+			const userCode = Bytes.from(code.userCode, "ascii");
+			if (userCode.length > 15) {
+				throw new ZWaveError(
+					"User codes must fit in the four-bit length field",
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			const buffer = Bytes.concat([
+				[0, 0, code.userIdStatus, userCode.length],
+				userCode,
+			]);
+			buffer.writeUInt16BE(code.userId, 0);
+			return buffer;
+		});
+		this.payload = Bytes.concat([
+			[this.userCodes.length],
+			...codes,
+			[0, 0],
+		]);
+		this.payload.writeUInt16BE(this.nextUserId, this.payload.length - 2);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {};
 		for (const { userId, userIdStatus, userCode } of this.userCodes) {
@@ -2388,18 +2419,15 @@ export class UserCodeCCExtendedUserCodeGet extends UserCodeCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): UserCodeCCExtendedUserCodeGet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
-
-		// return new UserCodeCCExtendedUserCodeGet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		validatePayload(raw.payload.length >= 3);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			userId: raw.payload.readUInt16BE(0),
+			reportMore: !!(raw.payload[2] & 0b1),
+		});
 	}
 
 	public userId: number;

--- a/packages/cc/src/cc/VersionCC.test.ts
+++ b/packages/cc/src/cc/VersionCC.test.ts
@@ -1,0 +1,92 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { VersionCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import { VersionCCZWaveSoftwareReport } from "./VersionCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 3,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+
+test("Z-Wave Software Report encodes versions and big-endian build numbers", async () => {
+	const options = {
+		nodeId: 2,
+		sdkVersion: "7.20.1",
+		applicationFrameworkAPIVersion: "1.2.3",
+		applicationFrameworkBuildNumber: 0x1234,
+		hostInterfaceVersion: "4.5.6",
+		hostInterfaceBuildNumber: 0x5678,
+		zWaveProtocolVersion: "7.8.9",
+		zWaveProtocolBuildNumber: 0x9abc,
+		applicationVersion: "10.11.12",
+		applicationBuildNumber: 0xdef0,
+	};
+	const cc = new VersionCCZWaveSoftwareReport(options);
+	const payload = Bytes.from([
+		7, 20, 1, 1, 2, 3, 0x12, 0x34, 4, 5, 6, 0x56, 0x78, 7, 8, 9, 0x9a, 0xbc,
+		10, 11, 12, 0xde, 0xf0,
+	]);
+	expect(await cc.serialize(ctx)).toEqual(
+		Bytes.concat([[0x86, 0x18], payload]),
+	);
+	expect(
+		VersionCCZWaveSoftwareReport.from(
+			new CCRaw(
+				CommandClasses.Version,
+				VersionCommand.ZWaveSoftwareReport,
+				payload,
+			),
+			ctx,
+		),
+	).toMatchObject(options);
+});
+
+test("Z-Wave Software Report zeros unused components and builds", async () => {
+	const cc = new VersionCCZWaveSoftwareReport({
+		nodeId: 2,
+		sdkVersion: "unused",
+		applicationFrameworkAPIVersion: "unused",
+		applicationFrameworkBuildNumber: 1,
+		hostInterfaceVersion: "unused",
+		hostInterfaceBuildNumber: 2,
+		zWaveProtocolVersion: "unused",
+		zWaveProtocolBuildNumber: 3,
+		applicationVersion: "unused",
+		applicationBuildNumber: 4,
+	});
+	expect(await cc.serialize(ctx)).toEqual(
+		Bytes.concat([[0x86, 0x18], new Bytes(23)]),
+	);
+});
+
+test("Z-Wave Software Report rejects truncated build numbers", () => {
+	expect(() =>
+		VersionCCZWaveSoftwareReport.from(
+			new CCRaw(
+				CommandClasses.Version,
+				VersionCommand.ZWaveSoftwareReport,
+				new Bytes(22),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -1060,6 +1060,43 @@ export class VersionCCZWaveSoftwareReport extends VersionCC {
 
 	public readonly applicationBuildNumber: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const encodeVersion = (version: string): number[] => {
+			if (version === "unused") return [0, 0, 0];
+			const [major, minor = 0, patch = 0] = version
+				.split(".")
+				.map(Number);
+			return [major, minor, patch];
+		};
+		this.payload = Bytes.concat([
+			encodeVersion(this.sdkVersion),
+			encodeVersion(this.applicationFrameworkAPIVersion),
+			[0, 0],
+			encodeVersion(this.hostInterfaceVersion),
+			[0, 0],
+			encodeVersion(this.zWaveProtocolVersion),
+			[0, 0],
+			encodeVersion(this.applicationVersion),
+			[0, 0],
+		]);
+		for (const [version, build, offset] of [
+			[
+				this.applicationFrameworkAPIVersion,
+				this.applicationFrameworkBuildNumber,
+				6,
+			],
+			[this.hostInterfaceVersion, this.hostInterfaceBuildNumber, 11],
+			[this.zWaveProtocolVersion, this.zWaveProtocolBuildNumber, 16],
+			[this.applicationVersion, this.applicationBuildNumber, 21],
+		] as const) {
+			this.payload.writeUInt16BE(
+				version === "unused" ? 0 : build,
+				offset,
+			);
+		}
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {
 			"SDK version": this.sdkVersion,

--- a/packages/cc/src/cc/WakeUpCC.test.ts
+++ b/packages/cc/src/cc/WakeUpCC.test.ts
@@ -1,0 +1,121 @@
+import { CommandClasses, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../lib/CommandClass.js";
+import { WakeUpCommand } from "../lib/_Types.js";
+import type { CCEncodingContext, CCParsingContext } from "../lib/traits.js";
+
+import {
+	WakeUpCCIntervalCapabilitiesReport,
+	WakeUpCCIntervalReport,
+} from "./WakeUpCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 3,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+
+test("Wake Up Interval Report serializes a 24-bit interval", async () => {
+	const cc = new WakeUpCCIntervalReport({
+		nodeId: 2,
+		wakeUpInterval: 0x123456,
+		controllerNodeId: 5,
+	});
+	const payload = Bytes.from([0x12, 0x34, 0x56, 5]);
+	expect(await cc.serialize(ctx)).toEqual(Bytes.concat([[0x84, 6], payload]));
+	expect(
+		WakeUpCCIntervalReport.from(
+			new CCRaw(
+				CommandClasses["Wake Up"],
+				WakeUpCommand.IntervalReport,
+				payload,
+			),
+			ctx,
+		),
+	).toMatchObject({ wakeUpInterval: 0x123456, controllerNodeId: 5 });
+});
+
+test.each([false, true])(
+	"Wake Up Capabilities serializes on-demand support %s",
+	async (wakeUpOnDemandSupported) => {
+		const options = {
+			nodeId: 2,
+			minWakeUpInterval: 0x010203,
+			maxWakeUpInterval: 0xffffff,
+			defaultWakeUpInterval: 0x040506,
+			wakeUpIntervalSteps: 0x070809,
+			wakeUpOnDemandSupported,
+		};
+		const cc = new WakeUpCCIntervalCapabilitiesReport(options);
+		const payload = Bytes.from([
+			1,
+			2,
+			3,
+			255,
+			255,
+			255,
+			4,
+			5,
+			6,
+			7,
+			8,
+			9,
+			+wakeUpOnDemandSupported,
+		]);
+		expect(await cc.serialize(ctx)).toEqual(
+			Bytes.concat([[0x84, 10], payload]),
+		);
+		expect(
+			WakeUpCCIntervalCapabilitiesReport.from(
+				new CCRaw(
+					CommandClasses["Wake Up"],
+					WakeUpCommand.IntervalCapabilitiesReport,
+					payload,
+				),
+				ctx,
+			),
+		).toMatchObject(options);
+	},
+);
+
+test("Wake Up reports reject truncated intervals", () => {
+	expect(() =>
+		WakeUpCCIntervalReport.from(
+			new CCRaw(
+				CommandClasses["Wake Up"],
+				WakeUpCommand.IntervalReport,
+				new Bytes(3),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+	expect(() =>
+		WakeUpCCIntervalCapabilitiesReport.from(
+			new CCRaw(
+				CommandClasses["Wake Up"],
+				WakeUpCommand.IntervalCapabilitiesReport,
+				new Bytes(11),
+			),
+			ctx,
+		),
+	).toThrow(
+		expect.objectContaining({
+			code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+		}),
+	);
+});

--- a/packages/cc/src/cc/WakeUpCC.ts
+++ b/packages/cc/src/cc/WakeUpCC.ts
@@ -425,6 +425,12 @@ export class WakeUpCCIntervalReport extends WakeUpCC {
 
 	public readonly controllerNodeId: number;
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([0, 0, 0, this.controllerNodeId]);
+		this.payload.writeUIntBE(this.wakeUpInterval, 0, 3);
+		return super.serialize(ctx);
+	}
+
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(ctx),
@@ -538,6 +544,16 @@ export class WakeUpCCIntervalCapabilitiesReport extends WakeUpCC {
 	public readonly wakeUpIntervalSteps: number;
 
 	public readonly wakeUpOnDemandSupported: boolean;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = new Bytes(13);
+		this.payload.writeUIntBE(this.minWakeUpInterval, 0, 3);
+		this.payload.writeUIntBE(this.maxWakeUpInterval, 3, 3);
+		this.payload.writeUIntBE(this.defaultWakeUpInterval, 6, 3);
+		this.payload.writeUIntBE(this.wakeUpIntervalSteps, 9, 3);
+		this.payload[12] = this.wakeUpOnDemandSupported ? 1 : 0;
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {

--- a/packages/cc/src/cc/manufacturerProprietary/FibaroCC.test.ts
+++ b/packages/cc/src/cc/manufacturerProprietary/FibaroCC.test.ts
@@ -1,0 +1,90 @@
+import { CommandClasses, UNKNOWN_STATE, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { expect, test, vi } from "vitest";
+
+import { CCRaw } from "../../lib/CommandClass.js";
+import type { CCEncodingContext, CCParsingContext } from "../../lib/traits.js";
+
+import {
+	FibaroVenetianBlindCCReport,
+	FibaroVenetianBlindCCSet,
+} from "./FibaroCC.js";
+
+const ctx: CCEncodingContext & CCParsingContext = {
+	ownNodeId: 1,
+	homeId: 1,
+	sourceNodeId: 2,
+	frameType: "singlecast",
+	securityManager: undefined,
+	securityManager2: undefined,
+	securityManagerLR: undefined,
+	getDeviceConfig: () => undefined,
+	getSupportedCCVersion: () => 1,
+	getHighestSecurityClass: () => undefined,
+	hasSecurityClass: () => false,
+	setSecurityClass: vi.fn(),
+};
+const raw = (payload: number[]) =>
+	new CCRaw(
+		CommandClasses["Manufacturer Proprietary"],
+		undefined,
+		Bytes.from(payload),
+	);
+
+test.each([
+	{
+		payload: [0xfe, 25, 88],
+		position: 25,
+		tilt: undefined,
+		encoded: [2, 25, 0],
+	},
+	{
+		payload: [1, 88, 40],
+		position: undefined,
+		tilt: 40,
+		encoded: [1, 0, 40],
+	},
+	{ payload: [3, 25, 40], position: 25, tilt: 40, encoded: [3, 25, 40] },
+])(
+	"Fibaro Set parses selected fields $payload",
+	async ({ payload, position, tilt, encoded }) => {
+		const cc = FibaroVenetianBlindCCSet.from(raw(payload), ctx);
+		expect(cc).toMatchObject({ position, tilt });
+		expect(await cc.serialize(ctx)).toEqual(
+			Bytes.from([0x91, 1, 0x0f, 0x26, 1, ...encoded]),
+		);
+	},
+);
+
+test.each([
+	{ position: 25, tilt: 40, payload: [3, 25, 40] },
+	{ position: UNKNOWN_STATE, tilt: undefined, payload: [2, 0xfe, 0] },
+	{ position: undefined, tilt: UNKNOWN_STATE, payload: [1, 0, 0xfe] },
+	{ position: undefined, tilt: undefined, payload: [0, 0, 0] },
+])(
+	"Fibaro Report encodes selected and unknown values $payload",
+	async ({ position, tilt, payload }) => {
+		const cc = new FibaroVenetianBlindCCReport({
+			nodeId: 2,
+			position,
+			tilt,
+		});
+		const expected = Bytes.from([0x91, 1, 0x0f, 0x26, 3, ...payload]);
+		expect(await cc.serialize(ctx)).toEqual(expected);
+		expect(await cc.serialize(ctx)).toEqual(expected);
+		expect(
+			FibaroVenetianBlindCCReport.from(raw(payload), ctx),
+		).toMatchObject({ position, tilt });
+	},
+);
+
+test.each([[], [3], [3, 1], [0, 1, 2]].map((payload) => ({ payload })))(
+	"Fibaro Set rejects malformed payload $payload",
+	({ payload }) => {
+		expect(() => FibaroVenetianBlindCCSet.from(raw(payload), ctx)).toThrow(
+			expect.objectContaining({
+				code: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			}),
+		);
+	},
+);

--- a/packages/cc/src/cc/manufacturerProprietary/FibaroCC.ts
+++ b/packages/cc/src/cc/manufacturerProprietary/FibaroCC.ts
@@ -5,6 +5,7 @@ import {
 	type MaybeUnknown,
 	type MessageOrCCLogEntry,
 	type MessageRecord,
+	UNKNOWN_STATE,
 	type ValueID,
 	ValueMetadata,
 	type WithAddress,
@@ -382,14 +383,22 @@ export class FibaroVenetianBlindCCSet extends FibaroVenetianBlindCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): FibaroVenetianBlindCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
+		validatePayload(raw.payload.length >= 3);
+		const hasPosition = !!(raw.payload[0] & 0b10);
+		const hasTilt = !!(raw.payload[0] & 0b01);
+		validatePayload(hasPosition || hasTilt);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			...(hasPosition
+				? {
+						position: raw.payload[1],
+						...(hasTilt ? { tilt: raw.payload[2] } : {}),
+					}
+				: { tilt: raw.payload[2] }),
+		});
 	}
 
 	public position: number | undefined;
@@ -495,6 +504,16 @@ export class FibaroVenetianBlindCCReport extends FibaroVenetianBlindCC {
 
 	public position: MaybeUnknown<number> | undefined;
 	public tilt: MaybeUnknown<number> | undefined;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([
+			(this.position !== undefined ? 0b10 : 0)
+				| (this.tilt !== undefined ? 0b01 : 0),
+			this.position === UNKNOWN_STATE ? 0xfe : (this.position ?? 0),
+			this.tilt === UNKNOWN_STATE ? 0xfe : (this.tilt ?? 0),
+		]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		const message: MessageRecord = {};


### PR DESCRIPTION
Implements all 83 methods from the missing-codec inventory: 38 `from()` parsers and 45 `serialize()` methods across 25 CC implementations.

Covers capability reports, notifications, configuration bulk commands, irrigation commands, firmware fragments, and Fibaro Venetian Blind commands. Firmware fragment parsing validates V2+ checksums and accepts V1 fragments when the parsing context supplies the version. Time Parameters Reports support explicit local-time encoding.

Also corrects the Irrigation System Config Set polarity bits exposed by the new roundtrip coverage. No command deduplication behavior is changed.

Adds adjacent codec tests for wire bytes, roundtrips, optional fields, and malformed payloads.