### PR TITLE
fix(config): change Qubino ZMNHTD parameter 40 value size to 1

### DIFF
--- a/packages/config/config/devices/0x0159/zmnhtd.json
+++ b/packages/config/config/devices/0x0159/zmnhtd.json
@@ -118,7 +118,7 @@
 			"#": "40",
 			"$purpose": "reporting_threshold.power",
 			"label": "Power Reporting (Watts) on Power Change",
-			"valueSize": 2,
+			"valueSize": 1,
 			"unit": "%",
 			"minValue": 0,
 			"maxValue": 100,


### PR DESCRIPTION
Parameter 40 (Power Reporting on Power Change, %) is a 1-byte parameter according to the Qubino manual (1 Byte DEC). The config declared valueSize 2, so every Configuration Set sent by the driver is silently ignored by the device: the subsequent Get always reports value size 1 with the unchanged value. Parameter 42 is correctly 2 bytes.

Verified on a ZMNHTD fw 80.1 (0x0159:0x0007:0x0052) with zwave-js 15.27.1 / HA 2026.9.2: setting the parameter with a raw 1-byte Set is accepted, whereas the 2-byte Set generated from the current config is ignored.